### PR TITLE
Refactor the codebase to replace usage of `shared_ptr`s with `unique_ptr`s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,11 @@ FRONTEND_SOURCES = $(wildcard $(FRONTEND_DIR)/*.cpp) \
   $(wildcard $(UTILS_DIR)/*.cpp) \
   $(SRC_DIR)/main.cpp
 
+# Midend-only source files.
+MIDEND_SOURCES = $(wildcard $(MIDEND_DIR)/*.cpp) \
+  $(wildcard $(UTILS_DIR)/*.cpp) \
+  $(SRC_DIR)/main.cpp
+
 # Header files.
 HEADERS = $(wildcard $(FRONTEND_DIR)/*.h) \
   $(wildcard $(MIDEND_DIR)/*.h) \
@@ -46,19 +51,28 @@ OBJECTS = $(patsubst $(SRC_DIR)/%.cpp, $(BIN_DIR)/%.o, $(SOURCES))
 # Frontend-only object files.
 FRONTEND_OBJECTS = $(patsubst $(SRC_DIR)/%.cpp, $(BIN_DIR)/%.o, $(FRONTEND_SOURCES))
 
+# Midend-only object files.
+MIDEND_OBJECTS = $(patsubst $(SRC_DIR)/%.cpp, $(BIN_DIR)/%.o, $(MIDEND_SOURCES))
+
 # Executable file.
 EXECUTABLE = $(BIN_DIR)/main
 
 # Frontend-only executable.
 FRONTEND_EXECUTABLE = $(BIN_DIR)/frontend_test
 
+# Midend-only executable.
+MIDEND_EXECUTABLE = $(BIN_DIR)/midend_test
+
 # Default target.
-.PHONY: all clean debug format release frontend-test
+.PHONY: all clean debug format release frontend-test midend-test
 
 all: $(BIN_DIR) $(EXECUTABLE)
 
 # Frontend-only test target.
 frontend-test: $(BIN_DIR) $(FRONTEND_EXECUTABLE)
+
+# Midend-only test target.
+midend-test: $(BIN_DIR) $(MIDEND_EXECUTABLE)
 
 # Create the `bin` directory if it does not exist.
 $(BIN_DIR):
@@ -85,6 +99,10 @@ $(EXECUTABLE): $(OBJECTS)
 # Link the frontend object files to create the frontend test executable.
 $(FRONTEND_EXECUTABLE): $(FRONTEND_OBJECTS)
 	$(CXX) $(FRONTEND_OBJECTS) -o $@ $(LDFLAGS) $(LDLIBS)
+
+# Link the midend object files to create the midend test executable.
+$(MIDEND_EXECUTABLE): $(MIDEND_OBJECTS)
+	$(CXX) $(MIDEND_OBJECTS) -o $@ $(LDFLAGS) $(LDLIBS)
 
 # Debug target.
 debug: CXXFLAGS += -g -O0 $(SAN_FLAGS) -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,11 @@ SOURCES = $(wildcard $(FRONTEND_DIR)/*.cpp) \
   $(wildcard $(UTILS_DIR)/*.cpp) \
   $(wildcard $(SRC_DIR)/*.cpp)
 
+# Frontend-only source files.
+FRONTEND_SOURCES = $(wildcard $(FRONTEND_DIR)/*.cpp) \
+  $(wildcard $(UTILS_DIR)/*.cpp) \
+  $(SRC_DIR)/main.cpp
+
 # Header files.
 HEADERS = $(wildcard $(FRONTEND_DIR)/*.h) \
   $(wildcard $(MIDEND_DIR)/*.h) \
@@ -38,13 +43,22 @@ HEADERS = $(wildcard $(FRONTEND_DIR)/*.h) \
 # Object files.
 OBJECTS = $(patsubst $(SRC_DIR)/%.cpp, $(BIN_DIR)/%.o, $(SOURCES))
 
+# Frontend-only object files.
+FRONTEND_OBJECTS = $(patsubst $(SRC_DIR)/%.cpp, $(BIN_DIR)/%.o, $(FRONTEND_SOURCES))
+
 # Executable file.
 EXECUTABLE = $(BIN_DIR)/main
 
+# Frontend-only executable.
+FRONTEND_EXECUTABLE = $(BIN_DIR)/frontend_test
+
 # Default target.
-.PHONY: all clean debug format release
+.PHONY: all clean debug format release frontend-test
 
 all: $(BIN_DIR) $(EXECUTABLE)
+
+# Frontend-only test target.
+frontend-test: $(BIN_DIR) $(FRONTEND_EXECUTABLE)
 
 # Create the `bin` directory if it does not exist.
 $(BIN_DIR):
@@ -67,6 +81,10 @@ DEPS = $(OBJECTS:.o=.d)
 # Link the object files to create the executable.
 $(EXECUTABLE): $(OBJECTS)
 	$(CXX) $(OBJECTS) -o $@ $(LDFLAGS) $(LDLIBS)
+
+# Link the frontend object files to create the frontend test executable.
+$(FRONTEND_EXECUTABLE): $(FRONTEND_OBJECTS)
+	$(CXX) $(FRONTEND_OBJECTS) -o $@ $(LDFLAGS) $(LDLIBS)
 
 # Debug target.
 debug: CXXFLAGS += -g -O0 $(SAN_FLAGS) -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG

--- a/src/backend/backendSymbolTable.h
+++ b/src/backend/backendSymbolTable.h
@@ -41,10 +41,12 @@ extern std::unordered_map<std::string, std::shared_ptr<BackendSymbolTableEntry>>
     backendSymbolTable;
 
 // Function to convert a frontend symbol table to a backend symbol table.
+// TODO(zzmic): The function signature is temporarily changed to accommodate
+// the frontend symbol table type change.
 void convertFrontendToBackendSymbolTable(
     const std::unordered_map<
-        std::string, std::pair<std::shared_ptr<AST::Type>,
-                               std::shared_ptr<AST::IdentifierAttribute>>>
+        std::string, std::pair<std::unique_ptr<AST::Type>,
+                               std::unique_ptr<AST::IdentifierAttribute>>>
         &frontendSymbolTable);
 } // namespace Assembly
 

--- a/src/frontend/block.cpp
+++ b/src/frontend/block.cpp
@@ -1,23 +1,22 @@
 #include "block.h"
+#include <memory>
 
 namespace AST {
-Block::Block(
-    std::shared_ptr<std::vector<std::shared_ptr<BlockItem>>> blockItems)
-    : blockItems(blockItems) {}
+Block::Block(std::vector<std::unique_ptr<BlockItem>> blockItems)
+    : blockItems(std::move(blockItems)) {}
 
 void Block::accept(Visitor &visitor) { visitor.visit(*this); }
 
-const std::shared_ptr<std::vector<std::shared_ptr<BlockItem>>> &
-Block::getBlockItems() const {
+std::vector<std::unique_ptr<BlockItem>> &Block::getBlockItems() {
     return blockItems;
 }
 
-void Block::addBlockItem(std::shared_ptr<BlockItem> blockItem) {
-    blockItems->push_back(blockItem);
+void Block::addBlockItem(std::unique_ptr<BlockItem> blockItem) {
+    blockItems.push_back(std::move(blockItem));
 }
 
 void Block::setBlockItems(
-    std::shared_ptr<std::vector<std::shared_ptr<BlockItem>>> newBlockItems) {
-    this->blockItems = newBlockItems;
+    std::vector<std::unique_ptr<BlockItem>> newBlockItems) {
+    this->blockItems = std::move(newBlockItems);
 }
 } // namespace AST

--- a/src/frontend/block.h
+++ b/src/frontend/block.h
@@ -2,23 +2,21 @@
 #define FRONTEND_BLOCK_H
 
 #include "blockItem.h"
+#include <memory>
 #include <vector>
 
 namespace AST {
 class Block : public AST {
   public:
-    explicit Block(
-        std::shared_ptr<std::vector<std::shared_ptr<BlockItem>>> blockItems);
+    explicit Block(std::vector<std::unique_ptr<BlockItem>> blockItems);
+    ~Block() = default; // Vector destructor handles cleanup automatically.
     void accept(Visitor &visitor) override;
-    [[nodiscard]] const std::shared_ptr<
-        std::vector<std::shared_ptr<BlockItem>>> &
-    getBlockItems() const;
-    void addBlockItem(std::shared_ptr<BlockItem> blockItem);
-    void setBlockItems(
-        std::shared_ptr<std::vector<std::shared_ptr<BlockItem>>> blockItems);
+    [[nodiscard]] std::vector<std::unique_ptr<BlockItem>> &getBlockItems();
+    void addBlockItem(std::unique_ptr<BlockItem> blockItem);
+    void setBlockItems(std::vector<std::unique_ptr<BlockItem>> blockItems);
 
   private:
-    std::shared_ptr<std::vector<std::shared_ptr<BlockItem>>> blockItems;
+    std::vector<std::unique_ptr<BlockItem>> blockItems;
 };
 } // namespace AST
 

--- a/src/frontend/blockItem.cpp
+++ b/src/frontend/blockItem.cpp
@@ -2,29 +2,27 @@
 #include "visitor.h"
 
 namespace AST {
-SBlockItem::SBlockItem(std::shared_ptr<Statement> statement)
-    : statement(statement) {}
+SBlockItem::SBlockItem(std::unique_ptr<Statement> statement)
+    : statement(std::move(statement)) {}
 
 void SBlockItem::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<Statement> SBlockItem::getStatement() const {
-    return statement;
+std::unique_ptr<Statement> &SBlockItem::getStatement() { return statement; }
+
+void SBlockItem::setStatement(std::unique_ptr<Statement> newStatement) {
+    this->statement = std::move(newStatement);
 }
 
-void SBlockItem::setStatement(std::shared_ptr<Statement> newStatement) {
-    this->statement = newStatement;
-}
-
-DBlockItem::DBlockItem(std::shared_ptr<Declaration> declaration)
-    : declaration(declaration) {}
+DBlockItem::DBlockItem(std::unique_ptr<Declaration> declaration)
+    : declaration(std::move(declaration)) {}
 
 void DBlockItem::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<Declaration> DBlockItem::getDeclaration() const {
+std::unique_ptr<Declaration> &DBlockItem::getDeclaration() {
     return declaration;
 }
 
-void DBlockItem::setDeclaration(std::shared_ptr<Declaration> newDeclaration) {
-    this->declaration = newDeclaration;
+void DBlockItem::setDeclaration(std::unique_ptr<Declaration> newDeclaration) {
+    this->declaration = std::move(newDeclaration);
 }
 } // Namespace AST

--- a/src/frontend/blockItem.h
+++ b/src/frontend/blockItem.h
@@ -13,24 +13,24 @@ class BlockItem : public AST {
 
 class SBlockItem : public BlockItem {
   public:
-    explicit SBlockItem(std::shared_ptr<Statement> statement);
+    explicit SBlockItem(std::unique_ptr<Statement> statement);
     void accept(Visitor &visitor) override;
-    [[nodiscard]] std::shared_ptr<Statement> getStatement() const;
-    void setStatement(std::shared_ptr<Statement> statement);
+    [[nodiscard]] std::unique_ptr<Statement> &getStatement();
+    void setStatement(std::unique_ptr<Statement> statement);
 
   private:
-    std::shared_ptr<Statement> statement;
+    std::unique_ptr<Statement> statement;
 };
 
 class DBlockItem : public BlockItem {
   public:
-    explicit DBlockItem(std::shared_ptr<Declaration> declaration);
+    explicit DBlockItem(std::unique_ptr<Declaration> declaration);
     void accept(Visitor &visitor) override;
-    [[nodiscard]] std::shared_ptr<Declaration> getDeclaration() const;
-    void setDeclaration(std::shared_ptr<Declaration> declaration);
+    [[nodiscard]] std::unique_ptr<Declaration> &getDeclaration();
+    void setDeclaration(std::unique_ptr<Declaration> declaration);
 
   private:
-    std::shared_ptr<Declaration> declaration;
+    std::unique_ptr<Declaration> declaration;
 };
 } // namespace AST
 

--- a/src/frontend/declaration.cpp
+++ b/src/frontend/declaration.cpp
@@ -1,4 +1,5 @@
 #include "declaration.h"
+#include "block.h"
 #include "visitor.h"
 
 namespace AST {
@@ -97,6 +98,13 @@ void FunctionDeclaration::setParameters(
 
 void FunctionDeclaration::setOptBody(std::optional<Block *> newOptBody) {
     this->optBody = newOptBody;
+}
+
+FunctionDeclaration::~FunctionDeclaration() {
+    // Clean up the raw pointer if it exists.
+    if (optBody.has_value()) {
+        delete optBody.value();
+    }
 }
 
 void FunctionDeclaration::setFunType(std::unique_ptr<Type> newFunType) {

--- a/src/frontend/declaration.cpp
+++ b/src/frontend/declaration.cpp
@@ -3,121 +3,108 @@
 
 namespace AST {
 VariableDeclaration::VariableDeclaration(std::string_view identifier,
-                                         std::shared_ptr<Type> varType)
-    : identifier(identifier), varType(varType) {}
+                                         std::unique_ptr<Type> varType)
+    : identifier(identifier), varType(std::move(varType)) {}
 
 VariableDeclaration::VariableDeclaration(
     std::string_view identifier,
-    std::optional<std::shared_ptr<Expression>> optInitializer,
-    std::shared_ptr<Type> varType)
-    : identifier(identifier), optInitializer(optInitializer), varType(varType) {
+    std::optional<std::unique_ptr<Expression>> optInitializer,
+    std::unique_ptr<Type> varType)
+    : identifier(identifier), optInitializer(std::move(optInitializer)),
+      varType(std::move(varType)) {}
+
+VariableDeclaration::VariableDeclaration(
+    std::string_view identifier, std::unique_ptr<Type> varType,
+    std::optional<std::unique_ptr<StorageClass>> optStorageClass)
+    : identifier(identifier), varType(std::move(varType)),
+      optStorageClass(std::move(optStorageClass)) {}
+
+VariableDeclaration::VariableDeclaration(
+    std::string_view identifier,
+    std::optional<std::unique_ptr<Expression>> optInitializer,
+    std::unique_ptr<Type> varType,
+    std::optional<std::unique_ptr<StorageClass>> optStorageClass)
+    : identifier(identifier), optInitializer(std::move(optInitializer)),
+      varType(std::move(varType)), optStorageClass(std::move(optStorageClass)) {
 }
-
-VariableDeclaration::VariableDeclaration(
-    std::string_view identifier, std::shared_ptr<Type> varType,
-    std::optional<std::shared_ptr<StorageClass>> optStorageClass)
-    : identifier(identifier), varType(varType),
-      optStorageClass(optStorageClass) {}
-
-VariableDeclaration::VariableDeclaration(
-    std::string_view identifier,
-    std::optional<std::shared_ptr<Expression>> optInitializer,
-    std::shared_ptr<Type> varType,
-    std::optional<std::shared_ptr<StorageClass>> optStorageClass)
-    : identifier(identifier), optInitializer(optInitializer), varType(varType),
-      optStorageClass(optStorageClass) {}
 
 void VariableDeclaration::accept(Visitor &visitor) { visitor.visit(*this); }
 
-const std::string &VariableDeclaration::getIdentifier() const {
-    return identifier;
-}
+std::string &VariableDeclaration::getIdentifier() { return identifier; }
 
-std::optional<std::shared_ptr<Expression>>
-VariableDeclaration::getOptInitializer() const {
+std::optional<std::unique_ptr<Expression>> &
+VariableDeclaration::getOptInitializer() {
     return optInitializer;
 }
 
-std::shared_ptr<Type> VariableDeclaration::getVarType() const {
-    return varType;
-}
+std::unique_ptr<Type> &VariableDeclaration::getVarType() { return varType; }
 
-std::optional<std::shared_ptr<StorageClass>>
-VariableDeclaration::getOptStorageClass() const {
+std::optional<std::unique_ptr<StorageClass>> &
+VariableDeclaration::getOptStorageClass() {
     return optStorageClass;
 }
 
-FunctionDeclaration::FunctionDeclaration(
-    std::string_view identifier,
-    std::shared_ptr<std::vector<std::string>> parameters,
-    std::shared_ptr<Type> funType)
-    : identifier(identifier), parameters(parameters), funType(funType) {}
+FunctionDeclaration::FunctionDeclaration(std::string_view identifier,
+                                         std::vector<std::string> parameters,
+                                         std::unique_ptr<Type> funType)
+    : identifier(identifier), parameters(std::move(parameters)),
+      funType(std::move(funType)) {}
+
+FunctionDeclaration::FunctionDeclaration(std::string_view identifier,
+                                         std::vector<std::string> parameters,
+                                         std::optional<Block *> optBody,
+                                         std::unique_ptr<Type> funType)
+    : identifier(identifier), parameters(std::move(parameters)),
+      optBody(optBody), funType(std::move(funType)) {}
 
 FunctionDeclaration::FunctionDeclaration(
-    std::string_view identifier,
-    std::shared_ptr<std::vector<std::string>> parameters,
-    std::optional<std::shared_ptr<Block>> optBody,
-    std::shared_ptr<Type> funType)
-    : identifier(identifier), parameters(parameters), optBody(optBody),
-      funType(funType) {}
+    std::string_view identifier, std::vector<std::string> parameters,
+    std::unique_ptr<Type> funType,
+    std::optional<std::unique_ptr<StorageClass>> optStorageClass)
+    : identifier(identifier), parameters(std::move(parameters)),
+      funType(std::move(funType)), optStorageClass(std::move(optStorageClass)) {
+}
 
 FunctionDeclaration::FunctionDeclaration(
-    std::string_view identifier,
-    std::shared_ptr<std::vector<std::string>> parameters,
-    std::shared_ptr<Type> funType,
-    std::optional<std::shared_ptr<StorageClass>> optStorageClass)
-    : identifier(identifier), parameters(parameters), funType(funType),
-      optStorageClass(optStorageClass) {}
-
-FunctionDeclaration::FunctionDeclaration(
-    std::string_view identifier,
-    std::shared_ptr<std::vector<std::string>> parameters,
-    std::optional<std::shared_ptr<Block>> optBody,
-    std::shared_ptr<Type> funType,
-    std::optional<std::shared_ptr<StorageClass>> optStorageClass)
-    : identifier(identifier), parameters(parameters), optBody(optBody),
-      funType(funType), optStorageClass(optStorageClass) {}
+    std::string_view identifier, std::vector<std::string> parameters,
+    std::optional<Block *> optBody, std::unique_ptr<Type> funType,
+    std::optional<std::unique_ptr<StorageClass>> optStorageClass)
+    : identifier(identifier), parameters(std::move(parameters)),
+      optBody(optBody), funType(std::move(funType)),
+      optStorageClass(std::move(optStorageClass)) {}
 
 void FunctionDeclaration::accept(Visitor &visitor) { visitor.visit(*this); }
 
-const std::string &FunctionDeclaration::getIdentifier() const {
-    return identifier;
-}
+std::string &FunctionDeclaration::getIdentifier() { return identifier; }
 
-const std::shared_ptr<std::vector<std::string>> &
-FunctionDeclaration::getParameterIdentifiers() const {
+std::vector<std::string> &FunctionDeclaration::getParameterIdentifiers() {
     return parameters;
 }
 
-std::shared_ptr<Type> FunctionDeclaration::getFunType() const {
-    return funType;
-}
+std::unique_ptr<Type> &FunctionDeclaration::getFunType() { return funType; }
 
-std::optional<std::shared_ptr<Block>> FunctionDeclaration::getOptBody() const {
-    return optBody;
-}
+std::optional<Block *> &FunctionDeclaration::getOptBody() { return optBody; }
 
-std::optional<std::shared_ptr<StorageClass>>
-FunctionDeclaration::getOptStorageClass() const {
+std::optional<std::unique_ptr<StorageClass>> &
+FunctionDeclaration::getOptStorageClass() {
     return optStorageClass;
 }
 
 void FunctionDeclaration::setParameters(
-    std::shared_ptr<std::vector<std::string>> newParameters) {
-    this->parameters = newParameters;
+    std::vector<std::string> newParameters) {
+    this->parameters = std::move(newParameters);
 }
 
-void FunctionDeclaration::setOptBody(
-    std::optional<std::shared_ptr<Block>> newOptBody) {
+void FunctionDeclaration::setOptBody(std::optional<Block *> newOptBody) {
     this->optBody = newOptBody;
 }
 
-void FunctionDeclaration::setFunType(std::shared_ptr<Type> newFunType) {
-    this->funType = newFunType;
+void FunctionDeclaration::setFunType(std::unique_ptr<Type> newFunType) {
+    this->funType = std::move(newFunType);
 }
 
 void FunctionDeclaration::setOptStorageClass(
-    std::optional<std::shared_ptr<StorageClass>> newOptStorageClass) {
-    this->optStorageClass = newOptStorageClass;
+    std::optional<std::unique_ptr<StorageClass>> newOptStorageClass) {
+    this->optStorageClass = std::move(newOptStorageClass);
 }
 } // Namespace AST

--- a/src/frontend/declaration.h
+++ b/src/frontend/declaration.h
@@ -60,6 +60,7 @@ class FunctionDeclaration : public Declaration {
         std::string_view identifier, std::vector<std::string> parameters,
         std::optional<Block *> optBody, std::unique_ptr<Type> funType,
         std::optional<std::unique_ptr<StorageClass>> optStorageClass);
+    ~FunctionDeclaration();
     void accept(Visitor &visitor) override;
     [[nodiscard]] std::string &getIdentifier();
     [[nodiscard]] std::vector<std::string> &getParameterIdentifiers();

--- a/src/frontend/declaration.h
+++ b/src/frontend/declaration.h
@@ -15,76 +15,70 @@ class Declaration : public AST {};
 class VariableDeclaration : public Declaration {
   public:
     explicit VariableDeclaration(std::string_view identifier,
-                                 std::shared_ptr<Type> varType);
+                                 std::unique_ptr<Type> varType);
     explicit VariableDeclaration(
         std::string_view identifier,
-        std::optional<std::shared_ptr<Expression>> optInitializer,
-        std::shared_ptr<Type> varType);
+        std::optional<std::unique_ptr<Expression>> optInitializer,
+        std::unique_ptr<Type> varType);
     explicit VariableDeclaration(
-        std::string_view identifier, std::shared_ptr<Type> varType,
-        std::optional<std::shared_ptr<StorageClass>> optStorageClass);
+        std::string_view identifier, std::unique_ptr<Type> varType,
+        std::optional<std::unique_ptr<StorageClass>> optStorageClass);
     explicit VariableDeclaration(
         std::string_view identifier,
-        std::optional<std::shared_ptr<Expression>> optInitializer,
-        std::shared_ptr<Type> varType,
-        std::optional<std::shared_ptr<StorageClass>> optStorageClass);
+        std::optional<std::unique_ptr<Expression>> optInitializer,
+        std::unique_ptr<Type> varType,
+        std::optional<std::unique_ptr<StorageClass>> optStorageClass);
     void accept(Visitor &visitor) override;
-    [[nodiscard]] const std::string &getIdentifier() const;
-    [[nodiscard]] std::optional<std::shared_ptr<Expression>>
-    getOptInitializer() const;
-    [[nodiscard]] std::shared_ptr<Type> getVarType() const;
-    [[nodiscard]] std::optional<std::shared_ptr<StorageClass>>
-    getOptStorageClass() const;
+    [[nodiscard]] std::string &getIdentifier();
+    [[nodiscard]] std::optional<std::unique_ptr<Expression>> &
+    getOptInitializer();
+    [[nodiscard]] std::unique_ptr<Type> &getVarType();
+    [[nodiscard]] std::optional<std::unique_ptr<StorageClass>> &
+    getOptStorageClass();
 
   private:
     std::string identifier;
-    std::optional<std::shared_ptr<Expression>> optInitializer;
-    std::shared_ptr<Type> varType;
-    std::optional<std::shared_ptr<StorageClass>> optStorageClass;
+    std::optional<std::unique_ptr<Expression>> optInitializer;
+    std::unique_ptr<Type> varType;
+    std::optional<std::unique_ptr<StorageClass>> optStorageClass;
 };
 
 class FunctionDeclaration : public Declaration {
   public:
+    explicit FunctionDeclaration(std::string_view identifier,
+                                 std::vector<std::string> parameters,
+                                 std::unique_ptr<Type> funType);
+    explicit FunctionDeclaration(std::string_view identifier,
+                                 std::vector<std::string> parameters,
+                                 std::optional<Block *> optBody,
+                                 std::unique_ptr<Type> funType);
     explicit FunctionDeclaration(
-        std::string_view identifier,
-        std::shared_ptr<std::vector<std::string>> parameters,
-        std::shared_ptr<Type> funType);
+        std::string_view identifier, std::vector<std::string> parameters,
+        std::unique_ptr<Type> funType,
+        std::optional<std::unique_ptr<StorageClass>> optStorageClass);
     explicit FunctionDeclaration(
-        std::string_view identifier,
-        std::shared_ptr<std::vector<std::string>> parameters,
-        std::optional<std::shared_ptr<Block>> optBody,
-        std::shared_ptr<Type> funType);
-    explicit FunctionDeclaration(
-        std::string_view identifier,
-        std::shared_ptr<std::vector<std::string>> parameters,
-        std::shared_ptr<Type> funType,
-        std::optional<std::shared_ptr<StorageClass>> optStorageClass);
-    explicit FunctionDeclaration(
-        std::string_view identifier,
-        std::shared_ptr<std::vector<std::string>> parameters,
-        std::optional<std::shared_ptr<Block>> optBody,
-        std::shared_ptr<Type> funType,
-        std::optional<std::shared_ptr<StorageClass>> optStorageClass);
+        std::string_view identifier, std::vector<std::string> parameters,
+        std::optional<Block *> optBody, std::unique_ptr<Type> funType,
+        std::optional<std::unique_ptr<StorageClass>> optStorageClass);
     void accept(Visitor &visitor) override;
-    [[nodiscard]] const std::string &getIdentifier() const;
-    [[nodiscard]] const std::shared_ptr<std::vector<std::string>> &
-    getParameterIdentifiers() const;
-    [[nodiscard]] std::shared_ptr<Type> getFunType() const;
-    [[nodiscard]] std::optional<std::shared_ptr<Block>> getOptBody() const;
-    [[nodiscard]] std::optional<std::shared_ptr<StorageClass>>
-    getOptStorageClass() const;
-    void setParameters(std::shared_ptr<std::vector<std::string>> parameters);
-    void setOptBody(std::optional<std::shared_ptr<Block>> optBody);
-    void setFunType(std::shared_ptr<Type> funType);
+    [[nodiscard]] std::string &getIdentifier();
+    [[nodiscard]] std::vector<std::string> &getParameterIdentifiers();
+    [[nodiscard]] std::unique_ptr<Type> &getFunType();
+    [[nodiscard]] std::optional<Block *> &getOptBody();
+    [[nodiscard]] std::optional<std::unique_ptr<StorageClass>> &
+    getOptStorageClass();
+    void setParameters(std::vector<std::string> newParameters);
+    void setOptBody(std::optional<Block *> newOptBody);
+    void setFunType(std::unique_ptr<Type> newFunType);
     void setOptStorageClass(
-        std::optional<std::shared_ptr<StorageClass>> optStorageClass);
+        std::optional<std::unique_ptr<StorageClass>> newOptStorageClass);
 
   private:
     std::string identifier;
-    std::shared_ptr<std::vector<std::string>> parameters;
-    std::optional<std::shared_ptr<Block>> optBody;
-    std::shared_ptr<Type> funType;
-    std::optional<std::shared_ptr<StorageClass>> optStorageClass;
+    std::vector<std::string> parameters;
+    std::optional<Block *> optBody;
+    std::unique_ptr<Type> funType;
+    std::optional<std::unique_ptr<StorageClass>> optStorageClass;
 };
 } // Namespace AST
 

--- a/src/frontend/expression.cpp
+++ b/src/frontend/expression.cpp
@@ -1,98 +1,91 @@
 #include "expression.h"
 #include "visitor.h"
 
+#include <memory>
 #include <stdexcept>
 
 namespace AST {
-ConstantExpression::ConstantExpression(std::shared_ptr<Constant> constant)
-    : constant(constant) {}
+ConstantExpression::ConstantExpression(std::unique_ptr<Constant> constant)
+    : constant(std::move(constant)) {}
 
-ConstantExpression::ConstantExpression(std::shared_ptr<Constant> constant,
-                                       std::shared_ptr<Type> expType)
-    : constant(constant), expType(expType) {}
+ConstantExpression::ConstantExpression(std::unique_ptr<Constant> constant,
+                                       std::unique_ptr<Type> expType)
+    : constant(std::move(constant)), expType(std::move(expType)) {}
 
 void ConstantExpression::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<Constant> ConstantExpression::getConstant() const {
+std::unique_ptr<Constant> &ConstantExpression::getConstant() {
     return constant;
 }
 
-std::shared_ptr<Type> ConstantExpression::getExpType() const { return expType; }
+std::unique_ptr<Type> &ConstantExpression::getExpType() { return expType; }
 
-void ConstantExpression::setExpType(std::shared_ptr<Type> newExpType) {
-    this->expType = newExpType;
+void ConstantExpression::setExpType(std::unique_ptr<Type> newExpType) {
+    this->expType = std::move(newExpType);
 }
 
 std::variant<int, long>
 ConstantExpression::getConstantInIntOrLongVariant() const {
-    // If the constant is an integer constant, return the integer value.
-    if (auto intConstant = std::dynamic_pointer_cast<ConstantInt>(constant)) {
+    if (const auto *intConstant =
+            dynamic_cast<const ConstantInt *>(constant.get())) {
         return intConstant->getValue();
     }
-    // If the constant is a long constant, return the long value.
-    else if (auto longConstant =
-                 std::dynamic_pointer_cast<ConstantLong>(constant)) {
+    else if (const auto *longConstant =
+                 dynamic_cast<const ConstantLong *>(constant.get())) {
         return longConstant->getValue();
     }
-    else {
-        throw std::logic_error("Unknown constant type in constant expression");
-    }
+    throw std::logic_error("Unknown constant type in constant expression");
 }
 
 VariableExpression::VariableExpression(std::string_view identifier)
     : identifier(identifier) {}
 
 VariableExpression::VariableExpression(std::string_view identifier,
-                                       std::shared_ptr<Type> expType)
-    : identifier(identifier), expType(expType) {}
+                                       std::unique_ptr<Type> expType)
+    : identifier(identifier), expType(std::move(expType)) {}
 
 void VariableExpression::accept(Visitor &visitor) { visitor.visit(*this); }
 
-const std::string &VariableExpression::getIdentifier() const {
-    return identifier;
+std::string &VariableExpression::getIdentifier() { return identifier; }
+
+std::unique_ptr<Type> &VariableExpression::getExpType() { return expType; }
+
+void VariableExpression::setExpType(std::unique_ptr<Type> newExpType) {
+    this->expType = std::move(newExpType);
 }
 
-std::shared_ptr<Type> VariableExpression::getExpType() const { return expType; }
+CastExpression::CastExpression(std::unique_ptr<Type> targetType,
+                               std::unique_ptr<Expression> expr)
+    : targetType(std::move(targetType)), expr(std::move(expr)) {}
 
-void VariableExpression::setExpType(std::shared_ptr<Type> newExpType) {
-    this->expType = newExpType;
-}
-
-CastExpression::CastExpression(std::shared_ptr<Type> targetType,
-                               std::shared_ptr<Expression> expr)
-    : targetType(targetType), expr(expr) {}
-
-CastExpression::CastExpression(std::shared_ptr<Type> targetType,
-                               std::shared_ptr<Expression> expr,
-                               std::shared_ptr<Type> expType)
-    : targetType(targetType), expr(expr), expType(expType) {}
+CastExpression::CastExpression(std::unique_ptr<Type> targetType,
+                               std::unique_ptr<Expression> expr,
+                               std::unique_ptr<Type> expType)
+    : targetType(std::move(targetType)), expr(std::move(expr)),
+      expType(std::move(expType)) {}
 
 void CastExpression::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<Type> CastExpression::getTargetType() const {
-    return targetType;
-}
+std::unique_ptr<Type> &CastExpression::getTargetType() { return targetType; }
 
-std::shared_ptr<Expression> CastExpression::getExpression() const {
-    return expr;
-}
+std::unique_ptr<Expression> &CastExpression::getExpression() { return expr; }
 
-std::shared_ptr<Type> CastExpression::getExpType() const { return expType; }
+std::unique_ptr<Type> &CastExpression::getExpType() { return expType; }
 
-void CastExpression::setExpType(std::shared_ptr<Type> newExpType) {
-    this->expType = newExpType;
+void CastExpression::setExpType(std::unique_ptr<Type> newExpType) {
+    this->expType = std::move(newExpType);
 }
 
 UnaryExpression::UnaryExpression(std::string_view opInStr,
-                                 std::shared_ptr<Expression> expr) {
+                                 std::unique_ptr<Expression> expr) {
     if (opInStr == "-") {
-        op = std::make_shared<NegateOperator>();
+        op = std::make_unique<NegateOperator>();
     }
     else if (opInStr == "~") {
-        op = std::make_shared<ComplementOperator>();
+        op = std::make_unique<ComplementOperator>();
     }
     else if (opInStr == "!") {
-        op = std::make_shared<NotOperator>();
+        op = std::make_unique<NotOperator>();
     }
     else {
         throw std::invalid_argument(
@@ -103,21 +96,22 @@ UnaryExpression::UnaryExpression(std::string_view opInStr,
     }
     // Static-cast the expression to a factor, obeying the grammar `<unop>
     // <factor>`.
-    this->expr = std::static_pointer_cast<Factor>(expr);
+    this->expr = std::unique_ptr<Factor>(
+        static_cast<Factor *>(std::move(expr).release()));
 }
 
 UnaryExpression::UnaryExpression(std::string_view opInStr,
-                                 std::shared_ptr<Expression> expr,
-                                 std::shared_ptr<Type> expType)
-    : expType(expType) {
+                                 std::unique_ptr<Expression> expr,
+                                 std::unique_ptr<Type> expType)
+    : expType(std::move(expType)) {
     if (opInStr == "-") {
-        op = std::make_shared<NegateOperator>();
+        op = std::make_unique<NegateOperator>();
     }
     else if (opInStr == "~") {
-        op = std::make_shared<ComplementOperator>();
+        op = std::make_unique<ComplementOperator>();
     }
     else if (opInStr == "!") {
-        op = std::make_shared<NotOperator>();
+        op = std::make_unique<NotOperator>();
     }
     else {
         throw std::invalid_argument(
@@ -128,74 +122,76 @@ UnaryExpression::UnaryExpression(std::string_view opInStr,
     }
     // Static-cast the expression to a factor, obeying the grammar `<unop>
     // <factor>`.
-    this->expr = std::static_pointer_cast<Factor>(expr);
+    this->expr = std::unique_ptr<Factor>(static_cast<Factor *>(expr.release()));
 }
 
-UnaryExpression::UnaryExpression(std::shared_ptr<UnaryOperator> op,
-                                 std::shared_ptr<Factor> expr)
-    : op(op), expr(expr) {}
+UnaryExpression::UnaryExpression(std::unique_ptr<UnaryOperator> op,
+                                 std::unique_ptr<Factor> expr)
+    : op(std::move(op)), expr(std::move(expr)) {}
 
-UnaryExpression::UnaryExpression(std::shared_ptr<UnaryOperator> op,
-                                 std::shared_ptr<Factor> expr,
-                                 std::shared_ptr<Type> expType)
-    : op(op), expr(expr), expType(expType) {}
+UnaryExpression::UnaryExpression(std::unique_ptr<UnaryOperator> op,
+                                 std::unique_ptr<Factor> expr,
+                                 std::unique_ptr<Type> expType)
+    : op(std::move(op)), expr(std::move(expr)), expType(std::move(expType)) {}
 
 void UnaryExpression::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<UnaryOperator> UnaryExpression::getOperator() const {
-    return op;
+std::unique_ptr<UnaryOperator> &UnaryExpression::getOperator() { return op; }
+
+std::unique_ptr<Factor> &UnaryExpression::getExpression() { return expr; }
+
+void UnaryExpression::setExpression(std::unique_ptr<Factor> newExpr) {
+    this->expr = std::move(newExpr);
 }
 
-std::shared_ptr<Factor> UnaryExpression::getExpression() const { return expr; }
+std::unique_ptr<Type> &UnaryExpression::getExpType() { return expType; }
 
-std::shared_ptr<Type> UnaryExpression::getExpType() const { return expType; }
-
-void UnaryExpression::setExpType(std::shared_ptr<Type> newExpType) {
-    this->expType = newExpType;
+void UnaryExpression::setExpType(std::unique_ptr<Type> newExpType) {
+    this->expType = std::move(newExpType);
 }
 
-BinaryExpression::BinaryExpression(std::shared_ptr<Expression> left,
+BinaryExpression::BinaryExpression(std::unique_ptr<Expression> left,
                                    std::string_view opInStr,
-                                   std::shared_ptr<Expression> right)
-    : left(left), right(right) {
+                                   std::unique_ptr<Expression> right)
+    : left(std::move(left)), right(std::move(right)) {
     if (opInStr == "+") {
-        op = std::make_shared<AddOperator>();
+        op = std::make_unique<AddOperator>();
     }
     else if (opInStr == "-") {
-        op = std::make_shared<SubtractOperator>();
+        op = std::make_unique<SubtractOperator>();
     }
     else if (opInStr == "*") {
-        op = std::make_shared<MultiplyOperator>();
+        op = std::make_unique<MultiplyOperator>();
     }
     else if (opInStr == "/") {
-        op = std::make_shared<DivideOperator>();
+        op = std::make_unique<DivideOperator>();
     }
     else if (opInStr == "%") {
-        op = std::make_shared<RemainderOperator>();
+        op = std::make_unique<RemainderOperator>();
     }
     else if (opInStr == "&&") {
-        op = std::make_shared<AndOperator>();
+        op = std::make_unique<AndOperator>();
     }
     else if (opInStr == "||") {
-        op = std::make_shared<OrOperator>();
+        op = std::make_unique<OrOperator>();
     }
     else if (opInStr == "==") {
-        op = std::make_shared<EqualOperator>();
+        op = std::make_unique<EqualOperator>();
     }
     else if (opInStr == "!=") {
-        op = std::make_shared<NotEqualOperator>();
+        op = std::make_unique<NotEqualOperator>();
     }
     else if (opInStr == "<") {
-        op = std::make_shared<LessThanOperator>();
+        op = std::make_unique<LessThanOperator>();
     }
     else if (opInStr == "<=") {
-        op = std::make_shared<LessThanOrEqualOperator>();
+        op = std::make_unique<LessThanOrEqualOperator>();
     }
     else if (opInStr == ">") {
-        op = std::make_shared<GreaterThanOperator>();
+        op = std::make_unique<GreaterThanOperator>();
     }
     else if (opInStr == ">=") {
-        op = std::make_shared<GreaterThanOrEqualOperator>();
+        op = std::make_unique<GreaterThanOrEqualOperator>();
     }
     else {
         throw std::invalid_argument(
@@ -203,49 +199,50 @@ BinaryExpression::BinaryExpression(std::shared_ptr<Expression> left,
     }
 }
 
-BinaryExpression::BinaryExpression(std::shared_ptr<Expression> left,
+BinaryExpression::BinaryExpression(std::unique_ptr<Expression> left,
                                    std::string_view opInStr,
-                                   std::shared_ptr<Expression> right,
-                                   std::shared_ptr<Type> expType)
-    : left(left), right(right), expType(expType) {
+                                   std::unique_ptr<Expression> right,
+                                   std::unique_ptr<Type> expType)
+    : left(std::move(left)), right(std::move(right)),
+      expType(std::move(expType)) {
     if (opInStr == "+") {
-        op = std::make_shared<AddOperator>();
+        op = std::make_unique<AddOperator>();
     }
     else if (opInStr == "-") {
-        op = std::make_shared<SubtractOperator>();
+        op = std::make_unique<SubtractOperator>();
     }
     else if (opInStr == "*") {
-        op = std::make_shared<MultiplyOperator>();
+        op = std::make_unique<MultiplyOperator>();
     }
     else if (opInStr == "/") {
-        op = std::make_shared<DivideOperator>();
+        op = std::make_unique<DivideOperator>();
     }
     else if (opInStr == "%") {
-        op = std::make_shared<RemainderOperator>();
+        op = std::make_unique<RemainderOperator>();
     }
     else if (opInStr == "&&") {
-        op = std::make_shared<AndOperator>();
+        op = std::make_unique<AndOperator>();
     }
     else if (opInStr == "||") {
-        op = std::make_shared<OrOperator>();
+        op = std::make_unique<OrOperator>();
     }
     else if (opInStr == "==") {
-        op = std::make_shared<EqualOperator>();
+        op = std::make_unique<EqualOperator>();
     }
     else if (opInStr == "!=") {
-        op = std::make_shared<NotEqualOperator>();
+        op = std::make_unique<NotEqualOperator>();
     }
     else if (opInStr == "<") {
-        op = std::make_shared<LessThanOperator>();
+        op = std::make_unique<LessThanOperator>();
     }
     else if (opInStr == "<=") {
-        op = std::make_shared<LessThanOrEqualOperator>();
+        op = std::make_unique<LessThanOrEqualOperator>();
     }
     else if (opInStr == ">") {
-        op = std::make_shared<GreaterThanOperator>();
+        op = std::make_unique<GreaterThanOperator>();
     }
     else if (opInStr == ">=") {
-        op = std::make_shared<GreaterThanOrEqualOperator>();
+        op = std::make_unique<GreaterThanOrEqualOperator>();
     }
     else {
         throw std::invalid_argument(
@@ -253,155 +250,154 @@ BinaryExpression::BinaryExpression(std::shared_ptr<Expression> left,
     }
 }
 
-BinaryExpression::BinaryExpression(std::shared_ptr<Expression> left,
-                                   std::shared_ptr<BinaryOperator> op,
-                                   std::shared_ptr<Expression> right)
-    : left(left), op(op), right(right) {}
+BinaryExpression::BinaryExpression(std::unique_ptr<Expression> left,
+                                   std::unique_ptr<BinaryOperator> op,
+                                   std::unique_ptr<Expression> right)
+    : left(std::move(left)), op(std::move(op)), right(std::move(right)) {}
 
-BinaryExpression::BinaryExpression(std::shared_ptr<Expression> left,
-                                   std::shared_ptr<BinaryOperator> op,
-                                   std::shared_ptr<Expression> right,
-                                   std::shared_ptr<Type> expType)
-    : left(left), op(op), right(right), expType(expType) {}
+BinaryExpression::BinaryExpression(std::unique_ptr<Expression> left,
+                                   std::unique_ptr<BinaryOperator> op,
+                                   std::unique_ptr<Expression> right,
+                                   std::unique_ptr<Type> expType)
+    : left(std::move(left)), op(std::move(op)), right(std::move(right)),
+      expType(std::move(expType)) {}
 
 void BinaryExpression::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<Expression> BinaryExpression::getLeft() const { return left; }
+std::unique_ptr<Expression> &BinaryExpression::getLeft() { return left; }
 
-void BinaryExpression::setLeft(std::shared_ptr<Expression> newLeft) {
-    this->left = newLeft;
+void BinaryExpression::setLeft(std::unique_ptr<Expression> newLeft) {
+    this->left = std::move(newLeft);
 }
 
-std::shared_ptr<BinaryOperator> BinaryExpression::getOperator() const {
-    return op;
+std::unique_ptr<BinaryOperator> &BinaryExpression::getOperator() { return op; }
+
+void BinaryExpression::setOperator(std::unique_ptr<BinaryOperator> newOp) {
+    this->op = std::move(newOp);
 }
 
-void BinaryExpression::setOperator(std::shared_ptr<BinaryOperator> newOp) {
-    this->op = newOp;
+std::unique_ptr<Expression> &BinaryExpression::getRight() { return right; }
+
+void BinaryExpression::setRight(std::unique_ptr<Expression> newRight) {
+    this->right = std::move(newRight);
 }
 
-std::shared_ptr<Expression> BinaryExpression::getRight() const { return right; }
+std::unique_ptr<Type> &BinaryExpression::getExpType() { return expType; }
 
-void BinaryExpression::setRight(std::shared_ptr<Expression> newRight) {
-    this->right = newRight;
+void BinaryExpression::setExpType(std::unique_ptr<Type> newExpType) {
+    this->expType = std::move(newExpType);
 }
 
-std::shared_ptr<Type> BinaryExpression::getExpType() const { return expType; }
+AssignmentExpression::AssignmentExpression(std::unique_ptr<Expression> left,
+                                           std::unique_ptr<Expression> right)
+    : left(std::move(left)), right(std::move(right)) {}
 
-void BinaryExpression::setExpType(std::shared_ptr<Type> newExpType) {
-    this->expType = newExpType;
-}
-
-AssignmentExpression::AssignmentExpression(std::shared_ptr<Expression> left,
-                                           std::shared_ptr<Expression> right)
-    : left(left), right(right) {}
-
-AssignmentExpression::AssignmentExpression(std::shared_ptr<Expression> left,
-                                           std::shared_ptr<Expression> right,
-                                           std::shared_ptr<Type> expType)
-    : left(left), right(right), expType(expType) {}
+AssignmentExpression::AssignmentExpression(std::unique_ptr<Expression> left,
+                                           std::unique_ptr<Expression> right,
+                                           std::unique_ptr<Type> expType)
+    : left(std::move(left)), right(std::move(right)),
+      expType(std::move(expType)) {}
 
 void AssignmentExpression::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<Expression> AssignmentExpression::getLeft() const {
-    return left;
+std::unique_ptr<Expression> &AssignmentExpression::getLeft() { return left; }
+
+void AssignmentExpression::setLeft(std::unique_ptr<Expression> newLeft) {
+    this->left = std::move(newLeft);
 }
 
-std::shared_ptr<Expression> AssignmentExpression::getRight() const {
-    return right;
+std::unique_ptr<Expression> &AssignmentExpression::getRight() { return right; }
+
+void AssignmentExpression::setRight(std::unique_ptr<Expression> newRight) {
+    this->right = std::move(newRight);
 }
 
-std::shared_ptr<Type> AssignmentExpression::getExpType() const {
-    return expType;
-}
+std::unique_ptr<Type> &AssignmentExpression::getExpType() { return expType; }
 
-void AssignmentExpression::setExpType(std::shared_ptr<Type> newExpType) {
-    this->expType = newExpType;
+void AssignmentExpression::setExpType(std::unique_ptr<Type> newExpType) {
+    this->expType = std::move(newExpType);
 }
 
 ConditionalExpression::ConditionalExpression(
-    std::shared_ptr<Expression> condition,
-    std::shared_ptr<Expression> thenExpression,
-    std::shared_ptr<Expression> elseExpression)
-    : condition(condition), thenExpression(thenExpression),
-      elseExpression(elseExpression) {}
+    std::unique_ptr<Expression> condition,
+    std::unique_ptr<Expression> thenExpression,
+    std::unique_ptr<Expression> elseExpression)
+    : condition(std::move(condition)),
+      thenExpression(std::move(thenExpression)),
+      elseExpression(std::move(elseExpression)) {}
 
 ConditionalExpression::ConditionalExpression(
-    std::shared_ptr<Expression> condition,
-    std::shared_ptr<Expression> thenExpression,
-    std::shared_ptr<Expression> elseExpression, std::shared_ptr<Type> expType)
-    : condition(condition), thenExpression(thenExpression),
-      elseExpression(elseExpression), expType(expType) {}
+    std::unique_ptr<Expression> condition,
+    std::unique_ptr<Expression> thenExpression,
+    std::unique_ptr<Expression> elseExpression, std::unique_ptr<Type> expType)
+    : condition(std::move(condition)),
+      thenExpression(std::move(thenExpression)),
+      elseExpression(std::move(elseExpression)), expType(std::move(expType)) {}
 
 void ConditionalExpression::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<Expression> ConditionalExpression::getCondition() const {
+std::unique_ptr<Expression> &ConditionalExpression::getCondition() {
     return condition;
 }
 
 void ConditionalExpression::setCondition(
-    std::shared_ptr<Expression> newCondition) {
-    this->condition = newCondition;
+    std::unique_ptr<Expression> newCondition) {
+    this->condition = std::move(newCondition);
 }
 
-std::shared_ptr<Expression> ConditionalExpression::getThenExpression() const {
+std::unique_ptr<Expression> &ConditionalExpression::getThenExpression() {
     return thenExpression;
 }
 
 void ConditionalExpression::setThenExpression(
-    std::shared_ptr<Expression> newThenExpression) {
-    this->thenExpression = newThenExpression;
+    std::unique_ptr<Expression> newThenExpression) {
+    this->thenExpression = std::move(newThenExpression);
 }
 
-std::shared_ptr<Expression> ConditionalExpression::getElseExpression() const {
+std::unique_ptr<Expression> &ConditionalExpression::getElseExpression() {
     return elseExpression;
 }
 
 void ConditionalExpression::setElseExpression(
-    std::shared_ptr<Expression> newElseExpression) {
-    this->elseExpression = newElseExpression;
+    std::unique_ptr<Expression> newElseExpression) {
+    this->elseExpression = std::move(newElseExpression);
 }
 
-std::shared_ptr<Type> ConditionalExpression::getExpType() const {
-    return expType;
-}
+std::unique_ptr<Type> &ConditionalExpression::getExpType() { return expType; }
 
-void ConditionalExpression::setExpType(std::shared_ptr<Type> newExpType) {
-    this->expType = newExpType;
+void ConditionalExpression::setExpType(std::unique_ptr<Type> newExpType) {
+    this->expType = std::move(newExpType);
 }
 
 FunctionCallExpression::FunctionCallExpression(
     std::string_view identifier,
-    std::shared_ptr<std::vector<std::shared_ptr<Expression>>> arguments)
-    : identifier(identifier), arguments(arguments) {}
+    std::vector<std::unique_ptr<Expression>> arguments)
+    : identifier(identifier), arguments(std::move(arguments)) {}
 
 FunctionCallExpression::FunctionCallExpression(
     std::string_view identifier,
-    std::shared_ptr<std::vector<std::shared_ptr<Expression>>> arguments,
-    std::shared_ptr<Type> expType)
-    : identifier(identifier), arguments(arguments), expType(expType) {}
+    std::vector<std::unique_ptr<Expression>> arguments,
+    std::unique_ptr<Type> expType)
+    : identifier(identifier), arguments(std::move(arguments)),
+      expType(std::move(expType)) {}
 
 void FunctionCallExpression::accept(Visitor &visitor) { visitor.visit(*this); }
 
-const std::string &FunctionCallExpression::getIdentifier() const {
-    return identifier;
-}
+std::string &FunctionCallExpression::getIdentifier() { return identifier; }
 
-const std::shared_ptr<std::vector<std::shared_ptr<Expression>>> &
-FunctionCallExpression::getArguments() const {
+std::vector<std::unique_ptr<Expression>> &
+FunctionCallExpression::getArguments() {
     return arguments;
 }
 
 void FunctionCallExpression::setArguments(
-    std::shared_ptr<std::vector<std::shared_ptr<Expression>>> newArguments) {
-    this->arguments = newArguments;
+    std::vector<std::unique_ptr<Expression>> newArguments) {
+    this->arguments = std::move(newArguments);
 }
 
-std::shared_ptr<Type> FunctionCallExpression::getExpType() const {
-    return expType;
-}
+std::unique_ptr<Type> &FunctionCallExpression::getExpType() { return expType; }
 
-void FunctionCallExpression::setExpType(std::shared_ptr<Type> newExpType) {
-    this->expType = newExpType;
+void FunctionCallExpression::setExpType(std::unique_ptr<Type> newExpType) {
+    this->expType = std::move(newExpType);
 }
 } // Namespace AST

--- a/src/frontend/expression.h
+++ b/src/frontend/expression.h
@@ -15,189 +15,189 @@ namespace AST {
 class Expression : public AST {
   public:
     constexpr Expression() = default;
-    virtual std::shared_ptr<Type> getExpType() const = 0;
-    virtual void setExpType(std::shared_ptr<Type> expType) = 0;
+    virtual std::unique_ptr<Type> &getExpType() = 0;
+    virtual void setExpType(std::unique_ptr<Type> expType) = 0;
 };
 
 class Factor : public Expression {};
 
 class ConstantExpression : public Factor {
   public:
-    explicit ConstantExpression(std::shared_ptr<Constant> constant);
-    explicit ConstantExpression(std::shared_ptr<Constant> constant,
-                                std::shared_ptr<Type> expType);
+    explicit ConstantExpression(std::unique_ptr<Constant> constant);
+    explicit ConstantExpression(std::unique_ptr<Constant> constant,
+                                std::unique_ptr<Type> expType);
     void accept(Visitor &visitor) override;
-    [[nodiscard]] std::shared_ptr<Constant> getConstant() const;
-    [[nodiscard]] std::shared_ptr<Type> getExpType() const override;
-    void setExpType(std::shared_ptr<Type> expType) override;
+    [[nodiscard]] std::unique_ptr<Constant> &getConstant();
+    [[nodiscard]] std::unique_ptr<Type> &getExpType() override;
+    void setExpType(std::unique_ptr<Type> expType) override;
     [[nodiscard]] int getConstantInInt() const;
     [[nodiscard]] std::variant<int, long> getConstantInIntOrLongVariant() const;
 
   private:
-    std::shared_ptr<Constant> constant;
+    std::unique_ptr<Constant> constant;
     // Type information of, in this case, the constant-expression AST node.
-    std::shared_ptr<Type> expType;
+    std::unique_ptr<Type> expType;
 };
 
 class VariableExpression : public Factor {
   public:
     explicit VariableExpression(std::string_view identifier);
     explicit VariableExpression(std::string_view identifier,
-                                std::shared_ptr<Type> expType);
+                                std::unique_ptr<Type> expType);
     void accept(Visitor &visitor) override;
-    [[nodiscard]] const std::string &getIdentifier() const;
-    [[nodiscard]] std::shared_ptr<Type> getExpType() const override;
-    void setExpType(std::shared_ptr<Type> expType) override;
+    [[nodiscard]] std::string &getIdentifier();
+    [[nodiscard]] std::unique_ptr<Type> &getExpType() override;
+    void setExpType(std::unique_ptr<Type> expType) override;
 
   private:
     std::string identifier;
-    std::shared_ptr<Type> expType;
+    std::unique_ptr<Type> expType;
 };
 
 class CastExpression : public Factor {
   public:
-    explicit CastExpression(std::shared_ptr<Type> targetType,
-                            std::shared_ptr<Expression> expr);
-    explicit CastExpression(std::shared_ptr<Type> targetType,
-                            std::shared_ptr<Expression> expr,
-                            std::shared_ptr<Type> expType);
+    explicit CastExpression(std::unique_ptr<Type> targetType,
+                            std::unique_ptr<Expression> expr);
+    explicit CastExpression(std::unique_ptr<Type> targetType,
+                            std::unique_ptr<Expression> expr,
+                            std::unique_ptr<Type> expType);
     void accept(Visitor &visitor) override;
-    [[nodiscard]] std::shared_ptr<Type> getTargetType() const;
-    [[nodiscard]] std::shared_ptr<Expression> getExpression() const;
-    [[nodiscard]] std::shared_ptr<Type> getExpType() const override;
-    void setExpType(std::shared_ptr<Type> expType) override;
+    [[nodiscard]] std::unique_ptr<Type> &getTargetType();
+    [[nodiscard]] std::unique_ptr<Expression> &getExpression();
+    [[nodiscard]] std::unique_ptr<Type> &getExpType() override;
+    void setExpType(std::unique_ptr<Type> expType) override;
 
   private:
-    std::shared_ptr<Type> targetType;
-    std::shared_ptr<Expression> expr;
-    std::shared_ptr<Type> expType;
+    std::unique_ptr<Type> targetType;
+    std::unique_ptr<Expression> expr;
+    std::unique_ptr<Type> expType;
 };
 
 class UnaryExpression : public Factor {
   public:
     explicit UnaryExpression(std::string_view opInStr,
-                             std::shared_ptr<Expression> expr);
+                             std::unique_ptr<Expression> expr);
     explicit UnaryExpression(std::string_view opInStr,
-                             std::shared_ptr<Expression> expr,
-                             std::shared_ptr<Type> expType);
-    explicit UnaryExpression(std::shared_ptr<UnaryOperator> op,
-                             std::shared_ptr<Factor> expr);
-    explicit UnaryExpression(std::shared_ptr<UnaryOperator> op,
-                             std::shared_ptr<Factor> expr,
-                             std::shared_ptr<Type> expType);
+                             std::unique_ptr<Expression> expr,
+                             std::unique_ptr<Type> expType);
+    explicit UnaryExpression(std::unique_ptr<UnaryOperator> op,
+                             std::unique_ptr<Factor> expr);
+    explicit UnaryExpression(std::unique_ptr<UnaryOperator> op,
+                             std::unique_ptr<Factor> expr,
+                             std::unique_ptr<Type> expType);
     void accept(Visitor &visitor) override;
-    [[nodiscard]] std::shared_ptr<UnaryOperator> getOperator() const;
-    [[nodiscard]] std::shared_ptr<Factor> getExpression() const;
-    [[nodiscard]] std::shared_ptr<Type> getExpType() const override;
-    void setExpType(std::shared_ptr<Type> expType) override;
+    [[nodiscard]] std::unique_ptr<UnaryOperator> &getOperator();
+    [[nodiscard]] std::unique_ptr<Factor> &getExpression();
+    void setExpression(std::unique_ptr<Factor> newExpr);
+    [[nodiscard]] std::unique_ptr<Type> &getExpType() override;
+    void setExpType(std::unique_ptr<Type> expType) override;
 
   private:
-    std::shared_ptr<UnaryOperator> op;
-    std::shared_ptr<Factor> expr;
-    std::shared_ptr<Type> expType;
+    std::unique_ptr<UnaryOperator> op;
+    std::unique_ptr<Factor> expr;
+    std::unique_ptr<Type> expType;
 };
 
 class BinaryExpression : public Expression {
   public:
-    explicit BinaryExpression(std::shared_ptr<Expression> left,
+    explicit BinaryExpression(std::unique_ptr<Expression> left,
                               std::string_view opInStr,
-                              std::shared_ptr<Expression> right);
-    explicit BinaryExpression(std::shared_ptr<Expression> left,
+                              std::unique_ptr<Expression> right);
+    explicit BinaryExpression(std::unique_ptr<Expression> left,
                               std::string_view opInStr,
-                              std::shared_ptr<Expression> right,
-                              std::shared_ptr<Type> expType);
-    explicit BinaryExpression(std::shared_ptr<Expression> left,
-                              std::shared_ptr<BinaryOperator> op,
-                              std::shared_ptr<Expression> right);
-    explicit BinaryExpression(std::shared_ptr<Expression> left,
-                              std::shared_ptr<BinaryOperator> op,
-                              std::shared_ptr<Expression> right,
-                              std::shared_ptr<Type> expType);
+                              std::unique_ptr<Expression> right,
+                              std::unique_ptr<Type> expType);
+    explicit BinaryExpression(std::unique_ptr<Expression> left,
+                              std::unique_ptr<BinaryOperator> op,
+                              std::unique_ptr<Expression> right);
+    explicit BinaryExpression(std::unique_ptr<Expression> left,
+                              std::unique_ptr<BinaryOperator> op,
+                              std::unique_ptr<Expression> right,
+                              std::unique_ptr<Type> expType);
     void accept(Visitor &visitor) override;
-    [[nodiscard]] std::shared_ptr<Expression> getLeft() const;
-    void setLeft(std::shared_ptr<Expression> left);
-    [[nodiscard]] std::shared_ptr<BinaryOperator> getOperator() const;
-    void setOperator(std::shared_ptr<BinaryOperator> op);
-    [[nodiscard]] std::shared_ptr<Expression> getRight() const;
-    void setRight(std::shared_ptr<Expression> right);
-    [[nodiscard]] std::shared_ptr<Type> getExpType() const override;
-    void setExpType(std::shared_ptr<Type> expType) override;
+    [[nodiscard]] std::unique_ptr<Expression> &getLeft();
+    void setLeft(std::unique_ptr<Expression> newLeft);
+    [[nodiscard]] std::unique_ptr<BinaryOperator> &getOperator();
+    void setOperator(std::unique_ptr<BinaryOperator> newOp);
+    [[nodiscard]] std::unique_ptr<Expression> &getRight();
+    void setRight(std::unique_ptr<Expression> newRight);
+    [[nodiscard]] std::unique_ptr<Type> &getExpType() override;
+    void setExpType(std::unique_ptr<Type> expType) override;
 
   private:
-    std::shared_ptr<Expression> left;
-    std::shared_ptr<BinaryOperator> op;
-    std::shared_ptr<Expression> right;
-    std::shared_ptr<Type> expType;
+    std::unique_ptr<Expression> left;
+    std::unique_ptr<BinaryOperator> op;
+    std::unique_ptr<Expression> right;
+    std::unique_ptr<Type> expType;
 };
 
 class AssignmentExpression : public Expression {
   public:
-    explicit AssignmentExpression(std::shared_ptr<Expression> left,
-                                  std::shared_ptr<Expression> right);
-    explicit AssignmentExpression(std::shared_ptr<Expression> left,
-                                  std::shared_ptr<Expression> right,
-                                  std::shared_ptr<Type> expType);
+    explicit AssignmentExpression(std::unique_ptr<Expression> left,
+                                  std::unique_ptr<Expression> right);
+    explicit AssignmentExpression(std::unique_ptr<Expression> left,
+                                  std::unique_ptr<Expression> right,
+                                  std::unique_ptr<Type> expType);
     void accept(Visitor &visitor) override;
-    [[nodiscard]] std::shared_ptr<Expression> getLeft() const;
-    [[nodiscard]] std::shared_ptr<Expression> getRight() const;
-    [[nodiscard]] std::shared_ptr<Type> getExpType() const override;
-    void setExpType(std::shared_ptr<Type> expType) override;
+    [[nodiscard]] std::unique_ptr<Expression> &getLeft();
+    void setLeft(std::unique_ptr<Expression> newLeft);
+    [[nodiscard]] std::unique_ptr<Expression> &getRight();
+    void setRight(std::unique_ptr<Expression> newRight);
+    [[nodiscard]] std::unique_ptr<Type> &getExpType() override;
+    void setExpType(std::unique_ptr<Type> expType) override;
 
   private:
-    std::shared_ptr<Expression> left;
-    std::shared_ptr<Expression> right;
-    std::shared_ptr<Type> expType;
+    std::unique_ptr<Expression> left;
+    std::unique_ptr<Expression> right;
+    std::unique_ptr<Type> expType;
 };
 
 class ConditionalExpression : public Expression {
   public:
-    explicit ConditionalExpression(std::shared_ptr<Expression> condition,
-                                   std::shared_ptr<Expression> thenExpression,
-                                   std::shared_ptr<Expression> elseExpression);
-    explicit ConditionalExpression(std::shared_ptr<Expression> condition,
-                                   std::shared_ptr<Expression> thenExpression,
-                                   std::shared_ptr<Expression> elseExpression,
-                                   std::shared_ptr<Type> expType);
+    explicit ConditionalExpression(std::unique_ptr<Expression> condition,
+                                   std::unique_ptr<Expression> thenExpression,
+                                   std::unique_ptr<Expression> elseExpression);
+    explicit ConditionalExpression(std::unique_ptr<Expression> condition,
+                                   std::unique_ptr<Expression> thenExpression,
+                                   std::unique_ptr<Expression> elseExpression,
+                                   std::unique_ptr<Type> expType);
     void accept(Visitor &visitor) override;
-    [[nodiscard]] std::shared_ptr<Expression> getCondition() const;
-    void setCondition(std::shared_ptr<Expression> condition);
-    [[nodiscard]] std::shared_ptr<Expression> getThenExpression() const;
-    void setThenExpression(std::shared_ptr<Expression> thenExpression);
-    [[nodiscard]] std::shared_ptr<Expression> getElseExpression() const;
-    void setElseExpression(std::shared_ptr<Expression> elseExpression);
-    [[nodiscard]] std::shared_ptr<Type> getExpType() const override;
-    void setExpType(std::shared_ptr<Type> expType) override;
+    [[nodiscard]] std::unique_ptr<Expression> &getCondition();
+    void setCondition(std::unique_ptr<Expression> newCondition);
+    [[nodiscard]] std::unique_ptr<Expression> &getThenExpression();
+    void setThenExpression(std::unique_ptr<Expression> newThenExpression);
+    [[nodiscard]] std::unique_ptr<Expression> &getElseExpression();
+    void setElseExpression(std::unique_ptr<Expression> newElseExpression);
+    [[nodiscard]] std::unique_ptr<Type> &getExpType() override;
+    void setExpType(std::unique_ptr<Type> expType) override;
 
   private:
-    std::shared_ptr<Expression> condition;
-    std::shared_ptr<Expression> thenExpression;
-    std::shared_ptr<Expression> elseExpression;
-    std::shared_ptr<Type> expType;
+    std::unique_ptr<Expression> condition;
+    std::unique_ptr<Expression> thenExpression;
+    std::unique_ptr<Expression> elseExpression;
+    std::unique_ptr<Type> expType;
 };
 
 class FunctionCallExpression : public Expression {
   public:
     explicit FunctionCallExpression(
         std::string_view identifier,
-        std::shared_ptr<std::vector<std::shared_ptr<Expression>>> arguments);
+        std::vector<std::unique_ptr<Expression>> arguments);
     explicit FunctionCallExpression(
         std::string_view identifier,
-        std::shared_ptr<std::vector<std::shared_ptr<Expression>>> arguments,
-        std::shared_ptr<Type> expType);
+        std::vector<std::unique_ptr<Expression>> arguments,
+        std::unique_ptr<Type> expType);
     void accept(Visitor &visitor) override;
-    [[nodiscard]] const std::string &getIdentifier() const;
-    [[nodiscard]] const std::shared_ptr<
-        std::vector<std::shared_ptr<Expression>>> &
-    getArguments() const;
-    void setArguments(
-        std::shared_ptr<std::vector<std::shared_ptr<Expression>>> arguments);
-    [[nodiscard]] std::shared_ptr<Type> getExpType() const override;
-    void setExpType(std::shared_ptr<Type> expType) override;
+    [[nodiscard]] std::string &getIdentifier();
+    [[nodiscard]] std::vector<std::unique_ptr<Expression>> &getArguments();
+    void setArguments(std::vector<std::unique_ptr<Expression>> newArguments);
+    [[nodiscard]] std::unique_ptr<Type> &getExpType() override;
+    void setExpType(std::unique_ptr<Type> expType) override;
 
   private:
     std::string identifier;
-    std::shared_ptr<std::vector<std::shared_ptr<Expression>>> arguments;
-    std::shared_ptr<Type> expType;
+    std::vector<std::unique_ptr<Expression>> arguments;
+    std::unique_ptr<Type> expType;
 };
 } // Namespace AST
 

--- a/src/frontend/forInit.cpp
+++ b/src/frontend/forInit.cpp
@@ -1,20 +1,21 @@
 #include "forInit.h"
 
 namespace AST {
-InitDecl::InitDecl(std::shared_ptr<VariableDeclaration> decl) : decl(decl) {}
+InitDecl::InitDecl(std::unique_ptr<VariableDeclaration> decl)
+    : decl(std::move(decl)) {}
 
 void InitDecl::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<VariableDeclaration> InitDecl::getVariableDeclaration() const {
+std::unique_ptr<VariableDeclaration> &InitDecl::getVariableDeclaration() {
     return decl;
 }
 
-InitExpr::InitExpr(std::optional<std::shared_ptr<Expression>> expr)
-    : expr(expr) {}
+InitExpr::InitExpr(std::optional<std::unique_ptr<Expression>> expr)
+    : expr(std::move(expr)) {}
 
 void InitExpr::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::optional<std::shared_ptr<Expression>> InitExpr::getExpression() const {
+std::optional<std::unique_ptr<Expression>> &InitExpr::getExpression() {
     return expr;
 }
 } // Namespace AST

--- a/src/frontend/forInit.h
+++ b/src/frontend/forInit.h
@@ -13,25 +13,24 @@ class ForInit : public AST {
 
 class InitDecl : public ForInit {
   public:
-    explicit InitDecl(std::shared_ptr<VariableDeclaration> decl);
+    explicit InitDecl(std::unique_ptr<VariableDeclaration> decl);
     void accept(Visitor &visitor) override;
-    [[nodiscard]] std::shared_ptr<VariableDeclaration>
-    getVariableDeclaration() const;
+    [[nodiscard]] std::unique_ptr<VariableDeclaration> &
+    getVariableDeclaration();
 
   private:
-    std::shared_ptr<VariableDeclaration> decl;
+    std::unique_ptr<VariableDeclaration> decl;
 };
 
 class InitExpr : public ForInit {
   public:
     constexpr InitExpr() = default;
-    explicit InitExpr(std::optional<std::shared_ptr<Expression>> expr);
+    explicit InitExpr(std::optional<std::unique_ptr<Expression>> expr);
     void accept(Visitor &visitor) override;
-    [[nodiscard]] std::optional<std::shared_ptr<Expression>>
-    getExpression() const;
+    [[nodiscard]] std::optional<std::unique_ptr<Expression>> &getExpression();
 
   private:
-    std::optional<std::shared_ptr<Expression>> expr;
+    std::optional<std::unique_ptr<Expression>> expr;
 };
 } // Namespace AST
 

--- a/src/frontend/frontendSymbolTable.cpp
+++ b/src/frontend/frontendSymbolTable.cpp
@@ -1,8 +1,9 @@
 #include "frontendSymbolTable.h"
+#include <memory>
 
 namespace AST {
 // Global frontend symbol table definition.
-std::unordered_map<std::string, std::pair<std::shared_ptr<Type>,
-                                          std::shared_ptr<IdentifierAttribute>>>
+std::unordered_map<std::string, std::pair<std::unique_ptr<Type>,
+                                          std::unique_ptr<IdentifierAttribute>>>
     frontendSymbolTable;
 } // namespace AST

--- a/src/frontend/frontendSymbolTable.h
+++ b/src/frontend/frontendSymbolTable.h
@@ -10,7 +10,7 @@ namespace AST {
 // Global frontend symbol table declaration.
 extern std::unordered_map<
     std::string,
-    std::pair<std::shared_ptr<Type>, std::shared_ptr<IdentifierAttribute>>>
+    std::pair<std::unique_ptr<Type>, std::unique_ptr<IdentifierAttribute>>>
     frontendSymbolTable;
 } // namespace AST
 

--- a/src/frontend/function.cpp
+++ b/src/frontend/function.cpp
@@ -6,7 +6,8 @@ Function::Function(std::string_view identifier, Block *body)
     : identifier(identifier), body(body) {}
 
 Function::~Function() {
-    delete body; // Clean up raw pointer.
+    // Clean up the raw pointer.
+    delete body;
 }
 
 void Function::accept(Visitor &visitor) { visitor.visit(*this); }

--- a/src/frontend/function.cpp
+++ b/src/frontend/function.cpp
@@ -2,14 +2,18 @@
 #include "visitor.h"
 
 namespace AST {
-Function::Function(std::string_view identifier, std::shared_ptr<Block> body)
+Function::Function(std::string_view identifier, Block *body)
     : identifier(identifier), body(body) {}
+
+Function::~Function() {
+    delete body; // Clean up raw pointer.
+}
 
 void Function::accept(Visitor &visitor) { visitor.visit(*this); }
 
-const std::string &Function::getIdentifier() const { return identifier; }
+std::string &Function::getIdentifier() { return identifier; }
 
-std::shared_ptr<Block> Function::getBody() const { return body; }
+Block *Function::getBody() { return body; }
 
-void Function::setBody(std::shared_ptr<Block> newBody) { this->body = newBody; }
+void Function::setBody(Block *newBody) { this->body = newBody; }
 } // Namespace AST

--- a/src/frontend/function.h
+++ b/src/frontend/function.h
@@ -12,15 +12,16 @@
 namespace AST {
 class Function : public AST {
   public:
-    explicit Function(std::string_view identifier, std::shared_ptr<Block> body);
+    explicit Function(std::string_view identifier, Block *body);
+    ~Function(); // Need destructor to clean up raw pointer
     void accept(Visitor &vistor) override;
-    [[nodiscard]] const std::string &getIdentifier() const;
-    [[nodiscard]] std::shared_ptr<Block> getBody() const;
-    void setBody(std::shared_ptr<Block> body);
+    [[nodiscard]] std::string &getIdentifier();
+    [[nodiscard]] Block *getBody();
+    void setBody(Block *body);
 
   private:
     std::string identifier;
-    std::shared_ptr<Block> body;
+    Block *body;
 };
 } // Namespace AST
 

--- a/src/frontend/function.h
+++ b/src/frontend/function.h
@@ -13,7 +13,7 @@ namespace AST {
 class Function : public AST {
   public:
     explicit Function(std::string_view identifier, Block *body);
-    ~Function(); // Need destructor to clean up raw pointer
+    ~Function();
     void accept(Visitor &vistor) override;
     [[nodiscard]] std::string &getIdentifier();
     [[nodiscard]] Block *getBody();

--- a/src/frontend/parser.cpp
+++ b/src/frontend/parser.cpp
@@ -4,14 +4,13 @@
 namespace AST {
 Parser::Parser(const std::vector<Token> &tokens) : tokens(tokens), current(0) {}
 
-std::shared_ptr<Program> Parser::parse() {
-    auto declarations =
-        std::make_shared<std::vector<std::shared_ptr<Declaration>>>();
+std::unique_ptr<Program> Parser::parse() {
+    auto declarations = std::vector<std::unique_ptr<Declaration>>();
     while (current < tokens.size()) {
         auto declaration = parseDeclaration();
-        declarations->emplace_back(std::move(declaration));
+        declarations.emplace_back(std::move(declaration));
     }
-    return std::make_shared<Program>(std::move(declarations));
+    return std::make_unique<Program>(std::move(declarations));
 }
 
 bool Parser::matchToken(TokenType type) {
@@ -50,7 +49,7 @@ void Parser::expectToken(TokenType type) {
     consumeToken(type);
 }
 
-std::shared_ptr<BlockItem> Parser::parseBlockItem() {
+std::unique_ptr<BlockItem> Parser::parseBlockItem() {
     if (matchToken(TokenType::intKeyword) ||
         matchToken(TokenType::longKeyword) ||
         matchToken(TokenType::staticKeyword) ||
@@ -66,33 +65,32 @@ std::shared_ptr<BlockItem> Parser::parseBlockItem() {
                 // If the sequence matches `int <identifier> (<params>)`, it's a
                 // function declaration.
                 auto functionDeclaration = parseDeclaration();
-                return std::make_shared<DBlockItem>(
+                return std::make_unique<DBlockItem>(
                     std::move(functionDeclaration));
             }
         }
         // Otherwise, treat it as a variable declaration.
         auto declaration = parseDeclaration();
-        return std::make_shared<DBlockItem>(std::move(declaration));
+        return std::make_unique<DBlockItem>(std::move(declaration));
     }
     else {
         auto statement = parseStatement();
-        return std::make_shared<SBlockItem>(std::move(statement));
+        return std::make_unique<SBlockItem>(std::move(statement));
     }
 }
 
-std::shared_ptr<Block> Parser::parseBlock() {
+Block *Parser::parseBlock() {
     expectToken(TokenType::OpenBrace);
-    auto blockItems =
-        std::make_shared<std::vector<std::shared_ptr<BlockItem>>>();
+    std::vector<std::unique_ptr<BlockItem>> blockItems;
     while (!matchToken(TokenType::CloseBrace)) {
         auto nextBlockItem = parseBlockItem();
-        blockItems->emplace_back(std::move(nextBlockItem));
+        blockItems.emplace_back(std::move(nextBlockItem));
     }
     expectToken(TokenType::CloseBrace);
-    return std::make_shared<Block>(std::move(blockItems));
+    return new Block(std::move(blockItems));
 }
 
-std::shared_ptr<Declaration> Parser::parseDeclaration() {
+std::unique_ptr<Declaration> Parser::parseDeclaration() {
     // Parse the specifier list.
     std::vector<std::string> specifierList;
     while (matchToken(TokenType::intKeyword) ||
@@ -118,17 +116,16 @@ std::shared_ptr<Declaration> Parser::parseDeclaration() {
     }
     // Parse the type and storage class.
     auto typesAndStorageClass = parseTypeAndStorageClass(specifierList);
-    auto type = typesAndStorageClass.first;
-    auto storageClass = typesAndStorageClass.second;
+    auto type = std::move(typesAndStorageClass.first);
+    auto storageClass = std::move(typesAndStorageClass.second);
     // Consume an identifier token (common to both variable and function
     // declarations).
     auto identifierToken = consumeToken(TokenType::Identifier);
     if (matchToken(TokenType::OpenParenthesis)) {
         // Parse a function declaration.
         expectToken(TokenType::OpenParenthesis);
-        auto parameters = std::make_shared<std::vector<std::string>>();
-        auto parameterTypes =
-            std::make_shared<std::vector<std::shared_ptr<Type>>>();
+        std::vector<std::string> parameters;
+        auto parameterTypes = std::vector<std::unique_ptr<Type>>();
 
         if (matchToken(TokenType::voidKeyword)) {
             consumeToken(TokenType::voidKeyword);
@@ -136,47 +133,47 @@ std::shared_ptr<Declaration> Parser::parseDeclaration() {
         else if (matchToken(TokenType::intKeyword)) {
             parseTypeSpecifiersInParameters(parameters);
             auto parameterNameToken1 = consumeToken(TokenType::Identifier);
-            parameters->emplace_back(parameterNameToken1.value);
-            parameterTypes->emplace_back(std::make_shared<IntType>());
+            parameters.emplace_back(parameterNameToken1.value);
+            parameterTypes.emplace_back(std::make_unique<IntType>());
             // Parse additional parameters if they exist.
             while (matchToken(TokenType::Comma)) {
                 consumeToken(TokenType::Comma);
                 parseTypeSpecifiersInParameters(parameters);
                 auto parameterNameToken2 = consumeToken(TokenType::Identifier);
-                parameters->emplace_back(parameterNameToken2.value);
-                parameterTypes->emplace_back(std::make_shared<IntType>());
+                parameters.emplace_back(parameterNameToken2.value);
+                parameterTypes.emplace_back(std::make_unique<IntType>());
             }
         }
         else if (matchToken(TokenType::longKeyword)) {
             parseTypeSpecifiersInParameters(parameters);
             auto parameterNameToken3 = consumeToken(TokenType::Identifier);
-            parameters->emplace_back(parameterNameToken3.value);
-            parameterTypes->emplace_back(std::make_shared<LongType>());
+            parameters.emplace_back(parameterNameToken3.value);
+            parameterTypes.emplace_back(std::make_unique<LongType>());
             // Parse additional parameters if they exist.
             while (matchToken(TokenType::Comma)) {
                 consumeToken(TokenType::Comma);
                 parseTypeSpecifiersInParameters(parameters);
                 auto parameterNameToken4 = consumeToken(TokenType::Identifier);
-                parameters->emplace_back(parameterNameToken4.value);
-                parameterTypes->emplace_back(std::make_shared<LongType>());
+                parameters.emplace_back(parameterNameToken4.value);
+                parameterTypes.emplace_back(std::make_unique<LongType>());
             }
         }
         expectToken(TokenType::CloseParenthesis);
 
         // Create a proper `FunctionType` with parameter types and return type.
-        auto functionType =
-            std::make_shared<FunctionType>(parameterTypes, type);
+        auto functionType = std::make_unique<FunctionType>(
+            std::move(parameterTypes), std::move(type));
 
         if (matchToken(TokenType::Semicolon)) {
             consumeToken(TokenType::Semicolon);
             if (storageClass) {
-                return std::make_shared<FunctionDeclaration>(
+                return std::make_unique<FunctionDeclaration>(
                     identifierToken.value, std::move(parameters),
                     std::move(functionType),
                     std::make_optional(std::move(storageClass)));
             }
             else {
-                return std::make_shared<FunctionDeclaration>(
+                return std::make_unique<FunctionDeclaration>(
                     identifierToken.value, std::move(parameters),
                     std::move(functionType));
             }
@@ -184,14 +181,14 @@ std::shared_ptr<Declaration> Parser::parseDeclaration() {
         else {
             auto functionBody = parseBlock();
             if (storageClass) {
-                return std::make_shared<FunctionDeclaration>(
+                return std::make_unique<FunctionDeclaration>(
                     identifierToken.value, std::move(parameters),
                     std::make_optional(std::move(functionBody)),
                     std::move(functionType),
                     std::make_optional(std::move(storageClass)));
             }
             else {
-                return std::make_shared<FunctionDeclaration>(
+                return std::make_unique<FunctionDeclaration>(
                     identifierToken.value, std::move(parameters),
                     std::make_optional(std::move(functionBody)),
                     std::move(functionType));
@@ -205,24 +202,24 @@ std::shared_ptr<Declaration> Parser::parseDeclaration() {
             auto expr = parseExpression(0);
             expectToken(TokenType::Semicolon);
             if (storageClass) {
-                return std::make_shared<VariableDeclaration>(
+                return std::make_unique<VariableDeclaration>(
                     identifierToken.value, std::move(expr), std::move(type),
                     std::move(storageClass));
             }
             else {
-                return std::make_shared<VariableDeclaration>(
+                return std::make_unique<VariableDeclaration>(
                     identifierToken.value, std::move(expr), std::move(type));
             }
         }
         else {
             expectToken(TokenType::Semicolon);
             if (storageClass) {
-                return std::make_shared<VariableDeclaration>(
+                return std::make_unique<VariableDeclaration>(
                     identifierToken.value, std::move(type),
                     std::move(storageClass));
             }
             else {
-                return std::make_shared<VariableDeclaration>(
+                return std::make_unique<VariableDeclaration>(
                     identifierToken.value, std::move(type));
             }
         }
@@ -230,62 +227,61 @@ std::shared_ptr<Declaration> Parser::parseDeclaration() {
 }
 
 void Parser::parseTypeSpecifiersInParameters(
-    const std::shared_ptr<std::vector<std::string>> &parameters) {
+    std::vector<std::string> &parameters) {
     while (matchToken(TokenType::intKeyword) ||
            matchToken(TokenType::longKeyword)) {
         if (matchToken(TokenType::intKeyword)) {
             expectToken(TokenType::intKeyword);
-            parameters->emplace_back("int");
+            parameters.emplace_back("int");
         }
         else if (matchToken(TokenType::longKeyword)) {
             expectToken(TokenType::longKeyword);
-            parameters->emplace_back("long");
+            parameters.emplace_back("long");
         }
     }
 }
 
-std::shared_ptr<ForInit> Parser::parseForInit() {
+std::unique_ptr<ForInit> Parser::parseForInit() {
     if (matchToken(TokenType::intKeyword) ||
         matchToken(TokenType::longKeyword) ||
         matchToken(TokenType::staticKeyword) ||
         matchToken(TokenType::externKeyword)) {
         auto declaration = parseDeclaration();
-        if (std::dynamic_pointer_cast<VariableDeclaration>(declaration)) {
-            return std::make_shared<InitDecl>(
-                std::static_pointer_cast<VariableDeclaration>(declaration));
+        if (dynamic_cast<VariableDeclaration *>(declaration.get())) {
+            return std::make_unique<InitDecl>(
+                std::unique_ptr<VariableDeclaration>(
+                    static_cast<VariableDeclaration *>(declaration.release())));
         }
         else {
             throw std::invalid_argument(
                 "Function declarations aren't permitted in for-loop headers");
         }
-        return std::make_shared<InitDecl>(
-            std::static_pointer_cast<VariableDeclaration>(declaration));
     }
     else {
         if (matchToken(TokenType::Semicolon)) {
             consumeToken(TokenType::Semicolon);
-            return std::make_shared<InitExpr>();
+            return std::make_unique<InitExpr>();
         }
         else {
-            std::shared_ptr<Expression> expr = parseExpression(0);
+            std::unique_ptr<Expression> expr = parseExpression(0);
             expectToken(TokenType::Semicolon);
-            return std::make_shared<InitExpr>(std::move(expr));
+            return std::make_unique<InitExpr>(std::move(expr));
         }
     }
 }
 
-std::shared_ptr<Statement> Parser::parseStatement() {
+std::unique_ptr<Statement> Parser::parseStatement() {
     // Parse a return statement.
     if (matchToken(TokenType::returnKeyword)) {
         consumeToken(TokenType::returnKeyword);
         auto expr = parseExpression(0);
         expectToken(TokenType::Semicolon);
-        return std::make_shared<ReturnStatement>(std::move(expr));
+        return std::make_unique<ReturnStatement>(std::move(expr));
     }
     // Parse a null statement.
     else if (matchToken(TokenType::Semicolon)) {
         consumeToken(TokenType::Semicolon);
-        return std::make_shared<NullStatement>();
+        return std::make_unique<NullStatement>();
     }
     // Parse an if-statement.
     else if (matchToken(TokenType::ifKeyword)) {
@@ -297,29 +293,29 @@ std::shared_ptr<Statement> Parser::parseStatement() {
         if (matchToken(TokenType::elseKeyword)) {
             consumeToken(TokenType::elseKeyword);
             auto elseStatement = parseStatement();
-            return std::make_shared<IfStatement>(std::move(condition),
+            return std::make_unique<IfStatement>(std::move(condition),
                                                  std::move(thenStatement),
                                                  std::move(elseStatement));
         }
-        return std::make_shared<IfStatement>(std::move(condition),
+        return std::make_unique<IfStatement>(std::move(condition),
                                              std::move(thenStatement));
     }
     // Parse a compound statement.
     else if (matchToken(TokenType::OpenBrace)) {
         auto block = parseBlock();
-        return std::make_shared<CompoundStatement>(std::move(block));
+        return std::make_unique<CompoundStatement>(std::move(block));
     }
     // Parse a break statement.
     else if (matchToken(TokenType::breakKeyword)) {
         consumeToken(TokenType::breakKeyword);
         expectToken(TokenType::Semicolon);
-        return std::make_shared<BreakStatement>();
+        return std::make_unique<BreakStatement>();
     }
     // Parse a continue statement.
     else if (matchToken(TokenType::continueKeyword)) {
         consumeToken(TokenType::continueKeyword);
         expectToken(TokenType::Semicolon);
-        return std::make_shared<ContinueStatement>();
+        return std::make_unique<ContinueStatement>();
     }
     // Parse a while-statement.
     else if (matchToken(TokenType::whileKeyword)) {
@@ -328,7 +324,7 @@ std::shared_ptr<Statement> Parser::parseStatement() {
         auto condition = parseExpression(0);
         expectToken(TokenType::CloseParenthesis);
         auto body = parseStatement();
-        return std::make_shared<WhileStatement>(std::move(condition),
+        return std::make_unique<WhileStatement>(std::move(condition),
                                                 std::move(body));
     }
     // Parse a do-while-statement.
@@ -340,7 +336,7 @@ std::shared_ptr<Statement> Parser::parseStatement() {
         auto condition = parseExpression(0);
         expectToken(TokenType::CloseParenthesis);
         expectToken(TokenType::Semicolon);
-        return std::make_shared<DoWhileStatement>(std::move(condition),
+        return std::make_unique<DoWhileStatement>(std::move(condition),
                                                   std::move(body));
     }
     // Parse a for-statement.
@@ -348,8 +344,8 @@ std::shared_ptr<Statement> Parser::parseStatement() {
         consumeToken(TokenType::forKeyword);
         expectToken(TokenType::OpenParenthesis);
         auto init = parseForInit();
-        std::optional<std::shared_ptr<Expression>> optCondition;
-        std::optional<std::shared_ptr<Expression>> optPost;
+        std::optional<std::unique_ptr<Expression>> optCondition;
+        std::optional<std::unique_ptr<Expression>> optPost;
         if (matchToken(TokenType::Semicolon)) {
             consumeToken(TokenType::Semicolon);
         }
@@ -367,7 +363,7 @@ std::shared_ptr<Statement> Parser::parseStatement() {
             expectToken(TokenType::CloseParenthesis);
         }
         auto body = parseStatement();
-        return std::make_shared<ForStatement>(
+        return std::make_unique<ForStatement>(
             std::move(init), std::move(optCondition), std::move(optPost),
             std::move(body));
     }
@@ -375,7 +371,7 @@ std::shared_ptr<Statement> Parser::parseStatement() {
     else {
         auto expr = parseExpression(0);
         expectToken(TokenType::Semicolon);
-        return std::make_shared<ExpressionStatement>(std::move(expr));
+        return std::make_unique<ExpressionStatement>(std::move(expr));
     }
     std::stringstream msg;
     msg << "Malformed statement: unexpected token: " << tokens[current].value;
@@ -383,23 +379,22 @@ std::shared_ptr<Statement> Parser::parseStatement() {
     throw std::invalid_argument(msg.str());
 }
 
-std::shared_ptr<Expression> Parser::parseFactor() {
+std::unique_ptr<Expression> Parser::parseFactor() {
     if (matchToken(TokenType::IntConstant) ||
         matchToken(TokenType::LongConstant)) {
-        return std::make_shared<ConstantExpression>(parseConstant());
+        return std::make_unique<ConstantExpression>(parseConstant());
     }
     else if (matchToken(TokenType::Identifier)) {
         auto identifierToken = consumeToken(TokenType::Identifier);
         // Parse a function-call expression.
         if (matchToken(TokenType::OpenParenthesis)) {
             consumeToken(TokenType::OpenParenthesis);
-            auto arguments =
-                std::make_shared<std::vector<std::shared_ptr<Expression>>>();
+            std::vector<std::unique_ptr<Expression>> arguments;
             if (!matchToken(TokenType::CloseParenthesis)) {
                 // Parse additional arguments if they exist.
                 do {
                     auto argument = parseExpression(0);
-                    arguments->emplace_back(std::move(argument));
+                    arguments.emplace_back(std::move(argument));
                     if (matchToken(TokenType::Comma)) {
                         consumeToken(TokenType::Comma);
                     }
@@ -409,12 +404,12 @@ std::shared_ptr<Expression> Parser::parseFactor() {
                 } while (true);
             }
             expectToken(TokenType::CloseParenthesis);
-            return std::make_shared<FunctionCallExpression>(
+            return std::make_unique<FunctionCallExpression>(
                 identifierToken.value, std::move(arguments));
         }
         // Parse a variable expression.
         else {
-            return std::make_shared<VariableExpression>(identifierToken.value);
+            return std::make_unique<VariableExpression>(identifierToken.value);
         }
     }
     else if (matchToken(TokenType::OpenParenthesis) &&
@@ -436,25 +431,25 @@ std::shared_ptr<Expression> Parser::parseFactor() {
         consumeToken(TokenType::CloseParenthesis);
         auto targetType = parseType(specifierList);
         auto innerExpr = parseFactor();
-        return std::make_shared<CastExpression>(std::move(targetType),
+        return std::make_unique<CastExpression>(std::move(targetType),
                                                 std::move(innerExpr));
     }
     else if (matchToken(TokenType::Tilde)) {
         auto tildeToken = consumeToken(TokenType::Tilde);
         auto innerExpr = parseFactor();
-        return std::make_shared<UnaryExpression>(tildeToken.value,
+        return std::make_unique<UnaryExpression>(tildeToken.value,
                                                  std::move(innerExpr));
     }
     else if (matchToken(TokenType::Minus)) {
         auto minusToken = consumeToken(TokenType::Minus);
         auto innerExpr = parseFactor();
-        return std::make_shared<UnaryExpression>(minusToken.value,
+        return std::make_unique<UnaryExpression>(minusToken.value,
                                                  std::move(innerExpr));
     }
     else if (matchToken(TokenType::LogicalNot)) {
         auto notToken = consumeToken(TokenType::LogicalNot);
         auto innerExpr = parseFactor();
-        return std::make_shared<UnaryExpression>(notToken.value,
+        return std::make_unique<UnaryExpression>(notToken.value,
                                                  std::move(innerExpr));
     }
     else if (matchToken(TokenType::OpenParenthesis)) {
@@ -477,7 +472,7 @@ std::shared_ptr<Expression> Parser::parseFactor() {
     }
 }
 
-std::shared_ptr<Constant> Parser::parseConstant() {
+std::unique_ptr<Constant> Parser::parseConstant() {
     auto constantValue = std::stoll(tokens[current].value);
     // pow(2, 63) - 1 = 9223372036854775807LL.
     if (constantValue > 9223372036854775807LL) {
@@ -488,22 +483,22 @@ std::shared_ptr<Constant> Parser::parseConstant() {
         // pow(2, 31) - 1 = 2147483647LL.
         if (constantValue <= 2147483647LL) {
             consumeToken(TokenType::IntConstant);
-            return std::make_shared<ConstantInt>(constantValue);
+            return std::make_unique<ConstantInt>(constantValue);
         }
         else {
             consumeToken(TokenType::IntConstant);
-            return std::make_shared<ConstantLong>(constantValue);
+            return std::make_unique<ConstantLong>(constantValue);
         }
     }
     else {
         consumeToken(TokenType::LongConstant);
-        return std::make_shared<ConstantLong>(constantValue);
+        return std::make_unique<ConstantLong>(constantValue);
     }
 }
 
-std::shared_ptr<Expression> Parser::parseExpression(int minPrecedence) {
+std::unique_ptr<Expression> Parser::parseExpression(int minPrecedence) {
     // Parse the left operand of the expression.
-    std::shared_ptr<Expression> left = parseFactor();
+    std::unique_ptr<Expression> left = parseFactor();
     // While the next otkn is a binary operator and has a precedence greater
     // than or equal to the minimum precedence, ...
     while (
@@ -522,14 +517,14 @@ std::shared_ptr<Expression> Parser::parseExpression(int minPrecedence) {
         if (matchToken(TokenType::Assign)) {
             auto assignToken = consumeToken(TokenType::Assign);
             auto right = parseExpression(getPrecedence(assignToken));
-            left = std::make_shared<AssignmentExpression>(std::move(left),
+            left = std::make_unique<AssignmentExpression>(std::move(left),
                                                           std::move(right));
         }
         else if (matchToken(TokenType::QuestionMark)) {
             auto questionMarkToken = consumeToken(TokenType::QuestionMark);
             auto middle = parseConditionalMiddle();
             auto right = parseExpression(getPrecedence(questionMarkToken));
-            left = std::make_shared<ConditionalExpression>(
+            left = std::make_unique<ConditionalExpression>(
                 std::move(left), std::move(middle), std::move(right));
         }
         // Otherwise, the next token is (should be) a binary operator.
@@ -548,16 +543,16 @@ std::shared_ptr<Expression> Parser::parseExpression(int minPrecedence) {
                     << " is not followed by a valid operand.";
                 throw std::invalid_argument(msg.str());
             }
-            std::shared_ptr<Expression> right =
+            std::unique_ptr<Expression> right =
                 parseExpression(getPrecedence(binOpToken) + 1);
-            left = std::make_shared<BinaryExpression>(
+            left = std::make_unique<BinaryExpression>(
                 std::move(left), binOpToken.value, std::move(right));
         }
     }
     return left;
 }
 
-std::shared_ptr<Expression> Parser::parseConditionalMiddle() {
+std::unique_ptr<Expression> Parser::parseConditionalMiddle() {
     // Note: The question mark token has already been consumed in the caller
     // (some `parseExpression` function call). Parse the middle expression.
     auto middle = parseExpression(0);
@@ -566,7 +561,7 @@ std::shared_ptr<Expression> Parser::parseConditionalMiddle() {
     return middle;
 }
 
-std::pair<std::shared_ptr<Type>, std::shared_ptr<StorageClass>>
+std::pair<std::unique_ptr<Type>, std::unique_ptr<StorageClass>>
 Parser::parseTypeAndStorageClass(
     const std::vector<std::string> &specifierList) {
     std::vector<std::string> types;
@@ -580,7 +575,7 @@ Parser::parseTypeAndStorageClass(
         }
     }
     auto type = parseType(types);
-    std::shared_ptr<StorageClass> storageClass;
+    std::unique_ptr<StorageClass> storageClass;
     if (storageClasses.size() > 1) {
         throw std::invalid_argument("Invalid storage class (specifier)");
     }
@@ -590,21 +585,21 @@ Parser::parseTypeAndStorageClass(
     else {
         storageClass = nullptr;
     }
-    return std::make_pair(type, storageClass);
+    return std::make_pair(std::move(type), std::move(storageClass));
 }
 
-std::shared_ptr<Type>
+std::unique_ptr<Type>
 Parser::parseType(const std::vector<std::string> &specifierList) {
     if (specifierList.size() == 1 && specifierList[0] == "int") {
-        return std::make_shared<IntType>();
+        return std::make_unique<IntType>();
     }
     else if ((specifierList.size() == 2) &&
              ((specifierList[0] == "int" && specifierList[1] == "long") ||
               (specifierList[0] == "long" && specifierList[1] == "int"))) {
-        return std::make_shared<LongType>();
+        return std::make_unique<LongType>();
     }
     else if (specifierList.size() == 1 && specifierList[0] == "long") {
-        return std::make_shared<LongType>();
+        return std::make_unique<LongType>();
     }
     else {
         std::stringstream msg;
@@ -617,22 +612,22 @@ Parser::parseType(const std::vector<std::string> &specifierList) {
     }
 }
 
-std::shared_ptr<StorageClass>
+std::unique_ptr<StorageClass>
 Parser::parseStorageClass(const std::string &specifier) {
     if (specifier == "static") {
-        return std::make_shared<StaticStorageClass>();
+        return std::make_unique<StaticStorageClass>();
     }
     else if (specifier == "extern") {
-        return std::make_shared<ExternStorageClass>();
+        return std::make_unique<ExternStorageClass>();
     }
     else {
         throw std::invalid_argument("Invalid storage class (specifier)");
     }
 }
 
-int Parser::getPrecedence(const Token &token) {
+int Parser::getPrecedence(const Token &token) const {
     if (precedenceMap.find(token.type) != precedenceMap.end()) {
-        return precedenceMap[token.type];
+        return precedenceMap.at(token.type);
     }
     return -1;
 }

--- a/src/frontend/parser.h
+++ b/src/frontend/parser.h
@@ -9,13 +9,14 @@
 #include "program.h"
 #include "statement.h"
 #include "type.h"
+#include <memory>
 #include <unordered_map>
 
 namespace AST {
 class Parser {
   public:
-    Parser(const std::vector<Token> &tokens);
-    std::shared_ptr<Program> parse();
+    explicit Parser(const std::vector<Token> &tokens);
+    std::unique_ptr<Program> parse();
 
   private:
     const std::vector<Token> &tokens;
@@ -36,24 +37,23 @@ class Parser {
     bool matchToken(TokenType type);
     Token consumeToken(TokenType type);
     void expectToken(TokenType type);
-    std::shared_ptr<Declaration> parseDeclaration();
-    void parseTypeSpecifiersInParameters(
-        const std::shared_ptr<std::vector<std::string>> &parameters);
-    std::shared_ptr<BlockItem> parseBlockItem();
-    std::shared_ptr<Block> parseBlock();
-    std::shared_ptr<ForInit> parseForInit();
-    std::shared_ptr<Statement> parseStatement();
-    std::shared_ptr<Expression> parseFactor();
-    std::shared_ptr<Constant> parseConstant();
-    std::shared_ptr<Expression> parseExpression(int minPrecedence = 0);
-    std::shared_ptr<Expression> parseConditionalMiddle();
-    std::pair<std::shared_ptr<Type>, std::shared_ptr<StorageClass>>
+    std::unique_ptr<Declaration> parseDeclaration();
+    void parseTypeSpecifiersInParameters(std::vector<std::string> &parameters);
+    std::unique_ptr<BlockItem> parseBlockItem();
+    Block *parseBlock();
+    std::unique_ptr<ForInit> parseForInit();
+    std::unique_ptr<Statement> parseStatement();
+    std::unique_ptr<Expression> parseFactor();
+    std::unique_ptr<Constant> parseConstant();
+    std::unique_ptr<Expression> parseExpression(int minPrecedence = 0);
+    std::unique_ptr<Expression> parseConditionalMiddle();
+    std::pair<std::unique_ptr<Type>, std::unique_ptr<StorageClass>>
     parseTypeAndStorageClass(const std::vector<std::string> &specifierList);
-    std::shared_ptr<Type>
+    std::unique_ptr<Type>
     parseType(const std::vector<std::string> &specifierList);
-    std::shared_ptr<StorageClass>
+    std::unique_ptr<StorageClass>
     parseStorageClass(const std::string &specifier);
-    int getPrecedence(const Token &token);
+    int getPrecedence(const Token &token) const;
 };
 } // Namespace AST
 

--- a/src/frontend/printVisitor.cpp
+++ b/src/frontend/printVisitor.cpp
@@ -1,7 +1,3 @@
-/*
- * This file defines the implementation of the pretty printer for the AST and
- * concretizes the abstract visitor interface.
- */
 #include "printVisitor.h"
 #include "expression.h"
 #include "function.h"
@@ -12,8 +8,8 @@ namespace AST {
 void PrintVisitor::visit(Program &program) {
     std::cout << "Program(\n";
 
-    if (program.getDeclarations()) {
-        auto &declarations = *program.getDeclarations();
+    const auto &declarations = program.getDeclarations();
+    if (declarations.size() > 0) {
         for (auto it = declarations.begin(); it != declarations.end(); it++) {
             auto &functionDeclaration = *it;
             functionDeclaration->accept(*this);
@@ -49,8 +45,8 @@ void PrintVisitor::visit(Function &function) {
 
     auto functionBody = function.getBody();
     if (functionBody) {
-        auto blockItems = functionBody->getBlockItems();
-        for (auto &blockItem : *blockItems) {
+        const auto &blockItems = functionBody->getBlockItems();
+        for (auto &blockItem : blockItems) {
             blockItem->accept(*this);
         }
     }
@@ -64,7 +60,8 @@ void PrintVisitor::visit(Function &function) {
 void PrintVisitor::visit(Block &block) {
     std::cout << "Block(";
 
-    for (auto &blockItem : *block.getBlockItems()) {
+    const auto &blockItems = block.getBlockItems();
+    for (auto &blockItem : blockItems) {
         blockItem->accept(*this);
     }
 
@@ -144,7 +141,7 @@ void PrintVisitor::visit(FunctionDeclaration &functionDeclaration) {
 
     std::cout << "\nparameters = (";
 
-    auto &parameters = *functionDeclaration.getParameterIdentifiers();
+    auto parameters = functionDeclaration.getParameterIdentifiers();
     for (auto it = parameters.begin(); it != parameters.end(); it++) {
         auto &parameter = *it;
         std::cout << parameter;
@@ -191,7 +188,7 @@ void PrintVisitor::visit(FunctionType &functionType) {
 
     std::cout << "parameters = (";
 
-    auto &parameters = *functionType.getParameterTypes();
+    const auto &parameters = functionType.getParameterTypes();
     for (auto it = parameters.begin(); it != parameters.end(); it++) {
         auto &parameter = *it;
         parameter->accept(*this);
@@ -203,7 +200,8 @@ void PrintVisitor::visit(FunctionType &functionType) {
     std::cout << ")";
 
     std::cout << "\nreturnType = ";
-    functionType.getReturnType()->accept(*this);
+    const auto &returnType = functionType.getReturnType();
+    returnType->accept(*this);
 
     std::cout << "\n)";
 }
@@ -300,7 +298,8 @@ void PrintVisitor::visit(CompoundStatement &compoundStatement) {
     std::cout << "CompoundStatement(\n";
 
     if (compoundStatement.getBlock()) {
-        compoundStatement.getBlock()->accept(*this);
+        auto block = compoundStatement.getBlock();
+        const_cast<Block *>(block)->accept(*this);
     }
     else {
         throw std::logic_error("Null block in compound statement");
@@ -413,12 +412,13 @@ void PrintVisitor::visit(NullStatement &nullStatement) {
 void PrintVisitor::visit(ConstantExpression &constantExpression) {
     std::cout << "ConstantExpression(";
 
-    auto constant = constantExpression.getConstant();
-    if (auto intConst = std::dynamic_pointer_cast<ConstantInt>(constant)) {
+    const auto &constant = constantExpression.getConstant();
+    if (const auto *intConst =
+            dynamic_cast<const ConstantInt *>(constant.get())) {
         std::cout << intConst->getValue();
     }
-    else if (auto longConst =
-                 std::dynamic_pointer_cast<ConstantLong>(constant)) {
+    else if (const auto *longConst =
+                 dynamic_cast<const ConstantLong *>(constant.get())) {
         std::cout << longConst->getValue();
     }
     else {
@@ -589,7 +589,7 @@ void PrintVisitor::visit(FunctionCallExpression &functionCallExpression) {
 
     std::cout << "\nargs = ";
 
-    auto &args = *functionCallExpression.getArguments();
+    const auto &args = functionCallExpression.getArguments();
     for (auto it = args.begin(); it != args.end(); it++) {
         auto &arg = *it;
         arg->accept(*this);

--- a/src/frontend/program.cpp
+++ b/src/frontend/program.cpp
@@ -2,20 +2,17 @@
 #include "visitor.h"
 
 namespace AST {
-Program::Program(
-    std::shared_ptr<std::vector<std::shared_ptr<Declaration>>> declarations)
-    : declarations(declarations) {}
+Program::Program(std::vector<std::unique_ptr<Declaration>> declarations)
+    : declarations(std::move(declarations)) {}
 
 void Program::accept(Visitor &visitor) { visitor.visit(*this); }
 
-const std::shared_ptr<std::vector<std::shared_ptr<Declaration>>> &
-Program::getDeclarations() const {
+std::vector<std::unique_ptr<Declaration>> &Program::getDeclarations() {
     return declarations;
 }
 
 void Program::setDeclarations(
-    std::shared_ptr<std::vector<std::shared_ptr<Declaration>>>
-        newDeclarations) {
-    this->declarations = newDeclarations;
+    std::vector<std::unique_ptr<Declaration>> newDeclarations) {
+    this->declarations = std::move(newDeclarations);
 }
 } // Namespace AST

--- a/src/frontend/program.h
+++ b/src/frontend/program.h
@@ -8,18 +8,14 @@
 namespace AST {
 class Program : public AST {
   public:
-    explicit Program(std::shared_ptr<std::vector<std::shared_ptr<Declaration>>>
-                         declarations);
+    explicit Program(std::vector<std::unique_ptr<Declaration>> declarations);
     void accept(Visitor &visitor) override;
-    [[nodiscard]] const std::shared_ptr<
-        std::vector<std::shared_ptr<Declaration>>> &
-    getDeclarations() const;
+    [[nodiscard]] std::vector<std::unique_ptr<Declaration>> &getDeclarations();
     void
-    setDeclarations(std::shared_ptr<std::vector<std::shared_ptr<Declaration>>>
-                        declarations);
+    setDeclarations(std::vector<std::unique_ptr<Declaration>> newDeclarations);
 
   private:
-    std::shared_ptr<std::vector<std::shared_ptr<Declaration>>> declarations;
+    std::vector<std::unique_ptr<Declaration>> declarations;
 };
 } // Namespace AST
 

--- a/src/frontend/semanticAnalysisPasses.cpp
+++ b/src/frontend/semanticAnalysisPasses.cpp
@@ -7,7 +7,8 @@ namespace AST {
 /*
  * Start: Functions for the identifier-resolution pass.
  */
-int IdentifierResolutionPass::resolveProgram(std::unique_ptr<Program> program) {
+std::pair<std::unique_ptr<Program>, int>
+IdentifierResolutionPass::resolveProgram(std::unique_ptr<Program> program) {
     // Initialize an empty identifier map (that will be passed to the helpers).
     // Instead of maintaining a "global" identifier map, we pass the identifier
     // map to the helper functions to, together with `copyIdentifierMap`, ensure
@@ -43,7 +44,7 @@ int IdentifierResolutionPass::resolveProgram(std::unique_ptr<Program> program) {
     }
     program->setDeclarations(std::move(resolvedDeclarations));
 
-    return this->variableResolutionCounter;
+    return std::make_pair(std::move(program), this->variableResolutionCounter);
 }
 
 std::unordered_map<std::string, MapEntry>

--- a/src/frontend/semanticAnalysisPasses.cpp
+++ b/src/frontend/semanticAnalysisPasses.cpp
@@ -725,6 +725,8 @@ TypeCheckingPass::typeCheckFunctionDeclaration(
     frontendSymbolTable[declaration->getIdentifier()] = {std::move(funType),
                                                          std::move(attribute)};
 
+    // If the function has a body, we need to set the parameter types in the
+    // symbol table.
     if (hasBody) {
         const auto &funcParameterTypes = funTypePtr->getParameterTypes();
         auto parameterIdentifiers =
@@ -734,7 +736,7 @@ TypeCheckingPass::typeCheckFunctionDeclaration(
         for (size_t i = 0; i < parameterIdentifiers.size(); ++i) {
             // If the parameter type is available, use it.
             if (i < funcParameterTypes.size()) {
-                // Create a copy of the parameter type
+                // Create a "copy" that resonates the parameter type.
                 std::unique_ptr<Type> paramTypeCopy;
                 if (dynamic_cast<IntType *>(funcParameterTypes[i].get())) {
                     paramTypeCopy = std::make_unique<IntType>();
@@ -744,14 +746,17 @@ TypeCheckingPass::typeCheckFunctionDeclaration(
                     paramTypeCopy = std::make_unique<LongType>();
                 }
                 else {
-                    paramTypeCopy = std::make_unique<IntType>(); // Fallback.
+                    // Fallback to `IntType`.
+                    paramTypeCopy = std::make_unique<IntType>();
                 }
                 frontendSymbolTable[parameterIdentifiers[i]] = {
                     std::move(paramTypeCopy),
                     std::make_unique<LocalAttribute>()};
             }
+            // Otherwise, fallback to `IntType`.
+            // TODO(zzmic): Check if this should be retained or be replaced by
+            // an exception being thrown.
             else {
-                // Otherwise, fallback to IntType.
                 frontendSymbolTable[parameterIdentifiers[i]] = {
                     std::make_unique<IntType>(),
                     std::make_unique<LocalAttribute>()};

--- a/src/frontend/semanticAnalysisPasses.h
+++ b/src/frontend/semanticAnalysisPasses.h
@@ -35,7 +35,8 @@ class MapEntry {
 
 class IdentifierResolutionPass : public SemanticAnalysisPass {
   public:
-    [[nodiscard]] int resolveProgram(std::unique_ptr<Program> program);
+    [[nodiscard]] std::pair<std::unique_ptr<Program>, int>
+    resolveProgram(std::unique_ptr<Program> program);
 
   private:
     int variableResolutionCounter = 0;

--- a/src/frontend/statement.cpp
+++ b/src/frontend/statement.cpp
@@ -67,6 +67,11 @@ void IfStatement::setElseOptStatement(
 
 CompoundStatement::CompoundStatement(Block *block) : block(block) {}
 
+CompoundStatement::~CompoundStatement() {
+    // Clean up the raw pointer.
+    delete block;
+}
+
 void CompoundStatement::accept(Visitor &visitor) { visitor.visit(*this); }
 
 Block *CompoundStatement::getBlock() { return block; }

--- a/src/frontend/statement.cpp
+++ b/src/frontend/statement.cpp
@@ -3,138 +3,187 @@
 #include "visitor.h"
 
 namespace AST {
-ReturnStatement::ReturnStatement(std::shared_ptr<Expression> expr)
-    : expr(expr) {}
+ReturnStatement::ReturnStatement(std::unique_ptr<Expression> expr)
+    : expr(std::move(expr)) {}
 
 void ReturnStatement::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<Expression> ReturnStatement::getExpression() const {
-    return expr;
+std::unique_ptr<Expression> &ReturnStatement::getExpression() { return expr; }
+
+void ReturnStatement::setExpression(std::unique_ptr<Expression> newExpr) {
+    this->expr = std::move(newExpr);
 }
 
-void ReturnStatement::setExpression(std::shared_ptr<Expression> newExpr) {
-    this->expr = newExpr;
-}
-
-ExpressionStatement::ExpressionStatement(std::shared_ptr<Expression> expr)
-    : expr(expr) {}
+ExpressionStatement::ExpressionStatement(std::unique_ptr<Expression> expr)
+    : expr(std::move(expr)) {}
 
 void ExpressionStatement::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<Expression> ExpressionStatement::getExpression() const {
+std::unique_ptr<Expression> &ExpressionStatement::getExpression() {
     return expr;
 }
 
-IfStatement::IfStatement(
-    std::shared_ptr<Expression> condition,
-    std::shared_ptr<Statement> thenStatement,
-    std::optional<std::shared_ptr<Statement>> elseOptStatement)
-    : condition(condition), thenStatement(thenStatement),
-      elseOptStatement(elseOptStatement) {}
+void ExpressionStatement::setExpression(std::unique_ptr<Expression> newExpr) {
+    this->expr = std::move(newExpr);
+}
 
-IfStatement::IfStatement(std::shared_ptr<Expression> condition,
-                         std::shared_ptr<Statement> thenStatement)
-    : condition(condition), thenStatement(thenStatement) {}
+IfStatement::IfStatement(
+    std::unique_ptr<Expression> condition,
+    std::unique_ptr<Statement> thenStatement,
+    std::optional<std::unique_ptr<Statement>> elseOptStatement)
+    : condition(std::move(condition)), thenStatement(std::move(thenStatement)),
+      elseOptStatement(std::move(elseOptStatement)) {}
+
+IfStatement::IfStatement(std::unique_ptr<Expression> condition,
+                         std::unique_ptr<Statement> thenStatement)
+    : condition(std::move(condition)), thenStatement(std::move(thenStatement)) {
+}
 
 void IfStatement::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<Expression> IfStatement::getCondition() const {
-    return condition;
-}
+std::unique_ptr<Expression> &IfStatement::getCondition() { return condition; }
 
-std::shared_ptr<Statement> IfStatement::getThenStatement() const {
+std::unique_ptr<Statement> &IfStatement::getThenStatement() {
     return thenStatement;
 }
 
-std::optional<std::shared_ptr<Statement>>
-IfStatement::getElseOptStatement() const {
+std::optional<std::unique_ptr<Statement>> &IfStatement::getElseOptStatement() {
     return elseOptStatement;
 }
 
-CompoundStatement::CompoundStatement(std::shared_ptr<Block> block)
-    : block(block) {}
+void IfStatement::setCondition(std::unique_ptr<Expression> newCondition) {
+    this->condition = std::move(newCondition);
+}
+
+void IfStatement::setThenStatement(
+    std::unique_ptr<Statement> newThenStatement) {
+    this->thenStatement = std::move(newThenStatement);
+}
+
+void IfStatement::setElseOptStatement(
+    std::optional<std::unique_ptr<Statement>> newElseOptStatement) {
+    this->elseOptStatement = std::move(newElseOptStatement);
+}
+
+CompoundStatement::CompoundStatement(Block *block) : block(block) {}
 
 void CompoundStatement::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<Block> CompoundStatement::getBlock() const { return block; }
+Block *CompoundStatement::getBlock() { return block; }
+
+void CompoundStatement::setBlock(Block *newBlock) { this->block = newBlock; }
 
 void BreakStatement::accept(Visitor &visitor) { visitor.visit(*this); }
 
-const std::string &BreakStatement::getLabel() const { return label; }
+std::string &BreakStatement::getLabel() { return label; }
 
 void BreakStatement::setLabel(std::string_view newLabel) {
-    this->label = newLabel;
+    this->label = std::string(newLabel);
 }
 
 void ContinueStatement::accept(Visitor &visitor) { visitor.visit(*this); }
 
-const std::string &ContinueStatement::getLabel() const { return label; }
+std::string &ContinueStatement::getLabel() { return label; }
 
 void ContinueStatement::setLabel(std::string_view newLabel) {
-    this->label = newLabel;
+    this->label = std::string(newLabel);
 }
 
-WhileStatement::WhileStatement(std::shared_ptr<Expression> condition,
-                               std::shared_ptr<Statement> body)
-    : condition(condition), body(body) {}
+WhileStatement::WhileStatement(std::unique_ptr<Expression> condition,
+                               std::unique_ptr<Statement> body)
+    : condition(std::move(condition)), body(std::move(body)) {}
 
 void WhileStatement::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<Expression> WhileStatement::getCondition() const {
+std::unique_ptr<Expression> &WhileStatement::getCondition() {
     return condition;
 }
 
-std::shared_ptr<Statement> WhileStatement::getBody() const { return body; }
+std::unique_ptr<Statement> &WhileStatement::getBody() { return body; }
 
-const std::string &WhileStatement::getLabel() const { return label; }
+std::string &WhileStatement::getLabel() { return label; }
 
-void WhileStatement::setLabel(std::string_view newLabel) {
-    this->label = newLabel;
+void WhileStatement::setCondition(std::unique_ptr<Expression> newCondition) {
+    this->condition = std::move(newCondition);
 }
 
-DoWhileStatement::DoWhileStatement(std::shared_ptr<Expression> condition,
-                                   std::shared_ptr<Statement> body)
-    : condition(condition), body(body) {}
+void WhileStatement::setBody(std::unique_ptr<Statement> newBody) {
+    this->body = std::move(newBody);
+}
+
+void WhileStatement::setLabel(std::string_view newLabel) {
+    this->label = std::string(newLabel);
+}
+
+DoWhileStatement::DoWhileStatement(std::unique_ptr<Expression> condition,
+                                   std::unique_ptr<Statement> body)
+    : condition(std::move(condition)), body(std::move(body)) {}
 
 void DoWhileStatement::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<Expression> DoWhileStatement::getCondition() const {
+std::unique_ptr<Expression> &DoWhileStatement::getCondition() {
     return condition;
 }
 
-std::shared_ptr<Statement> DoWhileStatement::getBody() const { return body; }
+std::unique_ptr<Statement> &DoWhileStatement::getBody() { return body; }
 
-const std::string &DoWhileStatement::getLabel() const { return label; }
+std::string &DoWhileStatement::getLabel() { return label; }
 
-void DoWhileStatement::setLabel(std::string_view newLabel) {
-    this->label = newLabel;
+void DoWhileStatement::setCondition(std::unique_ptr<Expression> newCondition) {
+    this->condition = std::move(newCondition);
 }
 
-ForStatement::ForStatement(std::shared_ptr<ForInit> forInit,
-                           std::optional<std::shared_ptr<Expression>> condition,
-                           std::optional<std::shared_ptr<Expression>> post,
-                           std::shared_ptr<Statement> body)
-    : forInit(forInit), optCondition(condition), optPost(post), body(body) {}
+void DoWhileStatement::setBody(std::unique_ptr<Statement> newBody) {
+    this->body = std::move(newBody);
+}
+
+void DoWhileStatement::setLabel(std::string_view newLabel) {
+    this->label = std::string(newLabel);
+}
+
+ForStatement::ForStatement(std::unique_ptr<ForInit> forInit,
+                           std::optional<std::unique_ptr<Expression>> condition,
+                           std::optional<std::unique_ptr<Expression>> post,
+                           std::unique_ptr<Statement> body)
+    : forInit(std::move(forInit)), optCondition(std::move(condition)),
+      optPost(std::move(post)), body(std::move(body)) {}
 
 void ForStatement::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<ForInit> ForStatement::getForInit() const { return forInit; }
+std::unique_ptr<ForInit> &ForStatement::getForInit() { return forInit; }
 
-std::optional<std::shared_ptr<Expression>>
-ForStatement::getOptCondition() const {
+std::optional<std::unique_ptr<Expression>> &ForStatement::getOptCondition() {
     return optCondition;
 }
 
-std::optional<std::shared_ptr<Expression>> ForStatement::getOptPost() const {
+std::optional<std::unique_ptr<Expression>> &ForStatement::getOptPost() {
     return optPost;
 }
 
-std::shared_ptr<Statement> ForStatement::getBody() const { return body; }
+std::unique_ptr<Statement> &ForStatement::getBody() { return body; }
 
-const std::string &ForStatement::getLabel() const { return label; }
+std::string &ForStatement::getLabel() { return label; }
+
+void ForStatement::setForInit(std::unique_ptr<ForInit> newForInit) {
+    this->forInit = std::move(newForInit);
+}
+
+void ForStatement::setOptCondition(
+    std::optional<std::unique_ptr<Expression>> newOptCondition) {
+    this->optCondition = std::move(newOptCondition);
+}
+
+void ForStatement::setOptPost(
+    std::optional<std::unique_ptr<Expression>> newOptPost) {
+    this->optPost = std::move(newOptPost);
+}
+
+void ForStatement::setBody(std::unique_ptr<Statement> newBody) {
+    this->body = std::move(newBody);
+}
 
 void ForStatement::setLabel(std::string_view newLabel) {
-    this->label = newLabel;
+    this->label = std::string(newLabel);
 }
 
 void NullStatement::accept(Visitor &visitor) { visitor.visit(*this); }

--- a/src/frontend/statement.h
+++ b/src/frontend/statement.h
@@ -68,7 +68,7 @@ class Block; // Forward declaration.
 class CompoundStatement : public Statement {
   public:
     explicit CompoundStatement(Block *block);
-    ~CompoundStatement() = default; // Need destructor to clean up raw pointer.
+    ~CompoundStatement();
     void accept(Visitor &visitor) override;
     [[nodiscard]] Block *getBlock();
     void setBlock(Block *block);

--- a/src/frontend/statement.h
+++ b/src/frontend/statement.h
@@ -19,60 +19,69 @@ class Statement : public AST {
 
 class ReturnStatement : public Statement {
   public:
-    explicit ReturnStatement(std::shared_ptr<Expression> expr);
+    explicit ReturnStatement(std::unique_ptr<Expression> expr);
     void accept(Visitor &visitor) override;
-    [[nodiscard]] std::shared_ptr<Expression> getExpression() const;
-    void setExpression(std::shared_ptr<Expression> expr);
+    [[nodiscard]] std::unique_ptr<Expression> &getExpression();
+    void setExpression(std::unique_ptr<Expression> expr);
 
   private:
-    std::shared_ptr<Expression> expr;
+    std::unique_ptr<Expression> expr;
 };
 
 class ExpressionStatement : public Statement {
   public:
-    explicit ExpressionStatement(std::shared_ptr<Expression> expr);
+    explicit ExpressionStatement(std::unique_ptr<Expression> expr);
     void accept(Visitor &visitor) override;
-    [[nodiscard]] std::shared_ptr<Expression> getExpression() const;
+    [[nodiscard]] std::unique_ptr<Expression> &getExpression();
+    void setExpression(std::unique_ptr<Expression> expr);
 
   private:
-    std::shared_ptr<Expression> expr;
+    std::unique_ptr<Expression> expr;
 };
 
 class IfStatement : public Statement {
   public:
     explicit IfStatement(
-        std::shared_ptr<Expression> condition,
-        std::shared_ptr<Statement> thenStatement,
-        std::optional<std::shared_ptr<Statement>> elseOptStatement);
-    explicit IfStatement(std::shared_ptr<Expression> condition,
-                         std::shared_ptr<Statement> thenStatement);
+        std::unique_ptr<Expression> condition,
+        std::unique_ptr<Statement> thenStatement,
+        std::optional<std::unique_ptr<Statement>> elseOptStatement);
+    explicit IfStatement(std::unique_ptr<Expression> condition,
+                         std::unique_ptr<Statement> thenStatement);
     void accept(Visitor &visitor) override;
-    [[nodiscard]] std::shared_ptr<Expression> getCondition() const;
-    [[nodiscard]] std::shared_ptr<Statement> getThenStatement() const;
-    [[nodiscard]] std::optional<std::shared_ptr<Statement>>
-    getElseOptStatement() const;
+    [[nodiscard]] std::unique_ptr<Expression> &getCondition();
+    [[nodiscard]] std::unique_ptr<Statement> &getThenStatement();
+    [[nodiscard]] std::optional<std::unique_ptr<Statement>> &
+    getElseOptStatement();
+    void setCondition(std::unique_ptr<Expression> condition);
+    void setThenStatement(std::unique_ptr<Statement> thenStatement);
+    void setElseOptStatement(
+        std::optional<std::unique_ptr<Statement>> elseOptStatement);
 
   private:
-    std::shared_ptr<Expression> condition;
-    std::shared_ptr<Statement> thenStatement;
-    std::optional<std::shared_ptr<Statement>> elseOptStatement;
+    std::unique_ptr<Expression> condition;
+    std::unique_ptr<Statement> thenStatement;
+    std::optional<std::unique_ptr<Statement>> elseOptStatement;
 };
+
+class Block; // Forward declaration.
 
 class CompoundStatement : public Statement {
   public:
-    explicit CompoundStatement(std::shared_ptr<Block> block);
+    explicit CompoundStatement(Block *block);
+    ~CompoundStatement() = default; // Need destructor to clean up raw pointer.
     void accept(Visitor &visitor) override;
-    [[nodiscard]] std::shared_ptr<Block> getBlock() const;
+    [[nodiscard]] Block *getBlock();
+    void setBlock(Block *block);
 
   private:
-    std::shared_ptr<Block> block;
+    Block *block;
 };
 
 class BreakStatement : public Statement {
   public:
     BreakStatement() : label("") {}
     void accept(Visitor &visitor) override;
-    [[nodiscard]] const std::string &getLabel() const;
+    [[nodiscard]] std::string &getLabel();
     void setLabel(std::string_view label);
 
   private:
@@ -83,7 +92,7 @@ class ContinueStatement : public Statement {
   public:
     ContinueStatement() : label("") {}
     void accept(Visitor &visitor) override;
-    [[nodiscard]] const std::string &getLabel() const;
+    [[nodiscard]] std::string &getLabel();
     void setLabel(std::string_view label);
 
   private:
@@ -92,56 +101,64 @@ class ContinueStatement : public Statement {
 
 class WhileStatement : public Statement {
   public:
-    explicit WhileStatement(std::shared_ptr<Expression> condition,
-                            std::shared_ptr<Statement> body);
+    explicit WhileStatement(std::unique_ptr<Expression> condition,
+                            std::unique_ptr<Statement> body);
     void accept(Visitor &visitor) override;
-    [[nodiscard]] std::shared_ptr<Expression> getCondition() const;
-    [[nodiscard]] std::shared_ptr<Statement> getBody() const;
-    [[nodiscard]] const std::string &getLabel() const;
+    [[nodiscard]] std::unique_ptr<Expression> &getCondition();
+    [[nodiscard]] std::unique_ptr<Statement> &getBody();
+    [[nodiscard]] std::string &getLabel();
+    void setCondition(std::unique_ptr<Expression> condition);
+    void setBody(std::unique_ptr<Statement> body);
     void setLabel(std::string_view label);
 
   private:
-    std::shared_ptr<Expression> condition;
-    std::shared_ptr<Statement> body;
+    std::unique_ptr<Expression> condition;
+    std::unique_ptr<Statement> body;
     std::string label;
 };
 
 class DoWhileStatement : public Statement {
   public:
-    explicit DoWhileStatement(std::shared_ptr<Expression> condition,
-                              std::shared_ptr<Statement> body);
+    explicit DoWhileStatement(std::unique_ptr<Expression> condition,
+                              std::unique_ptr<Statement> body);
     void accept(Visitor &visitor) override;
-    [[nodiscard]] std::shared_ptr<Expression> getCondition() const;
-    [[nodiscard]] std::shared_ptr<Statement> getBody() const;
-    [[nodiscard]] const std::string &getLabel() const;
+    [[nodiscard]] std::unique_ptr<Expression> &getCondition();
+    [[nodiscard]] std::unique_ptr<Statement> &getBody();
+    [[nodiscard]] std::string &getLabel();
+    void setCondition(std::unique_ptr<Expression> condition);
+    void setBody(std::unique_ptr<Statement> body);
     void setLabel(std::string_view label);
 
   private:
-    std::shared_ptr<Expression> condition;
-    std::shared_ptr<Statement> body;
+    std::unique_ptr<Expression> condition;
+    std::unique_ptr<Statement> body;
     std::string label;
 };
 
 class ForStatement : public Statement {
   public:
-    explicit ForStatement(std::shared_ptr<ForInit> forInit,
-                          std::optional<std::shared_ptr<Expression>> condition,
-                          std::optional<std::shared_ptr<Expression>> post,
-                          std::shared_ptr<Statement> body);
+    explicit ForStatement(std::unique_ptr<ForInit> forInit,
+                          std::optional<std::unique_ptr<Expression>> condition,
+                          std::optional<std::unique_ptr<Expression>> post,
+                          std::unique_ptr<Statement> body);
     void accept(Visitor &visitor) override;
-    [[nodiscard]] std::shared_ptr<ForInit> getForInit() const;
-    [[nodiscard]] std::optional<std::shared_ptr<Expression>>
-    getOptCondition() const;
-    [[nodiscard]] std::optional<std::shared_ptr<Expression>> getOptPost() const;
-    [[nodiscard]] std::shared_ptr<Statement> getBody() const;
-    [[nodiscard]] const std::string &getLabel() const;
+    [[nodiscard]] std::unique_ptr<ForInit> &getForInit();
+    [[nodiscard]] std::optional<std::unique_ptr<Expression>> &getOptCondition();
+    [[nodiscard]] std::optional<std::unique_ptr<Expression>> &getOptPost();
+    [[nodiscard]] std::unique_ptr<Statement> &getBody();
+    [[nodiscard]] std::string &getLabel();
+    void setForInit(std::unique_ptr<ForInit> forInit);
+    void
+    setOptCondition(std::optional<std::unique_ptr<Expression>> optCondition);
+    void setOptPost(std::optional<std::unique_ptr<Expression>> optPost);
+    void setBody(std::unique_ptr<Statement> body);
     void setLabel(std::string_view label);
 
   private:
-    std::shared_ptr<ForInit> forInit;
-    std::optional<std::shared_ptr<Expression>> optCondition;
-    std::optional<std::shared_ptr<Expression>> optPost;
-    std::shared_ptr<Statement> body;
+    std::unique_ptr<ForInit> forInit;
+    std::optional<std::unique_ptr<Expression>> optCondition;
+    std::optional<std::unique_ptr<Expression>> optPost;
+    std::unique_ptr<Statement> body;
     std::string label;
 };
 

--- a/src/frontend/type.cpp
+++ b/src/frontend/type.cpp
@@ -1,0 +1,51 @@
+#include "type.h"
+
+namespace AST {
+bool Type::isEqual(const Type &other) const {
+    return typeid(*this) == typeid(other);
+}
+
+bool operator==(const Type &lhs, const Type &rhs) { return lhs.isEqual(rhs); }
+
+bool operator!=(const Type &lhs, const Type &rhs) { return !lhs.isEqual(rhs); }
+
+void IntType::accept(Visitor &visitor) { visitor.visit(*this); }
+
+bool IntType::isEqual(const Type &other) const {
+    return dynamic_cast<const IntType *>(&other) != nullptr;
+}
+
+void LongType::accept(Visitor &visitor) { visitor.visit(*this); }
+
+bool LongType::isEqual(const Type &other) const {
+    return dynamic_cast<const LongType *>(&other) != nullptr;
+}
+
+void FunctionType::accept(Visitor &visitor) { visitor.visit(*this); }
+
+bool FunctionType::isEqual(const Type &other) const {
+    const auto *otherFn = dynamic_cast<const FunctionType *>(&other);
+    if (otherFn == nullptr) {
+        return false;
+    }
+    // Compare parameter types by value.
+    const auto &params1 = parameterTypes;
+    const auto &params2 = otherFn->parameterTypes;
+    if (params1.size() != params2.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < params1.size(); ++i) {
+        if (*(params1[i]) != *(params2[i])) {
+            return false;
+        }
+    }
+    // Compare return types by value.
+    return *returnType == *otherFn->returnType;
+}
+
+std::vector<std::unique_ptr<Type>> &FunctionType::getParameterTypes() {
+    return parameterTypes;
+}
+
+std::unique_ptr<Type> &FunctionType::getReturnType() { return returnType; }
+} // Namespace AST

--- a/src/frontend/type.h
+++ b/src/frontend/type.h
@@ -11,80 +11,47 @@ class Type : public AST {
   public:
     constexpr Type() = default;
     // Virtual function to check if two types are equal.
-    [[nodiscard]] virtual bool isEqual(const Type &other) const {
-        return typeid(*this) == typeid(other);
-    }
+    [[nodiscard]] virtual bool isEqual(const Type &other) const;
     // Overload the equality operator.
-    [[nodiscard]] friend bool operator==(const Type &lhs, const Type &rhs) {
-        return lhs.isEqual(rhs);
-    }
+    friend bool operator==(const Type &lhs, const Type &rhs);
     // Overload the inequality operator.
-    [[nodiscard]] friend bool operator!=(const Type &lhs, const Type &rhs) {
-        return !lhs.isEqual(rhs);
-    }
+    friend bool operator!=(const Type &lhs, const Type &rhs);
 };
 
 class IntType : public Type {
   public:
     constexpr IntType() = default;
-    void accept(Visitor &visitor) override { visitor.visit(*this); }
+    void accept(Visitor &visitor) override;
     // Override the `isEqual` function to check if the other type is an
     // `IntType`.
-    [[nodiscard]] bool isEqual(const Type &other) const override {
-        return dynamic_cast<const IntType *>(&other) != nullptr;
-    }
+    [[nodiscard]] bool isEqual(const Type &other) const override;
 };
 
 class LongType : public Type {
   public:
     constexpr LongType() = default;
-    void accept(Visitor &visitor) override { visitor.visit(*this); }
+    void accept(Visitor &visitor) override;
     // Override the `isEqual` function to check if the other type is a
     // `LongType`.
-    [[nodiscard]] bool isEqual(const Type &other) const override {
-        return dynamic_cast<const LongType *>(&other) != nullptr;
-    }
+    [[nodiscard]] bool isEqual(const Type &other) const override;
 };
 
 class FunctionType : public Type {
   public:
-    explicit FunctionType(
-        std::shared_ptr<std::vector<std::shared_ptr<Type>>> parameterTypes,
-        std::shared_ptr<Type> returnType)
-        : parameterTypes(parameterTypes), returnType(returnType) {}
-    void accept(Visitor &visitor) override { visitor.visit(*this); }
+    explicit FunctionType(std::vector<std::unique_ptr<Type>> parameterTypes,
+                          std::unique_ptr<Type> returnType)
+        : parameterTypes(std::move(parameterTypes)),
+          returnType(std::move(returnType)) {}
+    void accept(Visitor &visitor) override;
     // Override the `isEqual` function to check if the other type is a
     // `FunctionType`.
-    [[nodiscard]] bool isEqual(const Type &other) const override {
-        const auto *otherFn = dynamic_cast<const FunctionType *>(&other);
-        if (otherFn == nullptr) {
-            return false;
-        }
-        // Compare parameter types by value.
-        const auto &params1 = *parameterTypes;
-        const auto &params2 = *otherFn->parameterTypes;
-        if (params1.size() != params2.size()) {
-            return false;
-        }
-        for (size_t i = 0; i < params1.size(); ++i) {
-            if (*(params1[i]) != *(params2[i])) {
-                return false;
-            }
-        }
-        // Compare return types by value.
-        return *returnType == *otherFn->returnType;
-    }
-    [[nodiscard]] const std::shared_ptr<std::vector<std::shared_ptr<Type>>> &
-    getParameterTypes() const {
-        return parameterTypes;
-    }
-    [[nodiscard]] std::shared_ptr<Type> getReturnType() const {
-        return returnType;
-    }
+    [[nodiscard]] bool isEqual(const Type &other) const override;
+    [[nodiscard]] std::vector<std::unique_ptr<Type>> &getParameterTypes();
+    [[nodiscard]] std::unique_ptr<Type> &getReturnType();
 
   private:
-    std::shared_ptr<std::vector<std::shared_ptr<Type>>> parameterTypes;
-    std::shared_ptr<Type> returnType;
+    std::vector<std::unique_ptr<Type>> parameterTypes;
+    std::unique_ptr<Type> returnType;
 };
 } // namespace AST
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -172,8 +172,8 @@ int main(int argc, char *argv[]) {
         // Generate the IR from the AST program and return the IR program.
         auto irProgramAndIRStaticVariables =
             PipelineStagesExecutors::irGeneratorExecutor(
-                std::move(astProgram), variableResolutionCounter);
-        auto irProgram = irProgramAndIRStaticVariables.first;
+                astProgram, variableResolutionCounter);
+        auto irProgram = std::move(irProgramAndIRStaticVariables.first);
         auto irStaticVariables = irProgramAndIRStaticVariables.second;
 
         if (foldConstantsPass || propagateCopiesPass ||
@@ -182,8 +182,8 @@ int main(int argc, char *argv[]) {
             std::cout << "<<< Before optimization passes: >>>\n";
             PrettyPrinters::printIRProgram(irProgram, irStaticVariables);
 
-            // Perform the optimization passes on the IR program (if any of the
-            // flags is set to true).
+            // Perform the optimization passes on the IR program (if any of
+            // the flags is set to true).
             PipelineStagesExecutors::irOptimizationExecutor(
                 irProgram, foldConstantsPass, propagateCopiesPass,
                 eliminateUnreachableCodePass, eliminateDeadStoresPass);
@@ -197,6 +197,8 @@ int main(int argc, char *argv[]) {
             // Print the IR program onto the stdout.
             PrettyPrinters::printIRProgram(irProgram, irStaticVariables);
         }
+        // Print the IR program onto the stdout.
+        PrettyPrinters::printIRProgram(irProgram, irStaticVariables);
 
         if (tillIR) {
             std::cout

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -159,8 +159,10 @@ int main(int argc, char *argv[]) {
         }
 
         // Perform semantic analysis on the AST program.
-        auto variableResolutionCounter =
+        auto semanticAnalysisResult =
             PipelineStagesExecutors::semanticAnalysisExecutor(astProgram);
+        astProgram = std::move(semanticAnalysisResult.first);
+        auto variableResolutionCounter = semanticAnalysisResult.second;
 
         if (tillValidate) {
             std::cout << "Semantic analysis completed.\n";
@@ -170,7 +172,7 @@ int main(int argc, char *argv[]) {
         // Generate the IR from the AST program and return the IR program.
         auto irProgramAndIRStaticVariables =
             PipelineStagesExecutors::irGeneratorExecutor(
-                astProgram, variableResolutionCounter);
+                std::move(astProgram), variableResolutionCounter);
         auto irProgram = irProgramAndIRStaticVariables.first;
         auto irStaticVariables = irProgramAndIRStaticVariables.second;
 

--- a/src/midend/ir.cpp
+++ b/src/midend/ir.cpp
@@ -323,14 +323,9 @@ void LabelInstruction::setLabel(std::string_view newLabel) {
 
 FunctionCallInstruction::FunctionCallInstruction(
     std::string_view functionIdentifier,
-    std::unique_ptr<std::vector<std::unique_ptr<Value>>> args,
-    std::unique_ptr<Value> dst)
+    std::vector<std::unique_ptr<Value>> args, std::unique_ptr<Value> dst)
     : functionIdentifier(functionIdentifier), args(std::move(args)),
       dst(std::move(dst)) {
-    if (!args) {
-        throw std::logic_error(
-            "Creating FunctionCallInstruction with null args");
-    }
     if (!dst) {
         throw std::logic_error(
             "Creating FunctionCallInstruction with null dst");
@@ -341,8 +336,7 @@ const std::string &FunctionCallInstruction::getFunctionIdentifier() const {
     return functionIdentifier;
 }
 
-const std::unique_ptr<std::vector<std::unique_ptr<Value>>> &
-FunctionCallInstruction::getArgs() const {
+std::vector<std::unique_ptr<Value>> &FunctionCallInstruction::getArgs() {
     return args;
 }
 
@@ -354,10 +348,7 @@ void FunctionCallInstruction::setFunctionIdentifier(
 }
 
 void FunctionCallInstruction::setArgs(
-    std::unique_ptr<std::vector<std::unique_ptr<Value>>> newArgs) {
-    if (!newArgs) {
-        throw std::logic_error("Setting FunctionCallInstruction args to null");
-    }
+    std::vector<std::unique_ptr<Value>> newArgs) {
     this->args = std::move(newArgs);
 }
 
@@ -370,18 +361,10 @@ void FunctionCallInstruction::setDst(std::unique_ptr<Value> newDst) {
 
 FunctionDefinition::FunctionDefinition(
     std::string_view functionIdentifier, bool global,
-    std::unique_ptr<std::vector<std::string>> parameters,
-    std::unique_ptr<std::vector<std::unique_ptr<Instruction>>> functionBody)
+    std::vector<std::string> parameters,
+    std::vector<std::unique_ptr<Instruction>> functionBody)
     : functionIdentifier(functionIdentifier), global(global),
       parameters(std::move(parameters)), functionBody(std::move(functionBody)) {
-    if (!parameters) {
-        throw std::logic_error(
-            "Creating FunctionDefinition with null parameters");
-    }
-    if (!functionBody) {
-        throw std::logic_error(
-            "Creating FunctionDefinition with null functionBody");
-    }
 }
 
 const std::string &FunctionDefinition::getFunctionIdentifier() const {
@@ -390,23 +373,17 @@ const std::string &FunctionDefinition::getFunctionIdentifier() const {
 
 bool FunctionDefinition::isGlobal() const { return global; }
 
-const std::unique_ptr<std::vector<std::string>> &
-FunctionDefinition::getParameterIdentifiers() const {
+std::vector<std::string> &FunctionDefinition::getParameterIdentifiers() {
     return parameters;
 }
 
-const std::unique_ptr<std::vector<std::unique_ptr<Instruction>>> &
-FunctionDefinition::getFunctionBody() const {
+std::vector<std::unique_ptr<Instruction>> &
+FunctionDefinition::getFunctionBody() {
     return functionBody;
 }
 
 void FunctionDefinition::setFunctionBody(
-    std::unique_ptr<std::vector<std::unique_ptr<Instruction>>>
-        newFunctionBody) {
-    if (!newFunctionBody) {
-        throw std::logic_error(
-            "Setting FunctionDefinition functionBody to null");
-    }
+    std::vector<std::unique_ptr<Instruction>> newFunctionBody) {
     this->functionBody = std::move(newFunctionBody);
 }
 
@@ -433,16 +410,10 @@ std::unique_ptr<AST::StaticInit> &StaticVariable::getStaticInit() {
     return staticInit;
 }
 
-Program::Program(
-    std::unique_ptr<std::vector<std::unique_ptr<TopLevel>>> topLevels)
-    : topLevels(std::move(topLevels)) {
-    if (!topLevels) {
-        throw std::logic_error("Creating Program with null topLevels");
-    }
-}
+Program::Program(std::vector<std::unique_ptr<TopLevel>> topLevels)
+    : topLevels(std::move(topLevels)) {}
 
-std::unique_ptr<std::vector<std::unique_ptr<TopLevel>>> &
-Program::getTopLevels() {
+std::vector<std::unique_ptr<TopLevel>> &Program::getTopLevels() {
     return topLevels;
 }
 } // namespace IR

--- a/src/midend/ir.cpp
+++ b/src/midend/ir.cpp
@@ -1,0 +1,448 @@
+#include "ir.h"
+#include <stdexcept>
+
+namespace IR {
+ConstantValue::ConstantValue(std::unique_ptr<AST::Constant> astConstant)
+    : astConstant(std::move(astConstant)) {
+    if (!astConstant) {
+        throw std::logic_error("Creating ConstantValue with null astConstant");
+    }
+}
+
+ConstantValue::~ConstantValue() = default;
+
+std::unique_ptr<AST::Constant> &ConstantValue::getASTConstant() {
+    return astConstant;
+}
+
+void ConstantValue::setASTConstant(
+    std::unique_ptr<AST::Constant> newAstConstant) {
+    if (!newAstConstant) {
+        throw std::logic_error("Setting ConstantValue astConstant to null");
+    }
+    this->astConstant = std::move(newAstConstant);
+}
+
+VariableValue::VariableValue(std::string_view identifier)
+    : identifier(identifier) {}
+
+VariableValue::~VariableValue() = default;
+
+const std::string &VariableValue::getIdentifier() const { return identifier; }
+
+void VariableValue::setIdentifier(std::string_view newIdentifier) {
+    this->identifier = newIdentifier;
+}
+
+ReturnInstruction::ReturnInstruction(std::unique_ptr<Value> returnValue)
+    : returnValue(std::move(returnValue)) {
+    if (!returnValue) {
+        throw std::logic_error(
+            "Creating ReturnInstruction with null returnValue");
+    }
+}
+
+std::unique_ptr<Value> &ReturnInstruction::getReturnValue() {
+    return returnValue;
+}
+
+void ReturnInstruction::setReturnValue(std::unique_ptr<Value> newReturnValue) {
+    if (!newReturnValue) {
+        throw std::logic_error("Setting ReturnInstruction returnValue to null");
+    }
+    this->returnValue = std::move(newReturnValue);
+}
+
+SignExtendInstruction::SignExtendInstruction(std::unique_ptr<Value> src,
+                                             std::unique_ptr<Value> dst)
+    : src(std::move(src)), dst(std::move(dst)) {
+    if (!src) {
+        throw std::logic_error("Creating SignExtendInstruction with null src");
+    }
+    if (!dst) {
+        throw std::logic_error("Creating SignExtendInstruction with null dst");
+    }
+}
+
+std::unique_ptr<Value> &SignExtendInstruction::getSrc() { return src; }
+
+std::unique_ptr<Value> &SignExtendInstruction::getDst() { return dst; }
+
+void SignExtendInstruction::setSrc(std::unique_ptr<Value> newSrc) {
+    if (!newSrc) {
+        throw std::logic_error("Setting SignExtendInstruction src to null");
+    }
+    this->src = std::move(newSrc);
+}
+
+void SignExtendInstruction::setDst(std::unique_ptr<Value> newDst) {
+    if (!newDst) {
+        throw std::logic_error("Setting SignExtendInstruction dst to null");
+    }
+    this->dst = std::move(newDst);
+}
+
+TruncateInstruction::TruncateInstruction(std::unique_ptr<Value> src,
+                                         std::unique_ptr<Value> dst)
+    : src(std::move(src)), dst(std::move(dst)) {
+    if (!src) {
+        throw std::logic_error("Creating TruncateInstruction with null src");
+    }
+    if (!dst) {
+        throw std::logic_error("Creating TruncateInstruction with null dst");
+    }
+}
+
+std::unique_ptr<Value> &TruncateInstruction::getSrc() { return src; }
+
+std::unique_ptr<Value> &TruncateInstruction::getDst() { return dst; }
+
+void TruncateInstruction::setSrc(std::unique_ptr<Value> newSrc) {
+    if (!newSrc) {
+        throw std::logic_error("Setting TruncateInstruction src to null");
+    }
+    this->src = std::move(newSrc);
+}
+
+void TruncateInstruction::setDst(std::unique_ptr<Value> newDst) {
+    if (!newDst) {
+        throw std::logic_error("Setting TruncateInstruction dst to null");
+    }
+    this->dst = std::move(newDst);
+}
+
+UnaryInstruction::UnaryInstruction(std::unique_ptr<UnaryOperator> unaryOperator,
+                                   std::unique_ptr<Value> src,
+                                   std::unique_ptr<Value> dst)
+    : unaryOperator(std::move(unaryOperator)), src(std::move(src)),
+      dst(std::move(dst)) {
+    if (!unaryOperator) {
+        throw std::logic_error(
+            "Creating UnaryInstruction with null unaryOperator");
+    }
+    if (!src) {
+        throw std::logic_error("Creating UnaryInstruction with null src");
+    }
+    if (!dst) {
+        throw std::logic_error("Creating UnaryInstruction with null dst");
+    }
+}
+
+std::unique_ptr<UnaryOperator> &UnaryInstruction::getUnaryOperator() {
+    return unaryOperator;
+}
+
+std::unique_ptr<Value> &UnaryInstruction::getSrc() { return src; }
+
+std::unique_ptr<Value> &UnaryInstruction::getDst() { return dst; }
+
+void UnaryInstruction::setUnaryOperator(
+    std::unique_ptr<UnaryOperator> newUnaryOperator) {
+    if (!newUnaryOperator) {
+        throw std::logic_error(
+            "Setting UnaryInstruction unaryOperator to null");
+    }
+    this->unaryOperator = std::move(newUnaryOperator);
+}
+
+void UnaryInstruction::setSrc(std::unique_ptr<Value> newSrc) {
+    if (!newSrc) {
+        throw std::logic_error("Setting UnaryInstruction src to null");
+    }
+    this->src = std::move(newSrc);
+}
+
+void UnaryInstruction::setDst(std::unique_ptr<Value> newDst) {
+    if (!newDst) {
+        throw std::logic_error("Setting UnaryInstruction dst to null");
+    }
+    this->dst = std::move(newDst);
+}
+
+BinaryInstruction::BinaryInstruction(
+    std::unique_ptr<BinaryOperator> binaryOperator, std::unique_ptr<Value> src1,
+    std::unique_ptr<Value> src2, std::unique_ptr<Value> dst)
+    : binaryOperator(std::move(binaryOperator)), src1(std::move(src1)),
+      src2(std::move(src2)), dst(std::move(dst)) {
+    if (!binaryOperator) {
+        throw std::logic_error(
+            "Creating BinaryInstruction with null binaryOperator");
+    }
+    if (!src1) {
+        throw std::logic_error("Creating BinaryInstruction with null src1");
+    }
+    if (!src2) {
+        throw std::logic_error("Creating BinaryInstruction with null src2");
+    }
+    if (!dst) {
+        throw std::logic_error("Creating BinaryInstruction with null dst");
+    }
+}
+
+std::unique_ptr<BinaryOperator> &BinaryInstruction::getBinaryOperator() {
+    return binaryOperator;
+}
+
+std::unique_ptr<Value> &BinaryInstruction::getSrc1() { return src1; }
+
+std::unique_ptr<Value> &BinaryInstruction::getSrc2() { return src2; }
+
+std::unique_ptr<Value> &BinaryInstruction::getDst() { return dst; }
+
+void BinaryInstruction::setBinaryOperator(
+    std::unique_ptr<BinaryOperator> newBinaryOperator) {
+    if (!newBinaryOperator) {
+        throw std::logic_error(
+            "Setting BinaryInstruction binaryOperator to null");
+    }
+    this->binaryOperator = std::move(newBinaryOperator);
+}
+
+void BinaryInstruction::setSrc1(std::unique_ptr<Value> newSrc1) {
+    if (!newSrc1) {
+        throw std::logic_error("Setting BinaryInstruction src1 to null");
+    }
+    this->src1 = std::move(newSrc1);
+}
+
+void BinaryInstruction::setSrc2(std::unique_ptr<Value> newSrc2) {
+    if (!newSrc2) {
+        throw std::logic_error("Setting BinaryInstruction src2 to null");
+    }
+    this->src2 = std::move(newSrc2);
+}
+
+void BinaryInstruction::setDst(std::unique_ptr<Value> newDst) {
+    if (!newDst) {
+        throw std::logic_error("Setting BinaryInstruction dst to null");
+    }
+    this->dst = std::move(newDst);
+}
+
+CopyInstruction::CopyInstruction(std::unique_ptr<Value> src,
+                                 std::unique_ptr<Value> dst)
+    : src(std::move(src)), dst(std::move(dst)) {
+    if (!src) {
+        throw std::logic_error("Creating CopyInstruction with null src");
+    }
+    if (!dst) {
+        throw std::logic_error("Creating CopyInstruction with null dst");
+    }
+}
+
+std::unique_ptr<Value> &CopyInstruction::getSrc() { return src; }
+
+std::unique_ptr<Value> &CopyInstruction::getDst() { return dst; }
+
+void CopyInstruction::setSrc(std::unique_ptr<Value> newSrc) {
+    if (!newSrc) {
+        throw std::logic_error("Setting CopyInstruction src to null");
+    }
+    this->src = std::move(newSrc);
+}
+
+void CopyInstruction::setDst(std::unique_ptr<Value> newDst) {
+    if (!newDst) {
+        throw std::logic_error("Setting CopyInstruction dst to null");
+    }
+    this->dst = std::move(newDst);
+}
+
+JumpInstruction::JumpInstruction(std::string_view target) : target(target) {}
+
+const std::string &JumpInstruction::getTarget() const { return target; }
+
+void JumpInstruction::setTarget(std::string_view newTarget) {
+    this->target = newTarget;
+}
+
+JumpIfZeroInstruction::JumpIfZeroInstruction(std::unique_ptr<Value> condition,
+                                             std::string_view target)
+    : condition(std::move(condition)), target(target) {
+    if (!condition) {
+        throw std::logic_error(
+            "Creating JumpIfZeroInstruction with null condition");
+    }
+}
+
+std::unique_ptr<Value> &JumpIfZeroInstruction::getCondition() {
+    return condition;
+}
+
+const std::string &JumpIfZeroInstruction::getTarget() const { return target; }
+
+void JumpIfZeroInstruction::setCondition(std::unique_ptr<Value> newCondition) {
+    if (!newCondition) {
+        throw std::logic_error(
+            "Setting JumpIfZeroInstruction condition to null");
+    }
+    this->condition = std::move(newCondition);
+}
+
+void JumpIfZeroInstruction::setTarget(std::string_view newTarget) {
+    this->target = newTarget;
+}
+
+JumpIfNotZeroInstruction::JumpIfNotZeroInstruction(
+    std::unique_ptr<Value> condition, std::string_view target)
+    : condition(std::move(condition)), target(target) {
+    if (!condition) {
+        throw std::logic_error(
+            "Creating JumpIfNotZeroInstruction with null condition");
+    }
+}
+
+std::unique_ptr<Value> &JumpIfNotZeroInstruction::getCondition() {
+    return condition;
+}
+
+const std::string &JumpIfNotZeroInstruction::getTarget() const {
+    return target;
+}
+
+void JumpIfNotZeroInstruction::setCondition(
+    std::unique_ptr<Value> newCondition) {
+    if (!newCondition) {
+        throw std::logic_error(
+            "Setting JumpIfNotZeroInstruction condition to null");
+    }
+    this->condition = std::move(newCondition);
+}
+
+void JumpIfNotZeroInstruction::setTarget(std::string_view newTarget) {
+    this->target = newTarget;
+}
+
+LabelInstruction::LabelInstruction(std::string_view label) : label(label) {}
+
+const std::string &LabelInstruction::getLabel() const { return label; }
+
+void LabelInstruction::setLabel(std::string_view newLabel) {
+    this->label = newLabel;
+}
+
+FunctionCallInstruction::FunctionCallInstruction(
+    std::string_view functionIdentifier,
+    std::unique_ptr<std::vector<std::unique_ptr<Value>>> args,
+    std::unique_ptr<Value> dst)
+    : functionIdentifier(functionIdentifier), args(std::move(args)),
+      dst(std::move(dst)) {
+    if (!args) {
+        throw std::logic_error(
+            "Creating FunctionCallInstruction with null args");
+    }
+    if (!dst) {
+        throw std::logic_error(
+            "Creating FunctionCallInstruction with null dst");
+    }
+}
+
+const std::string &FunctionCallInstruction::getFunctionIdentifier() const {
+    return functionIdentifier;
+}
+
+const std::unique_ptr<std::vector<std::unique_ptr<Value>>> &
+FunctionCallInstruction::getArgs() const {
+    return args;
+}
+
+std::unique_ptr<Value> &FunctionCallInstruction::getDst() { return dst; }
+
+void FunctionCallInstruction::setFunctionIdentifier(
+    std::string_view newFunctionIdentifier) {
+    this->functionIdentifier = newFunctionIdentifier;
+}
+
+void FunctionCallInstruction::setArgs(
+    std::unique_ptr<std::vector<std::unique_ptr<Value>>> newArgs) {
+    if (!newArgs) {
+        throw std::logic_error("Setting FunctionCallInstruction args to null");
+    }
+    this->args = std::move(newArgs);
+}
+
+void FunctionCallInstruction::setDst(std::unique_ptr<Value> newDst) {
+    if (!newDst) {
+        throw std::logic_error("Setting FunctionCallInstruction dst to null");
+    }
+    this->dst = std::move(newDst);
+}
+
+FunctionDefinition::FunctionDefinition(
+    std::string_view functionIdentifier, bool global,
+    std::unique_ptr<std::vector<std::string>> parameters,
+    std::unique_ptr<std::vector<std::unique_ptr<Instruction>>> functionBody)
+    : functionIdentifier(functionIdentifier), global(global),
+      parameters(std::move(parameters)), functionBody(std::move(functionBody)) {
+    if (!parameters) {
+        throw std::logic_error(
+            "Creating FunctionDefinition with null parameters");
+    }
+    if (!functionBody) {
+        throw std::logic_error(
+            "Creating FunctionDefinition with null functionBody");
+    }
+}
+
+const std::string &FunctionDefinition::getFunctionIdentifier() const {
+    return functionIdentifier;
+}
+
+bool FunctionDefinition::isGlobal() const { return global; }
+
+const std::unique_ptr<std::vector<std::string>> &
+FunctionDefinition::getParameterIdentifiers() const {
+    return parameters;
+}
+
+const std::unique_ptr<std::vector<std::unique_ptr<Instruction>>> &
+FunctionDefinition::getFunctionBody() const {
+    return functionBody;
+}
+
+void FunctionDefinition::setFunctionBody(
+    std::unique_ptr<std::vector<std::unique_ptr<Instruction>>>
+        newFunctionBody) {
+    if (!newFunctionBody) {
+        throw std::logic_error(
+            "Setting FunctionDefinition functionBody to null");
+    }
+    this->functionBody = std::move(newFunctionBody);
+}
+
+StaticVariable::StaticVariable(std::string_view identifier, bool global,
+                               std::unique_ptr<AST::Type> type,
+                               std::unique_ptr<AST::StaticInit> staticInit)
+    : identifier(identifier), global(global), type(std::move(type)),
+      staticInit(std::move(staticInit)) {
+    if (!type) {
+        throw std::logic_error("Creating StaticVariable with null type");
+    }
+    if (!staticInit) {
+        throw std::logic_error("Creating StaticVariable with null staticInit");
+    }
+}
+
+const std::string &StaticVariable::getIdentifier() const { return identifier; }
+
+bool StaticVariable::isGlobal() const { return global; }
+
+std::unique_ptr<AST::Type> &StaticVariable::getType() { return type; }
+
+std::unique_ptr<AST::StaticInit> &StaticVariable::getStaticInit() {
+    return staticInit;
+}
+
+Program::Program(
+    std::unique_ptr<std::vector<std::unique_ptr<TopLevel>>> topLevels)
+    : topLevels(std::move(topLevels)) {
+    if (!topLevels) {
+        throw std::logic_error("Creating Program with null topLevels");
+    }
+}
+
+std::unique_ptr<std::vector<std::unique_ptr<TopLevel>>> &
+Program::getTopLevels() {
+    return topLevels;
+}
+} // namespace IR

--- a/src/midend/ir.h
+++ b/src/midend/ir.h
@@ -23,8 +23,10 @@ class ComplementOperator : public UnaryOperator {};
 
 class NotOperator : public UnaryOperator {};
 
-/* Note: The logical-and and logical-or operators in the AST are NOT binary
- * operators in the IR. */
+/*
+ * Note: The logical-and and logical-or operators in the AST are NOT binary
+ * operators in the IR.
+ */
 class BinaryOperator : public Operator {};
 
 class AddOperator : public BinaryOperator {};
@@ -56,26 +58,13 @@ class Value {
 
 class ConstantValue : public Value {
   private:
-    std::shared_ptr<AST::Constant> astConstant;
+    std::unique_ptr<AST::Constant> astConstant;
 
   public:
-    explicit ConstantValue(const std::shared_ptr<AST::Constant> &astConstant)
-        : astConstant(astConstant) {
-        if (!astConstant) {
-            throw std::logic_error(
-                "Creating ConstantValue with null astConstant");
-        }
-    }
-    ~ConstantValue() = default;
-    [[nodiscard]] std::shared_ptr<AST::Constant> getASTConstant() const {
-        return astConstant;
-    }
-    void setASTConstant(const std::shared_ptr<AST::Constant> &newAstConstant) {
-        if (!newAstConstant) {
-            throw std::logic_error("Setting ConstantValue astConstant to null");
-        }
-        this->astConstant = newAstConstant;
-    }
+    explicit ConstantValue(std::unique_ptr<AST::Constant> astConstant);
+    ~ConstantValue();
+    [[nodiscard]] std::unique_ptr<AST::Constant> &getASTConstant();
+    void setASTConstant(std::unique_ptr<AST::Constant> newAstConstant);
 };
 
 class VariableValue : public Value {
@@ -83,15 +72,10 @@ class VariableValue : public Value {
     std::string identifier;
 
   public:
-    explicit VariableValue(std::string_view identifier)
-        : identifier(identifier) {}
-    ~VariableValue() = default;
-    [[nodiscard]] const std::string &getIdentifier() const {
-        return identifier;
-    }
-    void setIdentifier(std::string_view newIdentifier) {
-        this->identifier = newIdentifier;
-    }
+    explicit VariableValue(std::string_view identifier);
+    ~VariableValue();
+    [[nodiscard]] const std::string &getIdentifier() const;
+    void setIdentifier(std::string_view newIdentifier);
 };
 
 class Instruction {
@@ -101,230 +85,84 @@ class Instruction {
 
 class ReturnInstruction : public Instruction {
   private:
-    std::shared_ptr<Value> returnValue;
+    std::unique_ptr<Value> returnValue;
 
   public:
-    explicit ReturnInstruction(const std::shared_ptr<Value> &returnValue)
-        : returnValue(returnValue) {
-        if (!returnValue) {
-            throw std::logic_error(
-                "Creating ReturnInstruction with null returnValue");
-        }
-    }
-    [[nodiscard]] std::shared_ptr<Value> getReturnValue() const {
-        return returnValue;
-    }
-    void setReturnValue(const std::shared_ptr<Value> &newReturnValue) {
-        if (!newReturnValue) {
-            throw std::logic_error(
-                "Setting ReturnInstruction returnValue to null");
-        }
-        this->returnValue = newReturnValue;
-    }
+    explicit ReturnInstruction(std::unique_ptr<Value> returnValue);
+    [[nodiscard]] std::unique_ptr<Value> &getReturnValue();
+    void setReturnValue(std::unique_ptr<Value> newReturnValue);
 };
 
 class SignExtendInstruction : public Instruction {
   private:
-    std::shared_ptr<Value> src, dst;
+    std::unique_ptr<Value> src, dst;
 
   public:
-    SignExtendInstruction(const std::shared_ptr<Value> &src,
-                          const std::shared_ptr<Value> &dst)
-        : src(src), dst(dst) {
-        if (!src) {
-            throw std::logic_error("Creating SignExtendInstruction with null "
-                                   "src");
-        }
-        if (!dst) {
-            throw std::logic_error("Creating SignExtendInstruction with null "
-                                   "dst");
-        }
-    }
-    [[nodiscard]] std::shared_ptr<Value> getSrc() const { return src; }
-    [[nodiscard]] std::shared_ptr<Value> getDst() const { return dst; }
-    void setSrc(const std::shared_ptr<Value> &newSrc) {
-        if (!newSrc) {
-            throw std::logic_error("Setting SignExtendInstruction src to null");
-        }
-        this->src = newSrc;
-    }
-    void setDst(const std::shared_ptr<Value> &newDst) {
-        if (!newDst) {
-            throw std::logic_error("Setting SignExtendInstruction dst to null");
-        }
-        this->dst = newDst;
-    }
+    SignExtendInstruction(std::unique_ptr<Value> src,
+                          std::unique_ptr<Value> dst);
+    [[nodiscard]] std::unique_ptr<Value> &getSrc();
+    [[nodiscard]] std::unique_ptr<Value> &getDst();
+    void setSrc(std::unique_ptr<Value> newSrc);
+    void setDst(std::unique_ptr<Value> newDst);
 };
 
 class TruncateInstruction : public Instruction {
   private:
-    std::shared_ptr<Value> src, dst;
+    std::unique_ptr<Value> src, dst;
 
   public:
-    TruncateInstruction(const std::shared_ptr<Value> &src,
-                        const std::shared_ptr<Value> &dst)
-        : src(src), dst(dst) {
-        if (!src) {
-            throw std::logic_error(
-                "Creating TruncateInstruction with null src");
-        }
-        if (!dst) {
-            throw std::logic_error(
-                "Creating TruncateInstruction with null dst");
-        }
-    }
-    [[nodiscard]] std::shared_ptr<Value> getSrc() const { return src; }
-    [[nodiscard]] std::shared_ptr<Value> getDst() const { return dst; }
-    void setSrc(const std::shared_ptr<Value> &newSrc) {
-        if (!newSrc) {
-            throw std::logic_error("Setting TruncateInstruction src to null");
-        }
-        this->src = newSrc;
-    }
-    void setDst(const std::shared_ptr<Value> &newDst) {
-        if (!newDst) {
-            throw std::logic_error("Setting TruncateInstruction dst to null");
-        }
-        this->dst = newDst;
-    }
+    TruncateInstruction(std::unique_ptr<Value> src, std::unique_ptr<Value> dst);
+    [[nodiscard]] std::unique_ptr<Value> &getSrc();
+    [[nodiscard]] std::unique_ptr<Value> &getDst();
+    void setSrc(std::unique_ptr<Value> newSrc);
+    void setDst(std::unique_ptr<Value> newDst);
 };
 
 class UnaryInstruction : public Instruction {
   private:
-    std::shared_ptr<UnaryOperator> unaryOperator;
-    std::shared_ptr<Value> src, dst;
+    std::unique_ptr<UnaryOperator> unaryOperator;
+    std::unique_ptr<Value> src, dst;
 
   public:
-    UnaryInstruction(const std::shared_ptr<UnaryOperator> &unaryOperator,
-                     const std::shared_ptr<Value> &src,
-                     const std::shared_ptr<Value> &dst)
-        : unaryOperator(unaryOperator), src(src), dst(dst) {
-        if (!unaryOperator) {
-            throw std::logic_error(
-                "Creating UnaryInstruction with null unaryOperator");
-        }
-        if (!src) {
-            throw std::logic_error("Creating UnaryInstruction with null src");
-        }
-        if (!dst) {
-            throw std::logic_error("Creating UnaryInstruction with null dst");
-        }
-    }
-    [[nodiscard]] std::shared_ptr<UnaryOperator> getUnaryOperator() const {
-        return unaryOperator;
-    }
-    [[nodiscard]] std::shared_ptr<Value> getSrc() const { return src; }
-    [[nodiscard]] std::shared_ptr<Value> getDst() const { return dst; }
-    void
-    setUnaryOperator(const std::shared_ptr<UnaryOperator> &newUnaryOperator) {
-        if (!newUnaryOperator) {
-            throw std::logic_error(
-                "Setting UnaryInstruction unaryOperator to null");
-        }
-        this->unaryOperator = newUnaryOperator;
-    }
-    void setSrc(const std::shared_ptr<Value> &newSrc) {
-        if (!newSrc) {
-            throw std::logic_error("Setting UnaryInstruction src to null");
-        }
-        this->src = newSrc;
-    }
-    void setDst(const std::shared_ptr<Value> &newDst) {
-        if (!newDst) {
-            throw std::logic_error("Setting UnaryInstruction dst to null");
-        }
-        this->dst = newDst;
-    }
+    UnaryInstruction(std::unique_ptr<UnaryOperator> unaryOperator,
+                     std::unique_ptr<Value> src, std::unique_ptr<Value> dst);
+    [[nodiscard]] std::unique_ptr<UnaryOperator> &getUnaryOperator();
+    [[nodiscard]] std::unique_ptr<Value> &getSrc();
+    [[nodiscard]] std::unique_ptr<Value> &getDst();
+    void setUnaryOperator(std::unique_ptr<UnaryOperator> newUnaryOperator);
+    void setSrc(std::unique_ptr<Value> newSrc);
+    void setDst(std::unique_ptr<Value> newDst);
 };
 
 class BinaryInstruction : public Instruction {
   private:
-    std::shared_ptr<BinaryOperator> binaryOperator;
-    std::shared_ptr<Value> src1, src2, dst;
+    std::unique_ptr<BinaryOperator> binaryOperator;
+    std::unique_ptr<Value> src1, src2, dst;
 
   public:
-    BinaryInstruction(const std::shared_ptr<BinaryOperator> &binaryOperator,
-                      const std::shared_ptr<Value> &src1,
-                      const std::shared_ptr<Value> &src2,
-                      const std::shared_ptr<Value> &dst)
-        : binaryOperator(binaryOperator), src1(src1), src2(src2), dst(dst) {
-        if (!binaryOperator) {
-            throw std::logic_error(
-                "Creating BinaryInstruction with null binaryOperator");
-        }
-        if (!src1) {
-            throw std::logic_error("Creating BinaryInstruction with null src1");
-        }
-        if (!src2) {
-            throw std::logic_error("Creating BinaryInstruction with null src2");
-        }
-        if (!dst) {
-            throw std::logic_error("Creating BinaryInstruction with null dst");
-        }
-    }
-    [[nodiscard]] std::shared_ptr<BinaryOperator> getBinaryOperator() const {
-        return binaryOperator;
-    }
-    [[nodiscard]] std::shared_ptr<Value> getSrc1() const { return src1; }
-    [[nodiscard]] std::shared_ptr<Value> getSrc2() const { return src2; }
-    [[nodiscard]] std::shared_ptr<Value> getDst() const { return dst; }
-    void setBinaryOperator(
-        const std::shared_ptr<BinaryOperator> &newBinaryOperator) {
-        if (!newBinaryOperator) {
-            throw std::logic_error(
-                "Setting BinaryInstruction binaryOperator to null");
-        }
-        this->binaryOperator = newBinaryOperator;
-    }
-    void setSrc1(const std::shared_ptr<Value> &newSrc1) {
-        if (!newSrc1) {
-            throw std::logic_error("Setting BinaryInstruction src1 to null");
-        }
-        this->src1 = newSrc1;
-    }
-    void setSrc2(const std::shared_ptr<Value> &newSrc2) {
-        if (!newSrc2) {
-            throw std::logic_error("Setting BinaryInstruction src2 to null");
-        }
-        this->src2 = newSrc2;
-    }
-    void setDst(const std::shared_ptr<Value> &newDst) {
-        if (!newDst) {
-            throw std::logic_error("Setting BinaryInstruction dst to null");
-        }
-        this->dst = newDst;
-    }
+    BinaryInstruction(std::unique_ptr<BinaryOperator> binaryOperator,
+                      std::unique_ptr<Value> src1, std::unique_ptr<Value> src2,
+                      std::unique_ptr<Value> dst);
+    [[nodiscard]] std::unique_ptr<BinaryOperator> &getBinaryOperator();
+    [[nodiscard]] std::unique_ptr<Value> &getSrc1();
+    [[nodiscard]] std::unique_ptr<Value> &getSrc2();
+    [[nodiscard]] std::unique_ptr<Value> &getDst();
+    void setBinaryOperator(std::unique_ptr<BinaryOperator> newBinaryOperator);
+    void setSrc1(std::unique_ptr<Value> newSrc1);
+    void setSrc2(std::unique_ptr<Value> newSrc2);
+    void setDst(std::unique_ptr<Value> newDst);
 };
 
 class CopyInstruction : public Instruction {
   private:
-    std::shared_ptr<Value> src, dst;
+    std::unique_ptr<Value> src, dst;
 
   public:
-    CopyInstruction(const std::shared_ptr<Value> &src,
-                    const std::shared_ptr<Value> &dst)
-        : src(src), dst(dst) {
-        if (!src) {
-            throw std::logic_error("Creating CopyInstruction with null src");
-        }
-        if (!dst) {
-            throw std::logic_error("Creating CopyInstruction with null dst");
-        }
-    }
-    [[nodiscard]] std::shared_ptr<Value> getSrc() const { return src; }
-    [[nodiscard]] std::shared_ptr<Value> getDst() const { return dst; }
-    void setSrc(const std::shared_ptr<Value> &newSrc) {
-        if (!newSrc) {
-            throw std::logic_error("Setting CopyInstruction src to null");
-        }
-        this->src = newSrc;
-    }
-    void setDst(const std::shared_ptr<Value> &newDst) {
-        if (!newDst) {
-            throw std::logic_error("Setting CopyInstruction dst to null");
-        }
-        this->dst = newDst;
-    }
+    CopyInstruction(std::unique_ptr<Value> src, std::unique_ptr<Value> dst);
+    [[nodiscard]] std::unique_ptr<Value> &getSrc();
+    [[nodiscard]] std::unique_ptr<Value> &getDst();
+    void setSrc(std::unique_ptr<Value> newSrc);
+    void setDst(std::unique_ptr<Value> newDst);
 };
 
 class JumpInstruction : public Instruction {
@@ -332,65 +170,37 @@ class JumpInstruction : public Instruction {
     std::string target;
 
   public:
-    explicit JumpInstruction(std::string_view target) : target(target) {}
-    [[nodiscard]] const std::string &getTarget() const { return target; }
-    void setTarget(std::string_view newTarget) { this->target = newTarget; }
+    explicit JumpInstruction(std::string_view target);
+    [[nodiscard]] const std::string &getTarget() const;
+    void setTarget(std::string_view newTarget);
 };
 
 class JumpIfZeroInstruction : public Instruction {
   private:
-    std::shared_ptr<Value> condition;
+    std::unique_ptr<Value> condition;
     std::string target;
 
   public:
-    JumpIfZeroInstruction(const std::shared_ptr<Value> &condition,
-                          std::string_view target)
-        : condition(condition), target(target) {
-        if (!condition) {
-            throw std::logic_error(
-                "Creating JumpIfZeroInstruction with null condition");
-        }
-    }
-    [[nodiscard]] std::shared_ptr<Value> getCondition() const {
-        return condition;
-    }
-    [[nodiscard]] const std::string &getTarget() const { return target; }
-    void setCondition(const std::shared_ptr<Value> &newCondition) {
-        if (!newCondition) {
-            throw std::logic_error(
-                "Setting JumpIfZeroInstruction condition to null");
-        }
-        this->condition = newCondition;
-    }
-    void setTarget(std::string_view newTarget) { this->target = newTarget; }
+    JumpIfZeroInstruction(std::unique_ptr<Value> condition,
+                          std::string_view target);
+    [[nodiscard]] std::unique_ptr<Value> &getCondition();
+    [[nodiscard]] const std::string &getTarget() const;
+    void setCondition(std::unique_ptr<Value> newCondition);
+    void setTarget(std::string_view newTarget);
 };
 
 class JumpIfNotZeroInstruction : public Instruction {
   private:
-    std::shared_ptr<Value> condition;
+    std::unique_ptr<Value> condition;
     std::string target;
 
   public:
-    JumpIfNotZeroInstruction(const std::shared_ptr<Value> &condition,
-                             std::string_view target)
-        : condition(condition), target(target) {
-        if (!condition) {
-            throw std::logic_error(
-                "Creating JumpIfNotZeroInstruction with null condition");
-        }
-    }
-    [[nodiscard]] std::shared_ptr<Value> getCondition() const {
-        return condition;
-    }
-    [[nodiscard]] const std::string &getTarget() const { return target; }
-    void setCondition(const std::shared_ptr<Value> &newCondition) {
-        if (!newCondition) {
-            throw std::logic_error(
-                "Setting JumpIfNotZeroInstruction condition to null");
-        }
-        this->condition = newCondition;
-    }
-    void setTarget(std::string_view newTarget) { this->target = newTarget; }
+    JumpIfNotZeroInstruction(std::unique_ptr<Value> condition,
+                             std::string_view target);
+    [[nodiscard]] std::unique_ptr<Value> &getCondition();
+    [[nodiscard]] const std::string &getTarget() const;
+    void setCondition(std::unique_ptr<Value> newCondition);
+    void setTarget(std::string_view newTarget);
 };
 
 class LabelInstruction : public Instruction {
@@ -398,58 +208,29 @@ class LabelInstruction : public Instruction {
     std::string label;
 
   public:
-    explicit LabelInstruction(std::string_view label) : label(label) {}
-    [[nodiscard]] const std::string &getLabel() const { return label; }
-    void setLabel(std::string_view newLabel) { this->label = newLabel; }
+    explicit LabelInstruction(std::string_view label);
+    [[nodiscard]] const std::string &getLabel() const;
+    void setLabel(std::string_view newLabel);
 };
 
 class FunctionCallInstruction : public Instruction {
   private:
     std::string functionIdentifier;
-    std::shared_ptr<std::vector<std::shared_ptr<Value>>> args;
-    std::shared_ptr<Value> dst;
+    std::unique_ptr<std::vector<std::unique_ptr<Value>>> args;
+    std::unique_ptr<Value> dst;
 
   public:
     FunctionCallInstruction(
         std::string_view functionIdentifier,
-        const std::shared_ptr<std::vector<std::shared_ptr<Value>>> &args,
-        const std::shared_ptr<Value> &dst)
-        : functionIdentifier(functionIdentifier), args(args), dst(dst) {
-        if (!args) {
-            throw std::logic_error(
-                "Creating FunctionCallInstruction with null args");
-        }
-        if (!dst) {
-            throw std::logic_error(
-                "Creating FunctionCallInstruction with null dst");
-        }
-    }
-    [[nodiscard]] const std::string &getFunctionIdentifier() const {
-        return functionIdentifier;
-    }
-    [[nodiscard]] const std::shared_ptr<std::vector<std::shared_ptr<Value>>> &
-    getArgs() const {
-        return args;
-    }
-    [[nodiscard]] std::shared_ptr<Value> getDst() const { return dst; }
-    void setFunctionIdentifier(std::string_view newFunctionIdentifier) {
-        this->functionIdentifier = newFunctionIdentifier;
-    }
-    void setArgs(
-        const std::shared_ptr<std::vector<std::shared_ptr<Value>>> &newArgs) {
-        if (!newArgs) {
-            throw std::logic_error(
-                "Setting FunctionCallInstruction args to null");
-        }
-        this->args = newArgs;
-    }
-    void setDst(const std::shared_ptr<Value> &newDst) {
-        if (!newDst) {
-            throw std::logic_error(
-                "Setting FunctionCallInstruction dst to null");
-        }
-        this->dst = newDst;
-    }
+        std::unique_ptr<std::vector<std::unique_ptr<Value>>> args,
+        std::unique_ptr<Value> dst);
+    [[nodiscard]] const std::string &getFunctionIdentifier() const;
+    [[nodiscard]] const std::unique_ptr<std::vector<std::unique_ptr<Value>>> &
+    getArgs() const;
+    [[nodiscard]] std::unique_ptr<Value> &getDst();
+    void setFunctionIdentifier(std::string_view newFunctionIdentifier);
+    void setArgs(std::unique_ptr<std::vector<std::unique_ptr<Value>>> newArgs);
+    void setDst(std::unique_ptr<Value> newDst);
 };
 
 class TopLevel {
@@ -461,99 +242,53 @@ class FunctionDefinition : public TopLevel {
   private:
     std::string functionIdentifier;
     bool global;
-    std::shared_ptr<std::vector<std::string>> parameters;
-    std::shared_ptr<std::vector<std::shared_ptr<Instruction>>> functionBody;
+    std::unique_ptr<std::vector<std::string>> parameters;
+    std::unique_ptr<std::vector<std::unique_ptr<Instruction>>> functionBody;
 
   public:
     FunctionDefinition(
         std::string_view functionIdentifier, bool global,
-        const std::shared_ptr<std::vector<std::string>> &parameters,
-        const std::shared_ptr<std::vector<std::shared_ptr<Instruction>>>
-            &functionBody)
-        : functionIdentifier(functionIdentifier), global(global),
-          parameters(parameters), functionBody(functionBody) {
-        if (!parameters) {
-            throw std::logic_error(
-                "Creating FunctionDefinition with null parameters");
-        }
-        if (!functionBody) {
-            throw std::logic_error(
-                "Creating FunctionDefinition with null functionBody");
-        }
-    }
-    [[nodiscard]] const std::string &getFunctionIdentifier() const {
-        return functionIdentifier;
-    }
-    [[nodiscard]] bool isGlobal() const { return global; }
-    [[nodiscard]] const std::shared_ptr<std::vector<std::string>> &
-    getParameterIdentifiers() const {
-        return parameters;
-    }
-    [[nodiscard]] const std::shared_ptr<
-        std::vector<std::shared_ptr<Instruction>>> &
-    getFunctionBody() const {
-        return functionBody;
-    }
-    void setFunctionBody(
-        const std::shared_ptr<std::vector<std::shared_ptr<Instruction>>>
-            &newFunctionBody) {
-        if (!newFunctionBody) {
-            throw std::logic_error(
-                "Setting FunctionDefinition functionBody to null");
-        }
-        this->functionBody = newFunctionBody;
-    }
+        std::unique_ptr<std::vector<std::string>> parameters,
+        std::unique_ptr<std::vector<std::unique_ptr<Instruction>>>
+            functionBody);
+    [[nodiscard]] const std::string &getFunctionIdentifier() const;
+    [[nodiscard]] bool isGlobal() const;
+    [[nodiscard]] const std::unique_ptr<std::vector<std::string>> &
+    getParameterIdentifiers() const;
+    [[nodiscard]] const std::unique_ptr<
+        std::vector<std::unique_ptr<Instruction>>> &
+    getFunctionBody() const;
+    void
+    setFunctionBody(std::unique_ptr<std::vector<std::unique_ptr<Instruction>>>
+                        newFunctionBody);
 };
 
 class StaticVariable : public TopLevel {
   private:
     std::string identifier;
     bool global;
-    std::shared_ptr<AST::Type> type;
-    std::shared_ptr<AST::StaticInit> staticInit;
+    std::unique_ptr<AST::Type> type;
+    std::unique_ptr<AST::StaticInit> staticInit;
 
   public:
     StaticVariable(std::string_view identifier, bool global,
-                   const std::shared_ptr<AST::Type> &type,
-                   const std::shared_ptr<AST::StaticInit> &staticInit)
-        : identifier(identifier), global(global), type(type),
-          staticInit(staticInit) {
-        if (!type) {
-            throw std::logic_error("Creating StaticVariable with null type");
-        }
-        if (!staticInit) {
-            throw std::logic_error(
-                "Creating StaticVariable with null staticInit");
-        }
-    }
-    [[nodiscard]] const std::string &getIdentifier() const {
-        return identifier;
-    }
-    [[nodiscard]] bool isGlobal() const { return global; }
-    [[nodiscard]] std::shared_ptr<AST::Type> getType() const { return type; }
-    [[nodiscard]] std::shared_ptr<AST::StaticInit> getStaticInit() const {
-        return staticInit;
-    }
+                   std::unique_ptr<AST::Type> type,
+                   std::unique_ptr<AST::StaticInit> staticInit);
+    [[nodiscard]] const std::string &getIdentifier() const;
+    [[nodiscard]] bool isGlobal() const;
+    [[nodiscard]] std::unique_ptr<AST::Type> &getType();
+    [[nodiscard]] std::unique_ptr<AST::StaticInit> &getStaticInit();
 };
 
 class Program {
   private:
-    std::shared_ptr<std::vector<std::shared_ptr<TopLevel>>> topLevels;
+    std::unique_ptr<std::vector<std::unique_ptr<TopLevel>>> topLevels;
 
   public:
     explicit Program(
-        const std::shared_ptr<std::vector<std::shared_ptr<TopLevel>>>
-            &topLevels)
-        : topLevels(topLevels) {
-        if (!topLevels) {
-            throw std::logic_error("Creating Program with null topLevels");
-        }
-    }
-    [[nodiscard]] const std::shared_ptr<
-        std::vector<std::shared_ptr<TopLevel>>> &
-    getTopLevels() const {
-        return topLevels;
-    }
+        std::unique_ptr<std::vector<std::unique_ptr<TopLevel>>> topLevels);
+    [[nodiscard]] std::unique_ptr<std::vector<std::unique_ptr<TopLevel>>> &
+    getTopLevels();
 };
 } // namespace IR
 

--- a/src/midend/ir.h
+++ b/src/midend/ir.h
@@ -216,20 +216,18 @@ class LabelInstruction : public Instruction {
 class FunctionCallInstruction : public Instruction {
   private:
     std::string functionIdentifier;
-    std::unique_ptr<std::vector<std::unique_ptr<Value>>> args;
+    std::vector<std::unique_ptr<Value>> args;
     std::unique_ptr<Value> dst;
 
   public:
-    FunctionCallInstruction(
-        std::string_view functionIdentifier,
-        std::unique_ptr<std::vector<std::unique_ptr<Value>>> args,
-        std::unique_ptr<Value> dst);
+    FunctionCallInstruction(std::string_view functionIdentifier,
+                            std::vector<std::unique_ptr<Value>> args,
+                            std::unique_ptr<Value> dst);
     [[nodiscard]] const std::string &getFunctionIdentifier() const;
-    [[nodiscard]] const std::unique_ptr<std::vector<std::unique_ptr<Value>>> &
-    getArgs() const;
+    [[nodiscard]] std::vector<std::unique_ptr<Value>> &getArgs();
     [[nodiscard]] std::unique_ptr<Value> &getDst();
     void setFunctionIdentifier(std::string_view newFunctionIdentifier);
-    void setArgs(std::unique_ptr<std::vector<std::unique_ptr<Value>>> newArgs);
+    void setArgs(std::vector<std::unique_ptr<Value>> newArgs);
     void setDst(std::unique_ptr<Value> newDst);
 };
 
@@ -242,25 +240,19 @@ class FunctionDefinition : public TopLevel {
   private:
     std::string functionIdentifier;
     bool global;
-    std::unique_ptr<std::vector<std::string>> parameters;
-    std::unique_ptr<std::vector<std::unique_ptr<Instruction>>> functionBody;
+    std::vector<std::string> parameters;
+    std::vector<std::unique_ptr<Instruction>> functionBody;
 
   public:
-    FunctionDefinition(
-        std::string_view functionIdentifier, bool global,
-        std::unique_ptr<std::vector<std::string>> parameters,
-        std::unique_ptr<std::vector<std::unique_ptr<Instruction>>>
-            functionBody);
+    FunctionDefinition(std::string_view functionIdentifier, bool global,
+                       std::vector<std::string> parameters,
+                       std::vector<std::unique_ptr<Instruction>> functionBody);
     [[nodiscard]] const std::string &getFunctionIdentifier() const;
     [[nodiscard]] bool isGlobal() const;
-    [[nodiscard]] const std::unique_ptr<std::vector<std::string>> &
-    getParameterIdentifiers() const;
-    [[nodiscard]] const std::unique_ptr<
-        std::vector<std::unique_ptr<Instruction>>> &
-    getFunctionBody() const;
+    [[nodiscard]] std::vector<std::string> &getParameterIdentifiers();
+    [[nodiscard]] std::vector<std::unique_ptr<Instruction>> &getFunctionBody();
     void
-    setFunctionBody(std::unique_ptr<std::vector<std::unique_ptr<Instruction>>>
-                        newFunctionBody);
+    setFunctionBody(std::vector<std::unique_ptr<Instruction>> newFunctionBody);
 };
 
 class StaticVariable : public TopLevel {
@@ -282,13 +274,11 @@ class StaticVariable : public TopLevel {
 
 class Program {
   private:
-    std::unique_ptr<std::vector<std::unique_ptr<TopLevel>>> topLevels;
+    std::vector<std::unique_ptr<TopLevel>> topLevels;
 
   public:
-    explicit Program(
-        std::unique_ptr<std::vector<std::unique_ptr<TopLevel>>> topLevels);
-    [[nodiscard]] std::unique_ptr<std::vector<std::unique_ptr<TopLevel>>> &
-    getTopLevels();
+    explicit Program(std::vector<std::unique_ptr<TopLevel>> topLevels);
+    [[nodiscard]] std::vector<std::unique_ptr<TopLevel>> &getTopLevels();
 };
 } // namespace IR
 

--- a/src/midend/irGenerator.cpp
+++ b/src/midend/irGenerator.cpp
@@ -13,7 +13,7 @@ IRGenerator::generateIR(const std::unique_ptr<AST::Program> &astProgram) {
     std::vector<std::unique_ptr<IR::TopLevel>> topLevels;
 
     // Generate IR instructions for each AST top-level element.
-    auto astDeclarations = astProgram->getDeclarations();
+    auto &astDeclarations = astProgram->getDeclarations();
     for (auto &astDeclaration : astDeclarations) {
         if (dynamic_cast<AST::FunctionDeclaration *>(astDeclaration.get())) {
             auto functionDeclaration =
@@ -175,7 +175,7 @@ void IRGenerator::generateIRBlock(
     std::vector<std::unique_ptr<IR::Instruction>> &instructions) {
 
     // Get the block items from the block.
-    auto blockItems = astBlock->getBlockItems();
+    auto &blockItems = astBlock->getBlockItems();
 
     // Generate IR instructions for each block item.
     for (const auto &blockItem : blockItems) {
@@ -279,14 +279,12 @@ void IRGenerator::generateIRStatement(
     std::unique_ptr<AST::Statement> &astStatement,
     std::vector<std::unique_ptr<IR::Instruction>> &instructions) {
 
-    if (auto returnStmt =
-            dynamic_cast<AST::ReturnStatement *>(astStatement.get())) {
+    if (dynamic_cast<AST::ReturnStatement *>(astStatement.get())) {
         auto returnStmtPtr = std::unique_ptr<AST::ReturnStatement>(
             static_cast<AST::ReturnStatement *>(astStatement.release()));
         generateIRReturnStatement(returnStmtPtr, instructions);
     }
-    else if (auto expressionStmt =
-                 dynamic_cast<AST::ExpressionStatement *>(astStatement.get())) {
+    else if (dynamic_cast<AST::ExpressionStatement *>(astStatement.get())) {
         auto expressionStmtPtr = std::unique_ptr<AST::ExpressionStatement>(
             static_cast<AST::ExpressionStatement *>(astStatement.release()));
         generateIRExpressionStatement(expressionStmtPtr, instructions);
@@ -296,44 +294,37 @@ void IRGenerator::generateIRStatement(
         // If the statement is a compound statement, generate a block.
         generateIRBlock(compoundStmt->getBlock(), instructions);
     }
-    else if (auto ifStmt =
-                 dynamic_cast<AST::IfStatement *>(astStatement.get())) {
+    else if (dynamic_cast<AST::IfStatement *>(astStatement.get())) {
         auto ifStmtPtr = std::unique_ptr<AST::IfStatement>(
             static_cast<AST::IfStatement *>(astStatement.release()));
         generateIRIfStatement(ifStmtPtr, instructions);
     }
-    else if (auto breakStmt =
-                 dynamic_cast<AST::BreakStatement *>(astStatement.get())) {
+    else if (dynamic_cast<AST::BreakStatement *>(astStatement.get())) {
         auto breakStmtPtr = std::unique_ptr<AST::BreakStatement>(
             static_cast<AST::BreakStatement *>(astStatement.release()));
         generateIRBreakStatement(breakStmtPtr, instructions);
     }
-    else if (auto continueStmt =
-                 dynamic_cast<AST::ContinueStatement *>(astStatement.get())) {
+    else if (dynamic_cast<AST::ContinueStatement *>(astStatement.get())) {
         auto continueStmtPtr = std::unique_ptr<AST::ContinueStatement>(
             static_cast<AST::ContinueStatement *>(astStatement.release()));
         generateIRContinueStatement(continueStmtPtr, instructions);
     }
-    else if (auto whileStmt =
-                 dynamic_cast<AST::WhileStatement *>(astStatement.get())) {
+    else if (dynamic_cast<AST::WhileStatement *>(astStatement.get())) {
         auto whileStmtPtr = std::unique_ptr<AST::WhileStatement>(
             static_cast<AST::WhileStatement *>(astStatement.release()));
         generateIRWhileStatement(whileStmtPtr, instructions);
     }
-    else if (auto doWhileStmt =
-                 dynamic_cast<AST::DoWhileStatement *>(astStatement.get())) {
+    else if (dynamic_cast<AST::DoWhileStatement *>(astStatement.get())) {
         auto doWhileStmtPtr = std::unique_ptr<AST::DoWhileStatement>(
             static_cast<AST::DoWhileStatement *>(astStatement.release()));
         generateIRDoWhileStatement(doWhileStmtPtr, instructions);
     }
-    else if (auto forStmt =
-                 dynamic_cast<AST::ForStatement *>(astStatement.get())) {
+    else if (dynamic_cast<AST::ForStatement *>(astStatement.get())) {
         auto forStmtPtr = std::unique_ptr<AST::ForStatement>(
             static_cast<AST::ForStatement *>(astStatement.release()));
         generateIRForStatement(forStmtPtr, instructions);
     }
-    else if (auto nullStmt =
-                 dynamic_cast<AST::NullStatement *>(astStatement.get())) {
+    else if (dynamic_cast<AST::NullStatement *>(astStatement.get())) {
         // If the statement is a null statement, do nothing.
     }
     else {
@@ -365,8 +356,7 @@ void IRGenerator::generateIRExpressionStatement(
 
     // Process the expression and generate the corresponding IR
     // instructions.
-    auto result = generateIRInstruction(exp, instructions);
-    instructions.emplace_back(std::move(result));
+    [[maybe_unused]] auto result = generateIRInstruction(exp, instructions);
 }
 
 void IRGenerator::generateIRIfStatement(
@@ -512,9 +502,8 @@ void IRGenerator::generateIRForStatement(
             static_cast<AST::InitExpr *>(forInit.release()));
         auto optExpr = std::move(initExprPtr->getExpression());
         if (optExpr.has_value()) {
-            auto resolvedExpr =
+            [[maybe_unused]] auto resolvedExpr =
                 generateIRInstruction(optExpr.value(), instructions);
-            instructions.emplace_back(std::move(resolvedExpr));
         }
     }
     else if (dynamic_cast<AST::InitDecl *>(forInit.get())) {
@@ -554,8 +543,8 @@ void IRGenerator::generateIRForStatement(
     // for-statement.
     auto optPost = std::move(forStmt->getOptPost());
     if (optPost.has_value()) {
-        auto postValue = generateIRInstruction(optPost.value(), instructions);
-        instructions.emplace_back(std::move(postValue));
+        [[maybe_unused]] auto postValue =
+            generateIRInstruction(optPost.value(), instructions);
     }
     // Generate a jump instruction with the start label.
     instructions.emplace_back(
@@ -1071,8 +1060,8 @@ IRGenerator::convertFrontendSymbolTableToIRStaticVariables() {
                 std::move(staticAttributePtr->getInitialValue());
             auto global = staticAttributePtr->isGlobal();
             if (dynamic_cast<AST::Initial *>(initialValue.get())) {
-                auto initialPtr = std::move(std::unique_ptr<AST::Initial>(
-                    static_cast<AST::Initial *>(initialValue.release())));
+                auto initialPtr = std::unique_ptr<AST::Initial>(
+                    static_cast<AST::Initial *>(initialValue.release()));
                 auto valueVariant = initialPtr->getStaticInit()->getValue();
                 if (std::holds_alternative<int>(valueVariant)) {
                     irDefs.emplace_back(std::make_unique<StaticVariable>(

--- a/src/midend/irGenerator.h
+++ b/src/midend/irGenerator.h
@@ -16,115 +16,91 @@ namespace IR {
 class IRGenerator {
   public:
     explicit IRGenerator(int variableResolutionCounter);
-    [[nodiscard]] std::pair<
-        std::shared_ptr<IR::Program>,
-        std::shared_ptr<std::vector<std::shared_ptr<IR::StaticVariable>>>>
-    generateIR(const std::shared_ptr<AST::Program> &astProgram);
+    [[nodiscard]] std::pair<std::unique_ptr<IR::Program>,
+                            std::vector<std::unique_ptr<IR::StaticVariable>>>
+    generateIR(const std::unique_ptr<AST::Program> &astProgram);
 
   private:
     int irTemporariesCounter = 0;
-    void generateIRBlock(
-        const std::shared_ptr<AST::Block> &astBlock,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    void generateIRFunctionDefinition(
-        const std::shared_ptr<AST::FunctionDeclaration> &astFunctionDeclaration,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    void generateIRVariableDefinition(
-        const std::shared_ptr<AST::VariableDeclaration> &astVariableDeclaration,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    void generateIRStatement(
-        const std::shared_ptr<AST::Statement> &astStatement,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    void generateIRReturnStatement(
-        const std::shared_ptr<AST::ReturnStatement> &returnStmt,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    void generateIRExpressionStatement(
-        const std::shared_ptr<AST::ExpressionStatement> &expressionStmt,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    void generateIRIfStatement(
-        const std::shared_ptr<AST::IfStatement> &ifStmt,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    void generateIRBreakStatement(
-        const std::shared_ptr<AST::BreakStatement> &breakStmt,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    void generateIRContinueStatement(
-        const std::shared_ptr<AST::ContinueStatement> &continueStmt,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    void generateIRWhileStatement(
-        const std::shared_ptr<AST::WhileStatement> &whileStmt,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    void generateIRDoWhileStatement(
-        const std::shared_ptr<AST::DoWhileStatement> &doWhileStmt,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    void generateIRForStatement(
-        const std::shared_ptr<AST::ForStatement> &forStmt,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    [[nodiscard]] std::shared_ptr<IR::Value> generateIRInstruction(
-        const std::shared_ptr<AST::Expression> &e,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    [[nodiscard]] std::shared_ptr<IR::VariableValue> generateIRUnaryInstruction(
-        const std::shared_ptr<AST::UnaryExpression> &unaryExpr,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    [[nodiscard]] std::shared_ptr<IR::VariableValue>
+    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>> generateIRBlock(
+        std::unique_ptr<AST::Block> &astBlock,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
+    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
+    generateIRFunctionDefinition(
+        std::unique_ptr<AST::FunctionDeclaration> &astFunctionDeclaration,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
+    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
+    generateIRVariableDefinition(
+        std::unique_ptr<AST::VariableDeclaration> &astVariableDeclaration,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
+    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
+    generateIRStatement(
+        std::unique_ptr<AST::Statement> &astStatement,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
+    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
+    generateIRReturnStatement(
+        std::unique_ptr<AST::ReturnStatement> &returnStmt,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
+    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
+    generateIRExpressionStatement(
+        std::unique_ptr<AST::ExpressionStatement> &expressionStmt,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
+    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
+    generateIRIfStatement(
+        std::unique_ptr<AST::IfStatement> &ifStmt,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
+    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
+    generateIRBreakStatement(
+        std::unique_ptr<AST::BreakStatement> &breakStmt,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
+    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
+    generateIRContinueStatement(
+        std::unique_ptr<AST::ContinueStatement> &continueStmt,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
+    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
+    generateIRWhileStatement(
+        std::unique_ptr<AST::WhileStatement> &whileStmt,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
+    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
+    generateIRDoWhileStatement(
+        std::unique_ptr<AST::DoWhileStatement> &doWhileStmt,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
+    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
+    generateIRForStatement(
+        std::unique_ptr<AST::ForStatement> &forStmt,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
+    [[nodiscard]] std::unique_ptr<IR::Value>
+    generateIRInstruction(std::unique_ptr<AST::Expression> &e);
+    [[nodiscard]] std::unique_ptr<IR::VariableValue> generateIRUnaryInstruction(
+        std::unique_ptr<AST::UnaryExpression> &unaryExpr);
+    [[nodiscard]] std::unique_ptr<IR::VariableValue>
     generateIRBinaryInstruction(
-        const std::shared_ptr<AST::BinaryExpression> &binaryExpr,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    [[nodiscard]] std::shared_ptr<IR::VariableValue>
+        std::unique_ptr<AST::BinaryExpression> &binaryExpr);
+    [[nodiscard]] std::unique_ptr<IR::VariableValue>
     generateIRInstructionWithLogicalAnd(
-        const std::shared_ptr<AST::BinaryExpression> &binaryExpr,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    [[nodiscard]] std::shared_ptr<IR::VariableValue>
+        std::unique_ptr<AST::BinaryExpression> &binaryExpr);
+    [[nodiscard]] std::unique_ptr<IR::VariableValue>
     generateIRInstructionWithLogicalOr(
-        const std::shared_ptr<AST::BinaryExpression> &binaryExpr,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    void generateIRCopyInstruction(
-        const std::shared_ptr<IR::Value> &src,
-        const std::shared_ptr<IR::Value> &dst,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    void generateIRJumpInstruction(
-        std::string_view target,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    void generateIRJumpIfZeroInstruction(
-        const std::shared_ptr<IR::Value> &condition, std::string_view target,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    void generateIRJumpIfNotZeroInstruction(
-        const std::shared_ptr<IR::Value> &condition, std::string_view target,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    void generateIRLabelInstruction(
-        std::string_view identifier,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    [[nodiscard]] std::shared_ptr<IR::VariableValue>
+        std::unique_ptr<AST::BinaryExpression> &binaryExpr);
+    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
+    generateIRCopyInstruction(std::unique_ptr<IR::Value> src,
+                              std::unique_ptr<IR::Value> dst);
+    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
+    generateIRJumpInstruction(std::string_view target);
+    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
+    generateIRJumpIfZeroInstruction(std::unique_ptr<IR::Value> condition,
+                                    std::string_view target);
+    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
+    generateIRJumpIfNotZeroInstruction(std::unique_ptr<IR::Value> condition,
+                                       std::string_view target);
+    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
+    generateIRLabelInstruction(std::string_view identifier);
+    [[nodiscard]] std::unique_ptr<IR::VariableValue>
     generateIRFunctionCallInstruction(
         std::string_view functionIdentifier,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Value>>> &args,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
-    [[nodiscard]] std::shared_ptr<IR::VariableValue> generateIRCastInstruction(
-        const std::shared_ptr<AST::CastExpression> &castExpr,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+        std::vector<std::unique_ptr<IR::Value>> &args);
+    [[nodiscard]] std::unique_ptr<IR::VariableValue>
+    generateIRCastInstruction(std::unique_ptr<AST::CastExpression> &castExpr);
     [[nodiscard]] std::string generateIRTemporary();
     [[nodiscard]] std::string generateIRFalseLabel();
     [[nodiscard]] std::string generateIRTrueLabel();
@@ -137,15 +113,15 @@ class IRGenerator {
     [[nodiscard]] std::string
     generateIRBreakLoopLabel(std::string_view loopLabelingLabel) const;
     [[nodiscard]] std::string generateIRStartLabel() const;
-    [[nodiscard]] std::shared_ptr<
-        std::vector<std::shared_ptr<IR::StaticVariable>>>
+    [[nodiscard]]
+    std::vector<std::unique_ptr<IR::StaticVariable>>
     convertFrontendSymbolTableToIRStaticVariables();
-    [[nodiscard]] std::shared_ptr<IR::UnaryOperator>
-    convertUnop(const std::shared_ptr<AST::UnaryOperator> &op);
-    [[nodiscard]] std::shared_ptr<IR::BinaryOperator>
-    convertBinop(const std::shared_ptr<AST::BinaryOperator> &op);
-    [[nodiscard]] std::shared_ptr<IR::VariableValue> generateIRVariable(
-        const std::shared_ptr<AST::BinaryExpression> &binaryExpr);
+    [[nodiscard]] std::unique_ptr<IR::UnaryOperator>
+    convertUnop(std::unique_ptr<AST::UnaryOperator> &op);
+    [[nodiscard]] std::unique_ptr<IR::BinaryOperator>
+    convertBinop(std::unique_ptr<AST::BinaryOperator> &op);
+    [[nodiscard]] std::unique_ptr<IR::VariableValue>
+    generateIRVariable(std::unique_ptr<AST::BinaryExpression> &binaryExpr);
 };
 } // namespace IR
 

--- a/src/midend/irGenerator.h
+++ b/src/midend/irGenerator.h
@@ -22,85 +22,83 @@ class IRGenerator {
 
   private:
     int irTemporariesCounter = 0;
-    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>> generateIRBlock(
-        std::unique_ptr<AST::Block> &astBlock,
+    void generateIRBlock(
+        AST::Block *astBlock,
         std::vector<std::unique_ptr<IR::Instruction>> &instructions);
-    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
-    generateIRFunctionDefinition(
+    void generateIRFunctionDefinition(
         std::unique_ptr<AST::FunctionDeclaration> &astFunctionDeclaration,
         std::vector<std::unique_ptr<IR::Instruction>> &instructions);
-    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
-    generateIRVariableDefinition(
+    void generateIRVariableDefinition(
         std::unique_ptr<AST::VariableDeclaration> &astVariableDeclaration,
         std::vector<std::unique_ptr<IR::Instruction>> &instructions);
-    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
-    generateIRStatement(
+    void generateIRStatement(
         std::unique_ptr<AST::Statement> &astStatement,
         std::vector<std::unique_ptr<IR::Instruction>> &instructions);
-    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
-    generateIRReturnStatement(
+    void generateIRReturnStatement(
         std::unique_ptr<AST::ReturnStatement> &returnStmt,
         std::vector<std::unique_ptr<IR::Instruction>> &instructions);
-    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
-    generateIRExpressionStatement(
+    void generateIRExpressionStatement(
         std::unique_ptr<AST::ExpressionStatement> &expressionStmt,
         std::vector<std::unique_ptr<IR::Instruction>> &instructions);
-    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
-    generateIRIfStatement(
+    void generateIRIfStatement(
         std::unique_ptr<AST::IfStatement> &ifStmt,
         std::vector<std::unique_ptr<IR::Instruction>> &instructions);
-    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
-    generateIRBreakStatement(
+    void generateIRBreakStatement(
         std::unique_ptr<AST::BreakStatement> &breakStmt,
         std::vector<std::unique_ptr<IR::Instruction>> &instructions);
-    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
-    generateIRContinueStatement(
+    void generateIRContinueStatement(
         std::unique_ptr<AST::ContinueStatement> &continueStmt,
         std::vector<std::unique_ptr<IR::Instruction>> &instructions);
-    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
-    generateIRWhileStatement(
+    void generateIRWhileStatement(
         std::unique_ptr<AST::WhileStatement> &whileStmt,
         std::vector<std::unique_ptr<IR::Instruction>> &instructions);
-    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
-    generateIRDoWhileStatement(
+    void generateIRDoWhileStatement(
         std::unique_ptr<AST::DoWhileStatement> &doWhileStmt,
         std::vector<std::unique_ptr<IR::Instruction>> &instructions);
-    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
-    generateIRForStatement(
+    void generateIRForStatement(
         std::unique_ptr<AST::ForStatement> &forStmt,
         std::vector<std::unique_ptr<IR::Instruction>> &instructions);
-    [[nodiscard]] std::unique_ptr<IR::Value>
-    generateIRInstruction(std::unique_ptr<AST::Expression> &e);
+    [[nodiscard]] std::unique_ptr<IR::Value> generateIRInstruction(
+        std::unique_ptr<AST::Expression> &e,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
     [[nodiscard]] std::unique_ptr<IR::VariableValue> generateIRUnaryInstruction(
-        std::unique_ptr<AST::UnaryExpression> &unaryExpr);
+        std::unique_ptr<AST::UnaryExpression> &unaryExpr,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
     [[nodiscard]] std::unique_ptr<IR::VariableValue>
     generateIRBinaryInstruction(
-        std::unique_ptr<AST::BinaryExpression> &binaryExpr);
+        std::unique_ptr<AST::BinaryExpression> &binaryExpr,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
     [[nodiscard]] std::unique_ptr<IR::VariableValue>
     generateIRInstructionWithLogicalAnd(
-        std::unique_ptr<AST::BinaryExpression> &binaryExpr);
+        std::unique_ptr<AST::BinaryExpression> &binaryExpr,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
     [[nodiscard]] std::unique_ptr<IR::VariableValue>
     generateIRInstructionWithLogicalOr(
-        std::unique_ptr<AST::BinaryExpression> &binaryExpr);
-    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
-    generateIRCopyInstruction(std::unique_ptr<IR::Value> src,
-                              std::unique_ptr<IR::Value> dst);
-    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
-    generateIRJumpInstruction(std::string_view target);
-    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
-    generateIRJumpIfZeroInstruction(std::unique_ptr<IR::Value> condition,
-                                    std::string_view target);
-    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
-    generateIRJumpIfNotZeroInstruction(std::unique_ptr<IR::Value> condition,
-                                       std::string_view target);
-    [[nodiscard]] std::vector<std::unique_ptr<IR::Instruction>>
-    generateIRLabelInstruction(std::string_view identifier);
+        std::unique_ptr<AST::BinaryExpression> &binaryExpr,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
+    void generateIRCopyInstruction(
+        std::unique_ptr<IR::Value> src, std::unique_ptr<IR::Value> dst,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
+    void generateIRJumpInstruction(
+        std::string_view target,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
+    void generateIRJumpIfZeroInstruction(
+        std::unique_ptr<IR::Value> condition, std::string_view target,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
+    void generateIRJumpIfNotZeroInstruction(
+        std::unique_ptr<IR::Value> condition, std::string_view target,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
+    void generateIRLabelInstruction(
+        std::string_view identifier,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
     [[nodiscard]] std::unique_ptr<IR::VariableValue>
     generateIRFunctionCallInstruction(
         std::string_view functionIdentifier,
-        std::vector<std::unique_ptr<IR::Value>> &args);
-    [[nodiscard]] std::unique_ptr<IR::VariableValue>
-    generateIRCastInstruction(std::unique_ptr<AST::CastExpression> &castExpr);
+        std::vector<std::unique_ptr<IR::Value>> &args,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
+    [[nodiscard]] std::unique_ptr<IR::VariableValue> generateIRCastInstruction(
+        std::unique_ptr<AST::CastExpression> &castExpr,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
     [[nodiscard]] std::string generateIRTemporary();
     [[nodiscard]] std::string generateIRFalseLabel();
     [[nodiscard]] std::string generateIRTrueLabel();

--- a/src/midend/irOptimizationPasses.h
+++ b/src/midend/irOptimizationPasses.h
@@ -14,10 +14,8 @@
 namespace IR {
 class IROptimizer {
   public:
-    [[nodiscard]] static std::shared_ptr<
-        std::vector<std::shared_ptr<IR::Instruction>>>
-    irOptimize(const std::shared_ptr<std::vector<std::shared_ptr<Instruction>>>
-                   &functionBody,
+    [[nodiscard]] static std::vector<std::unique_ptr<IR::Instruction>>
+    irOptimize(std::vector<std::unique_ptr<IR::Instruction>> &functionBody,
                bool foldConstantsPass, bool propagateCopiesPass,
                bool eliminateUnreachableCodePass, bool eliminateDeadStoresPass);
 };
@@ -29,55 +27,39 @@ class OptimizationPass {
 
 class ConstantFoldingPass : public OptimizationPass {
   public:
-    [[nodiscard]] static std::shared_ptr<
-        std::vector<std::shared_ptr<IR::Instruction>>>
-    foldConstants(
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &functionBody);
+    [[nodiscard]] static std::vector<std::unique_ptr<IR::Instruction>>
+    foldConstants(std::vector<std::unique_ptr<IR::Instruction>> &functionBody);
 };
 
 // TODO(zzmic): CFGs are temporarily of type
-// `std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>`.
+// `std::unique_ptr<std::vector<std::unique_ptr<IR::Instruction>>>`.
 class CFG {
   public:
-    [[nodiscard]] static std::shared_ptr<
-        std::vector<std::shared_ptr<IR::Instruction>>>
+    [[nodiscard]] static std::vector<std::unique_ptr<IR::Instruction>>
     makeControlFlowGraph(
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &functionBody);
+        std::vector<std::unique_ptr<IR::Instruction>> &functionBody);
 
-    [[nodiscard]] static std::shared_ptr<
-        std::vector<std::shared_ptr<IR::Instruction>>>
-    cfgToInstructions(
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &cfg);
+    [[nodiscard]] static std::vector<std::unique_ptr<IR::Instruction>>
+    cfgToInstructions(std::vector<std::unique_ptr<IR::Instruction>> &cfg);
 };
 
 class UnreachableCodeEliminationPass : public OptimizationPass {
   public:
-    [[nodiscard]] static std::shared_ptr<
-        std::vector<std::shared_ptr<IR::Instruction>>>
+    [[nodiscard]] static std::vector<std::unique_ptr<IR::Instruction>>
     eliminateUnreachableCode(
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &cfg);
+        std::vector<std::unique_ptr<IR::Instruction>> &cfg);
 };
 
 class CopyPropagationPass : public OptimizationPass {
   public:
-    [[nodiscard]] static std::shared_ptr<
-        std::vector<std::shared_ptr<IR::Instruction>>>
-    propagateCopies(
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &cfg);
+    [[nodiscard]] static std::vector<std::unique_ptr<IR::Instruction>>
+    propagateCopies(std::vector<std::unique_ptr<IR::Instruction>> &cfg);
 };
 
 class DeadStoreEliminationPass : public OptimizationPass {
   public:
-    [[nodiscard]] static std::shared_ptr<
-        std::vector<std::shared_ptr<IR::Instruction>>>
-    eliminateDeadStores(
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &cfg);
+    [[nodiscard]] static std::vector<std::unique_ptr<IR::Instruction>>
+    eliminateDeadStores(std::vector<std::unique_ptr<IR::Instruction>> &cfg);
 };
 } // namespace IR
 

--- a/src/utils/pipelineStagesExecutors.cpp
+++ b/src/utils/pipelineStagesExecutors.cpp
@@ -113,18 +113,18 @@ PipelineStagesExecutors::semanticAnalysisExecutor(
 }
 
 // Function to generate the IR from the AST program.
-std::pair<std::shared_ptr<IR::Program>,
-          std::shared_ptr<std::vector<std::shared_ptr<IR::StaticVariable>>>>
+std::pair<std::unique_ptr<IR::Program>,
+          std::vector<std::unique_ptr<IR::StaticVariable>>>
 PipelineStagesExecutors::irGeneratorExecutor(
-    const std::shared_ptr<AST::Program> &astProgram,
-    int variableResolutionCounter) {
+    std::unique_ptr<AST::Program> &astProgram, int variableResolutionCounter) {
     std::cout << "\n";
-    std::pair<std::shared_ptr<IR::Program>,
-              std::shared_ptr<std::vector<std::shared_ptr<IR::StaticVariable>>>>
+    std::pair<std::unique_ptr<IR::Program>,
+              std::vector<std::unique_ptr<IR::StaticVariable>>>
         irProgramAndIRStaticVariables;
     try {
         IR::IRGenerator irGenerator(variableResolutionCounter);
-        irProgramAndIRStaticVariables = irGenerator.generateIR(astProgram);
+        irProgramAndIRStaticVariables =
+            irGenerator.generateIR(std::move(astProgram));
     } catch (const std::runtime_error &e) {
         std::stringstream msg;
         msg << "IR generation error: " << e.what();

--- a/src/utils/pipelineStagesExecutors.cpp
+++ b/src/utils/pipelineStagesExecutors.cpp
@@ -135,13 +135,15 @@ PipelineStagesExecutors::irGeneratorExecutor(
 
 // Function to perform optimization passes on the IR program.
 void PipelineStagesExecutors::irOptimizationExecutor(
-    const std::shared_ptr<IR::Program> &irProgram, bool foldConstantsPass,
+    const std::unique_ptr<IR::Program> &irProgram, bool foldConstantsPass,
     bool propagateCopiesPass, bool eliminateUnreachableCodePass,
     bool eliminateDeadStoresPass) {
     auto topLevels = irProgram->getTopLevels();
-    for (auto topLevel : *topLevels) {
-        if (auto functionDefinition =
-                std::dynamic_pointer_cast<IR::FunctionDefinition>(topLevel)) {
+    for (auto &topLevel : topLevels) {
+        if (dynamic_cast<IR::FunctionDefinition *>(topLevel.get())) {
+            auto functionDefinition =
+                std::move(std::unique_ptr<IR::FunctionDefinition>(
+                    static_cast<IR::FunctionDefinition *>(topLevel.release())));
             auto functionBody = functionDefinition->getFunctionBody();
             auto optimizedFunctionBody = IR::IROptimizer::irOptimize(
                 functionBody, foldConstantsPass, propagateCopiesPass,

--- a/src/utils/pipelineStagesExecutors.h
+++ b/src/utils/pipelineStagesExecutors.h
@@ -16,6 +16,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <string.h>
 #include <string_view>
@@ -24,10 +25,10 @@ class PipelineStagesExecutors {
   public:
     [[nodiscard]] static std::vector<Token>
     lexerExecutor(std::string_view sourceFile);
-    [[nodiscard]] static std::shared_ptr<AST::Program>
+    [[nodiscard]] static std::unique_ptr<AST::Program>
     parserExecutor(const std::vector<Token> &tokens);
-    [[nodiscard]] static int
-    semanticAnalysisExecutor(const std::shared_ptr<AST::Program> &astProgram);
+    [[nodiscard]] static std::pair<std::unique_ptr<AST::Program>, int>
+    semanticAnalysisExecutor(std::unique_ptr<AST::Program> &astProgram);
     [[nodiscard]] static std::pair<
         std::shared_ptr<IR::Program>,
         std::shared_ptr<std::vector<std::shared_ptr<IR::StaticVariable>>>>

--- a/src/utils/pipelineStagesExecutors.h
+++ b/src/utils/pipelineStagesExecutors.h
@@ -35,7 +35,7 @@ class PipelineStagesExecutors {
     irGeneratorExecutor(std::unique_ptr<AST::Program> &astProgram,
                         int variableResolutionCounter);
     static void
-    irOptimizationExecutor(const std::shared_ptr<IR::Program> &irProgram,
+    irOptimizationExecutor(const std::unique_ptr<IR::Program> &irProgram,
                            bool foldConstantsPass, bool propagateCopiesPass,
                            bool eliminateUnreachableCodePass,
                            bool eliminateDeadStoresPass);

--- a/src/utils/pipelineStagesExecutors.h
+++ b/src/utils/pipelineStagesExecutors.h
@@ -30,9 +30,9 @@ class PipelineStagesExecutors {
     [[nodiscard]] static std::pair<std::unique_ptr<AST::Program>, int>
     semanticAnalysisExecutor(std::unique_ptr<AST::Program> &astProgram);
     [[nodiscard]] static std::pair<
-        std::shared_ptr<IR::Program>,
-        std::shared_ptr<std::vector<std::shared_ptr<IR::StaticVariable>>>>
-    irGeneratorExecutor(const std::shared_ptr<AST::Program> &astProgram,
+        std::unique_ptr<IR::Program>,
+        std::vector<std::unique_ptr<IR::StaticVariable>>>
+    irGeneratorExecutor(std::unique_ptr<AST::Program> &astProgram,
                         int variableResolutionCounter);
     static void
     irOptimizationExecutor(const std::shared_ptr<IR::Program> &irProgram,

--- a/src/utils/prettyPrinters.h
+++ b/src/utils/prettyPrinters.h
@@ -8,46 +8,35 @@
 class PrettyPrinters {
   public:
     static void printIRProgram(
-        const std::shared_ptr<IR::Program> &irProgram,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::StaticVariable>>>
-            &irStaticVariables);
+        std::unique_ptr<IR::Program> &irProgram,
+        std::vector<std::unique_ptr<IR::StaticVariable>> &irStaticVariables);
     static void printAssemblyProgram(
         const std::shared_ptr<Assembly::Program> &assemblyProgram);
 
   private:
     /* Auxiliary functions for printing the IR program. */
-    static void printIRFunctionDefinition(
-        const std::shared_ptr<IR::FunctionDefinition> &functionDefinition);
-    static void printIRStaticVariable(
-        const std::shared_ptr<IR::StaticVariable> &staticVariable);
     static void
-    printIRInstruction(const std::shared_ptr<IR::Instruction> &instruction);
-    static void printIRReturnInstruction(
-        const std::shared_ptr<IR::ReturnInstruction> &returnInstruction);
+    printIRFunctionDefinition(IR::FunctionDefinition *functionDefinition);
+    static void printIRStaticVariable(IR::StaticVariable *staticVariable);
+    static void printIRInstruction(IR::Instruction *instruction);
+    static void
+    printIRReturnInstruction(IR::ReturnInstruction *returnInstruction);
     static void printIRSignExtendInstruction(
-        const std::shared_ptr<IR::SignExtendInstruction>
-            &signExtendInstruction);
-    static void printIRTruncateInstruction(
-        const std::shared_ptr<IR::TruncateInstruction> &truncateInstruction);
-    static void printIRUnaryInstruction(
-        const std::shared_ptr<IR::UnaryInstruction> &unaryInstruction);
-    static void printIRBinaryInstruction(
-        const std::shared_ptr<IR::BinaryInstruction> &binaryInstruction);
-    static void printIRCopyInstruction(
-        const std::shared_ptr<IR::CopyInstruction> &copyInstruction);
-    static void printIRJumpInstruction(
-        const std::shared_ptr<IR::JumpInstruction> &jumpInstruction);
+        IR::SignExtendInstruction *signExtendInstruction);
+    static void
+    printIRTruncateInstruction(IR::TruncateInstruction *truncateInstruction);
+    static void printIRUnaryInstruction(IR::UnaryInstruction *unaryInstruction);
+    static void
+    printIRBinaryInstruction(IR::BinaryInstruction *binaryInstruction);
+    static void printIRCopyInstruction(IR::CopyInstruction *copyInstruction);
+    static void printIRJumpInstruction(IR::JumpInstruction *jumpInstruction);
     static void printIRJumpIfZeroInstruction(
-        const std::shared_ptr<IR::JumpIfZeroInstruction>
-            &jumpIfZeroInstruction);
+        IR::JumpIfZeroInstruction *jumpIfZeroInstruction);
     static void printIRJumpIfNotZeroInstruction(
-        const std::shared_ptr<IR::JumpIfNotZeroInstruction>
-            &jumpIfNotZeroInstruction);
-    static void printIRLabelInstruction(
-        const std::shared_ptr<IR::LabelInstruction> &labelInstruction);
+        IR::JumpIfNotZeroInstruction *jumpIfNotZeroInstruction);
+    static void printIRLabelInstruction(IR::LabelInstruction *labelInstruction);
     static void printIRFunctionCallInstruction(
-        const std::shared_ptr<IR::FunctionCallInstruction>
-            &functionCallInstruction);
+        IR::FunctionCallInstruction *functionCallInstruction);
 
     /* Auxiliary functions for printing the assembly program. */
     static void printAssyFunctionDefinition(


### PR DESCRIPTION
This pull request primarily works on replacing the usage of `shared_ptr`s with `unique_ptr`s across the codebase. The refactoring would be done in a "sequential" order, meaning refactoring from the frontend to the backend, along with the utilities code.