### PR TITLE
Refactor the codebase to replace the usage of `shared_ptr`s with `unique_ptr`s and/or references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ OBJECTS = $(patsubst $(SRC_DIR)/%.cpp, $(BIN_DIR)/%.o, $(SOURCES))
 
 # Frontend-only sources and objects for compilation checking.
 FRONTEND_SOURCES_ALL = $(wildcard $(FRONTEND_DIR)/*.cpp)
-FRONTEND_SOURCES = $(filter-out $(FRONTEND_DIR)/semanticAnalysisPasses.cpp, $(FRONTEND_SOURCES_ALL))
+FRONTEND_SOURCES = $(FRONTEND_SOURCES_ALL)
 FRONTEND_HEADERS = $(wildcard $(FRONTEND_DIR)/*.h)
 FRONTEND_OBJECTS = $(patsubst $(SRC_DIR)/%.cpp, $(BIN_DIR)/%.o, $(FRONTEND_SOURCES))
 

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,15 @@ HEADERS = $(wildcard $(FRONTEND_DIR)/*.h) \
 
 OBJECTS = $(patsubst $(SRC_DIR)/%.cpp, $(BIN_DIR)/%.o, $(SOURCES))
 
+# Frontend-only sources and objects for compilation checking.
+FRONTEND_SOURCES_ALL = $(wildcard $(FRONTEND_DIR)/*.cpp)
+FRONTEND_SOURCES = $(filter-out $(FRONTEND_DIR)/semanticAnalysisPasses.cpp, $(FRONTEND_SOURCES_ALL))
+FRONTEND_HEADERS = $(wildcard $(FRONTEND_DIR)/*.h)
+FRONTEND_OBJECTS = $(patsubst $(SRC_DIR)/%.cpp, $(BIN_DIR)/%.o, $(FRONTEND_SOURCES))
+
 EXECUTABLE = $(BIN_DIR)/main
 
-.PHONY: all debug release format clean help
+.PHONY: all debug release format clean help frontend-check
 
 all: $(BIN_DIR) $(EXECUTABLE)
 
@@ -74,13 +80,19 @@ format:
 clean:
 	rm -rf $(BIN_DIR)/* $(BIN_DIR)/**/*.d
 
+# Frontend-only compilation check target.
+# This compiles only the frontend sources to verify they compile independently.
+frontend-check: $(BIN_DIR) $(FRONTEND_OBJECTS)
+	@echo "Frontend compilation check passed!"
+
 help:
 	@echo 'Usage: make <target>'
 	@echo
 	@echo 'Targets:'
-	@printf '  %-10s %s\n' 'all' 'Build the main executable ($(EXECUTABLE)).'
-	@printf '  %-10s %s\n' 'debug' 'Build with debug info, sanitizers, and hardening.'
-	@printf '  %-10s %s\n' 'release' 'Build with optimizations for release.'
-	@printf '  %-10s %s\n' 'format' 'Format the code using clang-format.'
-	@printf '  %-10s %s\n' 'clean' 'Remove build artifacts.'
-	@printf '  %-10s %s\n' 'help' 'Show this help message.'
+	@printf '  %-15s %s\n' 'all' 'Build the main executable ($(EXECUTABLE)).'
+	@printf '  %-15s %s\n' 'debug' 'Build with debug info, sanitizers, and hardening.'
+	@printf '  %-15s %s\n' 'release' 'Build with optimizations for release.'
+	@printf '  %-15s %s\n' 'frontend-check' 'Compile frontend sources only (no linking).'
+	@printf '  %-15s %s\n' 'format' 'Format the code using clang-format.'
+	@printf '  %-15s %s\n' 'clean' 'Remove build artifacts.'
+	@printf '  %-15s %s\n' 'help' 'Show this help message.'

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,14 @@ FRONTEND_SOURCES = $(FRONTEND_SOURCES_ALL)
 FRONTEND_HEADERS = $(wildcard $(FRONTEND_DIR)/*.h)
 FRONTEND_OBJECTS = $(patsubst $(SRC_DIR)/%.cpp, $(BIN_DIR)/%.o, $(FRONTEND_SOURCES))
 
+# Frontend + midend compilation check target.
+MIDEND_SOURCES = $(wildcard $(FRONTEND_DIR)/*.cpp) \
+  $(wildcard $(MIDEND_DIR)/*.cpp)
+MIDEND_OBJECTS = $(patsubst $(SRC_DIR)/%.cpp, $(BIN_DIR)/%.o, $(MIDEND_SOURCES))
+
 EXECUTABLE = $(BIN_DIR)/main
 
-.PHONY: all debug release format clean help frontend-check
+.PHONY: all debug release format clean help frontend-check midend-check
 
 all: $(BIN_DIR) $(EXECUTABLE)
 
@@ -85,6 +90,11 @@ clean:
 frontend-check: $(BIN_DIR) $(FRONTEND_OBJECTS)
 	@echo "Frontend compilation check passed!"
 
+# Frontend + midend compilation check target.
+# This compiles the frontend and midend sources (no linking).
+midend-check: $(BIN_DIR) $(MIDEND_OBJECTS)
+	@echo "Frontend + midend compilation check passed!"
+
 help:
 	@echo 'Usage: make <target>'
 	@echo
@@ -93,6 +103,7 @@ help:
 	@printf '  %-15s %s\n' 'debug' 'Build with debug info, sanitizers, and hardening.'
 	@printf '  %-15s %s\n' 'release' 'Build with optimizations for release.'
 	@printf '  %-15s %s\n' 'frontend-check' 'Compile frontend sources only (no linking).'
+	@printf '  %-15s %s\n' 'midend-check' 'Compile frontend + midend sources (no linking).'
 	@printf '  %-15s %s\n' 'format' 'Format the code using clang-format.'
 	@printf '  %-15s %s\n' 'clean' 'Remove build artifacts.'
 	@printf '  %-15s %s\n' 'help' 'Show this help message.'

--- a/src/backend/assembly.h
+++ b/src/backend/assembly.h
@@ -104,15 +104,14 @@ class Operand {
      *
      * @return The register of the operand.
      */
-    [[nodiscard]] virtual std::shared_ptr<Register> getRegister() const;
+    [[nodiscard]] virtual Register *getRegister() const;
 
     /**
      * Get the reserved register of the operand.
      *
      * @return The reserved register of the operand.
      */
-    [[nodiscard]] virtual std::shared_ptr<ReservedRegister>
-    getReservedRegister() const;
+    [[nodiscard]] virtual ReservedRegister *getReservedRegister() const;
 
     /**
      * Get the pseudo register of the operand.
@@ -174,7 +173,7 @@ class RegisterOperand : public Operand {
     /**
      * The register of the operand.
      */
-    std::shared_ptr<Register> reg;
+    std::unique_ptr<Register> reg;
 
     /**
      * The mapping of register sizes to register names.
@@ -223,7 +222,7 @@ class RegisterOperand : public Operand {
      *
      * @param reg The register of the operand.
      */
-    explicit RegisterOperand(std::shared_ptr<Register> reg);
+    explicit RegisterOperand(std::unique_ptr<Register> reg);
 
     /**
      * Constructor for the register operand class.
@@ -232,7 +231,7 @@ class RegisterOperand : public Operand {
      */
     explicit RegisterOperand(std::string regInStr);
 
-    [[nodiscard]] std::shared_ptr<Register> getRegister() const override;
+    [[nodiscard]] Register *getRegister() const override;
 
     [[nodiscard]] std::string getRegisterInBytesInStr(int size) const;
 };
@@ -271,7 +270,7 @@ class StackOperand : public Operand {
     /**
      * The reserved register of the operand.
      */
-    std::shared_ptr<ReservedRegister> reservedReg;
+    std::unique_ptr<ReservedRegister> reservedReg;
 
   public:
     /**
@@ -281,12 +280,11 @@ class StackOperand : public Operand {
      * @param reservedReg The reserved register of the operand.
      */
     explicit StackOperand(int offset,
-                          std::shared_ptr<ReservedRegister> reservedReg);
+                          std::unique_ptr<ReservedRegister> reservedReg);
 
     [[nodiscard]] int getOffset() const override;
 
-    [[nodiscard]] std::shared_ptr<ReservedRegister>
-    getReservedRegister() const override;
+    [[nodiscard]] ReservedRegister *getReservedRegister() const override;
 
     [[nodiscard]] std::string getReservedRegisterInStr() const;
 };
@@ -445,12 +443,12 @@ class MovInstruction : public Instruction {
     /**
      * The type of the instruction.
      */
-    std::shared_ptr<AssemblyType> type;
+    std::unique_ptr<AssemblyType> type;
 
     /**
      * The source and destination operands of the instruction.
      */
-    std::shared_ptr<Operand> src, dst;
+    std::unique_ptr<Operand> src, dst;
 
   public:
     /**
@@ -460,21 +458,21 @@ class MovInstruction : public Instruction {
      * @param src The source operand of the instruction.
      * @param dst The destination operand of the instruction.
      */
-    explicit MovInstruction(std::shared_ptr<AssemblyType> type,
-                            std::shared_ptr<Operand> src,
-                            std::shared_ptr<Operand> dst);
+    explicit MovInstruction(std::unique_ptr<AssemblyType> type,
+                            std::unique_ptr<Operand> src,
+                            std::unique_ptr<Operand> dst);
 
-    [[nodiscard]] std::shared_ptr<AssemblyType> getType();
+    [[nodiscard]] const AssemblyType *getType() const;
 
-    [[nodiscard]] std::shared_ptr<Operand> getSrc();
+    [[nodiscard]] const Operand *getSrc() const;
 
-    [[nodiscard]] std::shared_ptr<Operand> getDst();
+    [[nodiscard]] const Operand *getDst() const;
 
-    void setType(std::shared_ptr<AssemblyType> newType);
+    void setType(std::unique_ptr<AssemblyType> newType);
 
-    void setSrc(std::shared_ptr<Operand> newSrc);
+    void setSrc(std::unique_ptr<Operand> newSrc);
 
-    void setDst(std::shared_ptr<Operand> newDst);
+    void setDst(std::unique_ptr<Operand> newDst);
 };
 
 /**
@@ -485,7 +483,7 @@ class MovsxInstruction : public Instruction {
     /**
      * The source and destination operands of the instruction.
      */
-    std::shared_ptr<Operand> src, dst;
+    std::unique_ptr<Operand> src, dst;
 
   public:
     /**
@@ -494,16 +492,16 @@ class MovsxInstruction : public Instruction {
      * @param src The source operand of the instruction.
      * @param dst The destination operand of the instruction.
      */
-    explicit MovsxInstruction(std::shared_ptr<Operand> src,
-                              std::shared_ptr<Operand> dst);
+    explicit MovsxInstruction(std::unique_ptr<Operand> src,
+                              std::unique_ptr<Operand> dst);
 
-    [[nodiscard]] std::shared_ptr<Operand> getSrc();
+    [[nodiscard]] const Operand *getSrc() const;
 
-    [[nodiscard]] std::shared_ptr<Operand> getDst();
+    [[nodiscard]] const Operand *getDst() const;
 
-    void setSrc(std::shared_ptr<Operand> newSrc);
+    void setSrc(std::unique_ptr<Operand> newSrc);
 
-    void setDst(std::shared_ptr<Operand> newDst);
+    void setDst(std::unique_ptr<Operand> newDst);
 };
 
 /**
@@ -514,17 +512,17 @@ class UnaryInstruction : public Instruction {
     /**
      * The unary operator of the instruction.
      */
-    std::shared_ptr<UnaryOperator> unaryOperator;
+    std::unique_ptr<UnaryOperator> unaryOperator;
 
     /**
      * The type of the instruction.
      */
-    std::shared_ptr<AssemblyType> type;
+    std::unique_ptr<AssemblyType> type;
 
     /**
      * The operand of the instruction.
      */
-    std::shared_ptr<Operand> operand;
+    std::unique_ptr<Operand> operand;
 
   public:
     /**
@@ -534,21 +532,21 @@ class UnaryInstruction : public Instruction {
      * @param type The type of the instruction.
      * @param operand The operand of the instruction.
      */
-    explicit UnaryInstruction(std::shared_ptr<UnaryOperator> unaryOperator,
-                              std::shared_ptr<AssemblyType> type,
-                              std::shared_ptr<Operand> operand);
+    explicit UnaryInstruction(std::unique_ptr<UnaryOperator> unaryOperator,
+                              std::unique_ptr<AssemblyType> type,
+                              std::unique_ptr<Operand> operand);
 
-    [[nodiscard]] std::shared_ptr<UnaryOperator> getUnaryOperator();
+    [[nodiscard]] const UnaryOperator *getUnaryOperator() const;
 
-    [[nodiscard]] std::shared_ptr<AssemblyType> getType();
+    [[nodiscard]] const AssemblyType *getType() const;
 
-    [[nodiscard]] std::shared_ptr<Operand> getOperand();
+    [[nodiscard]] const Operand *getOperand() const;
 
-    void setUnaryOperator(std::shared_ptr<UnaryOperator> newUnaryOperator);
+    void setUnaryOperator(std::unique_ptr<UnaryOperator> newUnaryOperator);
 
-    void setType(std::shared_ptr<AssemblyType> newType);
+    void setType(std::unique_ptr<AssemblyType> newType);
 
-    void setOperand(std::shared_ptr<Operand> newOperand);
+    void setOperand(std::unique_ptr<Operand> newOperand);
 };
 
 /**
@@ -559,17 +557,17 @@ class BinaryInstruction : public Instruction {
     /**
      * The binary operator of the instruction.
      */
-    std::shared_ptr<BinaryOperator> binaryOperator;
+    std::unique_ptr<BinaryOperator> binaryOperator;
 
     /**
      * The type of the instruction.
      */
-    std::shared_ptr<AssemblyType> type;
+    std::unique_ptr<AssemblyType> type;
 
     /**
      * The first and second operands of the instruction.
      */
-    std::shared_ptr<Operand> operand1, operand2;
+    std::unique_ptr<Operand> operand1, operand2;
 
   public:
     /**
@@ -580,26 +578,26 @@ class BinaryInstruction : public Instruction {
      * @param operand1 The first operand of the instruction.
      * @param operand2 The second operand of the instruction.
      */
-    explicit BinaryInstruction(std::shared_ptr<BinaryOperator> binaryOperator,
-                               std::shared_ptr<AssemblyType> type,
-                               std::shared_ptr<Operand> operand1,
-                               std::shared_ptr<Operand> operand2);
+    explicit BinaryInstruction(std::unique_ptr<BinaryOperator> binaryOperator,
+                               std::unique_ptr<AssemblyType> type,
+                               std::unique_ptr<Operand> operand1,
+                               std::unique_ptr<Operand> operand2);
 
-    [[nodiscard]] std::shared_ptr<BinaryOperator> getBinaryOperator();
+    [[nodiscard]] const BinaryOperator *getBinaryOperator() const;
 
-    [[nodiscard]] std::shared_ptr<AssemblyType> getType();
+    [[nodiscard]] const AssemblyType *getType() const;
 
-    [[nodiscard]] std::shared_ptr<Operand> getOperand1();
+    [[nodiscard]] const Operand *getOperand1() const;
 
-    [[nodiscard]] std::shared_ptr<Operand> getOperand2();
+    [[nodiscard]] const Operand *getOperand2() const;
 
-    void setBinaryOperator(std::shared_ptr<BinaryOperator> newBinaryOperator);
+    void setBinaryOperator(std::unique_ptr<BinaryOperator> newBinaryOperator);
 
-    void setType(std::shared_ptr<AssemblyType> newType);
+    void setType(std::unique_ptr<AssemblyType> newType);
 
-    void setOperand1(std::shared_ptr<Operand> newOperand1);
+    void setOperand1(std::unique_ptr<Operand> newOperand1);
 
-    void setOperand2(std::shared_ptr<Operand> newOperand2);
+    void setOperand2(std::unique_ptr<Operand> newOperand2);
 };
 
 /**
@@ -610,12 +608,12 @@ class CmpInstruction : public Instruction {
     /**
      * The type of the instruction.
      */
-    std::shared_ptr<AssemblyType> type;
+    std::unique_ptr<AssemblyType> type;
 
     /**
      * The first and second operands of the instruction.
      */
-    std::shared_ptr<Operand> operand1, operand2;
+    std::unique_ptr<Operand> operand1, operand2;
 
   public:
     /**
@@ -625,21 +623,21 @@ class CmpInstruction : public Instruction {
      * @param operand1 The first operand of the instruction.
      * @param operand2 The second operand of the instruction.
      */
-    explicit CmpInstruction(std::shared_ptr<AssemblyType> type,
-                            std::shared_ptr<Operand> operand1,
-                            std::shared_ptr<Operand> operand2);
+    explicit CmpInstruction(std::unique_ptr<AssemblyType> type,
+                            std::unique_ptr<Operand> operand1,
+                            std::unique_ptr<Operand> operand2);
 
-    [[nodiscard]] std::shared_ptr<AssemblyType> getType();
+    [[nodiscard]] const AssemblyType *getType() const;
 
-    [[nodiscard]] std::shared_ptr<Operand> getOperand1();
+    [[nodiscard]] const Operand *getOperand1() const;
 
-    [[nodiscard]] std::shared_ptr<Operand> getOperand2();
+    [[nodiscard]] const Operand *getOperand2() const;
 
-    void setType(std::shared_ptr<AssemblyType> newType);
+    void setType(std::unique_ptr<AssemblyType> newType);
 
-    void setOperand1(std::shared_ptr<Operand> newOperand1);
+    void setOperand1(std::unique_ptr<Operand> newOperand1);
 
-    void setOperand2(std::shared_ptr<Operand> newOperand2);
+    void setOperand2(std::unique_ptr<Operand> newOperand2);
 };
 
 /**
@@ -650,12 +648,12 @@ class IdivInstruction : public Instruction {
     /**
      * The type of the instruction.
      */
-    std::shared_ptr<AssemblyType> type;
+    std::unique_ptr<AssemblyType> type;
 
     /**
      * The operand of the instruction.
      */
-    std::shared_ptr<Operand> operand;
+    std::unique_ptr<Operand> operand;
 
   public:
     /**
@@ -664,16 +662,16 @@ class IdivInstruction : public Instruction {
      * @param type The type of the instruction.
      * @param operand The operand of the instruction.
      */
-    explicit IdivInstruction(std::shared_ptr<AssemblyType> type,
-                             std::shared_ptr<Operand> operand);
+    explicit IdivInstruction(std::unique_ptr<AssemblyType> type,
+                             std::unique_ptr<Operand> operand);
 
-    [[nodiscard]] std::shared_ptr<AssemblyType> getType();
+    [[nodiscard]] const AssemblyType *getType() const;
 
-    [[nodiscard]] std::shared_ptr<Operand> getOperand();
+    [[nodiscard]] const Operand *getOperand() const;
 
-    void setType(std::shared_ptr<AssemblyType> newType);
+    void setType(std::unique_ptr<AssemblyType> newType);
 
-    void setOperand(std::shared_ptr<Operand> newOperand);
+    void setOperand(std::unique_ptr<Operand> newOperand);
 };
 
 /**
@@ -684,7 +682,7 @@ class CdqInstruction : public Instruction {
     /**
      * The type of the instruction.
      */
-    std::shared_ptr<AssemblyType> type;
+    std::unique_ptr<AssemblyType> type;
 
   public:
     /**
@@ -692,11 +690,11 @@ class CdqInstruction : public Instruction {
      *
      * @param type The type of the instruction.
      */
-    explicit CdqInstruction(std::shared_ptr<AssemblyType> type);
+    explicit CdqInstruction(std::unique_ptr<AssemblyType> type);
 
-    [[nodiscard]] std::shared_ptr<AssemblyType> getType();
+    [[nodiscard]] const AssemblyType *getType() const;
 
-    void setType(std::shared_ptr<AssemblyType> newType);
+    void setType(std::unique_ptr<AssemblyType> newType);
 };
 
 /**
@@ -717,7 +715,7 @@ class JmpInstruction : public Instruction {
      */
     explicit JmpInstruction(std::string label);
 
-    [[nodiscard]] std::string getLabel();
+    [[nodiscard]] std::string getLabel() const;
 
     void setLabel(std::string newLabel);
 };
@@ -730,7 +728,7 @@ class JmpCCInstruction : public Instruction {
     /**
      * The condition code of the instruction.
      */
-    std::shared_ptr<CondCode> condCode;
+    std::unique_ptr<CondCode> condCode;
 
     /**
      * The label of the instruction.
@@ -744,14 +742,14 @@ class JmpCCInstruction : public Instruction {
      * @param condCode The condition code of the instruction.
      * @param label The label of the instruction.
      */
-    explicit JmpCCInstruction(std::shared_ptr<CondCode> condCode,
+    explicit JmpCCInstruction(std::unique_ptr<CondCode> condCode,
                               std::string label);
 
-    [[nodiscard]] std::shared_ptr<CondCode> getCondCode();
+    [[nodiscard]] const CondCode *getCondCode() const;
 
-    [[nodiscard]] std::string getLabel();
+    [[nodiscard]] std::string getLabel() const;
 
-    void setCondCode(std::shared_ptr<CondCode> newCondCode);
+    void setCondCode(std::unique_ptr<CondCode> newCondCode);
 
     void setLabel(std::string newLabel);
 };
@@ -764,12 +762,12 @@ class SetCCInstruction : public Instruction {
     /**
      * The condition code of the instruction.
      */
-    std::shared_ptr<CondCode> condCode;
+    std::unique_ptr<CondCode> condCode;
 
     /**
      * The operand of the instruction.
      */
-    std::shared_ptr<Operand> operand;
+    std::unique_ptr<Operand> operand;
 
   public:
     /**
@@ -778,16 +776,16 @@ class SetCCInstruction : public Instruction {
      * @param condCode The condition code of the instruction.
      * @param operand The operand of the instruction.
      */
-    explicit SetCCInstruction(std::shared_ptr<CondCode> condCode,
-                              std::shared_ptr<Operand> operand);
+    explicit SetCCInstruction(std::unique_ptr<CondCode> condCode,
+                              std::unique_ptr<Operand> operand);
 
-    [[nodiscard]] std::shared_ptr<CondCode> getCondCode();
+    [[nodiscard]] const CondCode *getCondCode() const;
 
-    [[nodiscard]] std::shared_ptr<Operand> getOperand();
+    [[nodiscard]] const Operand *getOperand() const;
 
-    void setCondCode(std::shared_ptr<CondCode> newCondCode);
+    void setCondCode(std::unique_ptr<CondCode> newCondCode);
 
-    void setOperand(std::shared_ptr<Operand> newOperand);
+    void setOperand(std::unique_ptr<Operand> newOperand);
 };
 
 /**
@@ -808,7 +806,7 @@ class LabelInstruction : public Instruction {
      */
     explicit LabelInstruction(std::string label);
 
-    [[nodiscard]] std::string getLabel();
+    [[nodiscard]] std::string getLabel() const;
 
     void setLabel(std::string newLabel);
 };
@@ -821,7 +819,7 @@ class PushInstruction : public Instruction {
     /**
      * The operand of the instruction.
      */
-    std::shared_ptr<Operand> operand;
+    std::unique_ptr<Operand> operand;
 
   public:
     /**
@@ -829,11 +827,11 @@ class PushInstruction : public Instruction {
      *
      * @param operand The operand of the instruction.
      */
-    explicit PushInstruction(std::shared_ptr<Operand> operand);
+    explicit PushInstruction(std::unique_ptr<Operand> operand);
 
-    [[nodiscard]] std::shared_ptr<Operand> getOperand();
+    [[nodiscard]] const Operand *getOperand() const;
 
-    void setOperand(std::shared_ptr<Operand> newOperand);
+    void setOperand(std::unique_ptr<Operand> newOperand);
 };
 
 /**
@@ -854,7 +852,7 @@ class CallInstruction : public Instruction {
      */
     explicit CallInstruction(std::string functionIdentifier);
 
-    [[nodiscard]] std::string getFunctionIdentifier();
+    [[nodiscard]] std::string getFunctionIdentifier() const;
 };
 
 /**
@@ -891,7 +889,7 @@ class FunctionDefinition : public TopLevel {
     /**
      * The function body of the function definition.
      */
-    std::shared_ptr<std::vector<std::shared_ptr<Instruction>>> functionBody;
+    std::unique_ptr<std::vector<std::unique_ptr<Instruction>>> functionBody;
 
     /**
      * The stack size of the function definition.
@@ -911,21 +909,23 @@ class FunctionDefinition : public TopLevel {
      */
     explicit FunctionDefinition(
         std::string functionIdentifier, bool global,
-        std::shared_ptr<std::vector<std::shared_ptr<Instruction>>> functionBody,
+        std::unique_ptr<std::vector<std::unique_ptr<Instruction>>> functionBody,
         size_t stackSize);
 
-    [[nodiscard]] std::string getFunctionIdentifier();
+    [[nodiscard]] std::string getFunctionIdentifier() const;
 
-    [[nodiscard]] bool isGlobal();
+    [[nodiscard]] bool isGlobal() const;
 
-    [[nodiscard]] std::shared_ptr<std::vector<std::shared_ptr<Instruction>>>
-    getFunctionBody();
+    [[nodiscard]] const std::vector<std::unique_ptr<Instruction>> &
+    getFunctionBody() const;
+
+    [[nodiscard]] std::vector<std::unique_ptr<Instruction>> &getFunctionBody();
 
     void
-    setFunctionBody(std::shared_ptr<std::vector<std::shared_ptr<Instruction>>>
+    setFunctionBody(std::unique_ptr<std::vector<std::unique_ptr<Instruction>>>
                         newFunctionBody);
 
-    [[nodiscard]] size_t getStackSize();
+    [[nodiscard]] size_t getStackSize() const;
 
     void setStackSize(size_t newStackSize);
 };
@@ -953,7 +953,7 @@ class StaticVariable : public TopLevel {
     /**
      * The static initialization of the static variable.
      */
-    std::shared_ptr<AST::StaticInit> staticInit;
+    std::unique_ptr<AST::StaticInit> staticInit;
 
   public:
     /**
@@ -965,19 +965,19 @@ class StaticVariable : public TopLevel {
      * @param staticInit The static initialization of the static variable.
      */
     explicit StaticVariable(std::string identifier, bool global, int alignment,
-                            std::shared_ptr<AST::StaticInit> staticInit);
+                            std::unique_ptr<AST::StaticInit> staticInit);
 
-    [[nodiscard]] std::string getIdentifier();
+    [[nodiscard]] std::string getIdentifier() const;
 
-    [[nodiscard]] bool isGlobal();
+    [[nodiscard]] bool isGlobal() const;
 
-    [[nodiscard]] int getAlignment();
+    [[nodiscard]] int getAlignment() const;
 
     void setAlignment(int newAlignment);
 
-    [[nodiscard]] std::shared_ptr<AST::StaticInit> getStaticInit();
+    [[nodiscard]] const AST::StaticInit *getStaticInit() const;
 
-    void setStaticInit(std::shared_ptr<AST::StaticInit> newStaticInit);
+    void setStaticInit(std::unique_ptr<AST::StaticInit> newStaticInit);
 };
 
 /**
@@ -988,7 +988,7 @@ class Program {
     /**
      * The top-levels of the program.
      */
-    std::shared_ptr<std::vector<std::shared_ptr<TopLevel>>> topLevels;
+    std::unique_ptr<std::vector<std::unique_ptr<TopLevel>>> topLevels;
 
   public:
     /**
@@ -997,13 +997,15 @@ class Program {
      * @param topLevels The top-levels of the program.
      */
     explicit Program(
-        std::shared_ptr<std::vector<std::shared_ptr<TopLevel>>> topLevels);
+        std::unique_ptr<std::vector<std::unique_ptr<TopLevel>>> topLevels);
 
-    [[nodiscard]] std::shared_ptr<std::vector<std::shared_ptr<TopLevel>>>
-    getTopLevels();
+    [[nodiscard]] const std::vector<std::unique_ptr<TopLevel>> &
+    getTopLevels() const;
+
+    [[nodiscard]] std::vector<std::unique_ptr<TopLevel>> &getTopLevels();
 
     void setTopLevels(
-        std::shared_ptr<std::vector<std::shared_ptr<TopLevel>>> newTopLevels);
+        std::unique_ptr<std::vector<std::unique_ptr<TopLevel>>> newTopLevels);
 };
 } // namespace Assembly
 

--- a/src/backend/assemblyGenerator.cpp
+++ b/src/backend/assemblyGenerator.cpp
@@ -6,26 +6,25 @@
 
 namespace Assembly {
 AssemblyGenerator::AssemblyGenerator(
-    std::shared_ptr<std::vector<std::shared_ptr<IR::StaticVariable>>>
-        irStaticVariables,
+    const std::vector<std::unique_ptr<IR::StaticVariable>> &irStaticVariables,
     const AST::FrontendSymbolTable &frontendSymbolTable)
     : irStaticVariables(irStaticVariables),
       frontendSymbolTable(frontendSymbolTable) {}
 
 std::shared_ptr<Assembly::Program>
-AssemblyGenerator::generateAssembly(std::shared_ptr<IR::Program> irProgram) {
-    auto irTopLevels = irProgram->getTopLevels();
+AssemblyGenerator::generateAssembly(const IR::Program &irProgram) {
+    auto &irTopLevels = irProgram.getTopLevels();
     auto assyTopLevels =
         std::make_shared<std::vector<std::shared_ptr<TopLevel>>>();
 
     // Generate assembly instructions for each IR top-level function definition.
-    for (auto irTopLevel : *irTopLevels) {
-        if (auto irFunctionDefinition =
-                std::dynamic_pointer_cast<IR::FunctionDefinition>(irTopLevel)) {
+    for (const auto &irTopLevel : irTopLevels) {
+        if (auto *irFunctionDefinition =
+                dynamic_cast<IR::FunctionDefinition *>(irTopLevel.get())) {
             auto instructions = std::make_shared<
                 std::vector<std::shared_ptr<Assembly::Instruction>>>();
             auto assyFunctionDefinition = convertIRFunctionDefinitionToAssy(
-                irFunctionDefinition, instructions);
+                *irFunctionDefinition, instructions);
             assyTopLevels->emplace_back(assyFunctionDefinition);
         }
         else {
@@ -35,9 +34,9 @@ AssemblyGenerator::generateAssembly(std::shared_ptr<IR::Program> irProgram) {
 
     // Generate assembly instructions for each IR (either top-level or local)
     // static variable.
-    for (auto irStaticVariable : *irStaticVariables) {
+    for (const auto &irStaticVariable : irStaticVariables) {
         auto assyStaticVariable =
-            convertIRStaticVariableToAssy(irStaticVariable);
+            convertIRStaticVariableToAssy(*irStaticVariable);
         assyTopLevels->emplace_back(assyStaticVariable);
     }
 
@@ -46,22 +45,22 @@ AssemblyGenerator::generateAssembly(std::shared_ptr<IR::Program> irProgram) {
 
 std::shared_ptr<Assembly::FunctionDefinition>
 AssemblyGenerator::convertIRFunctionDefinitionToAssy(
-    std::shared_ptr<IR::FunctionDefinition> irFunctionDefinition,
+    const IR::FunctionDefinition &irFunctionDefinition,
     std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
         instructions) {
-    auto functionIdentifier = irFunctionDefinition->getFunctionIdentifier();
-    auto functionGlobal = irFunctionDefinition->isGlobal();
-    auto functionBody = irFunctionDefinition->getFunctionBody();
+    auto functionIdentifier = irFunctionDefinition.getFunctionIdentifier();
+    auto functionGlobal = irFunctionDefinition.isGlobal();
+    auto &functionBody = irFunctionDefinition.getFunctionBody();
 
     // Generate instructions to move parameters from registers to the
     // stack.
-    auto irParameters = irFunctionDefinition->getParameterIdentifiers();
-    if (irParameters->size() > 0) {
+    auto &irParameters = irFunctionDefinition.getParameterIdentifiers();
+    if (!irParameters.empty()) {
         std::vector<std::string> argRegistersInStr = {"DI", "SI", "DX",
                                                       "CX", "R8", "R9"};
         size_t registerIndex = 0;
-        for (size_t i = 0; i < irParameters->size(); ++i) {
-            auto irParam = irParameters->at(i);
+        for (size_t i = 0; i < irParameters.size(); ++i) {
+            auto irParam = irParameters.at(i);
             auto irParamOperand =
                 std::make_shared<Assembly::PseudoRegisterOperand>(irParam);
             if (i < 6) { // First six parameters from registers.
@@ -70,8 +69,8 @@ AssemblyGenerator::convertIRFunctionDefinitionToAssy(
                         argRegistersInStr[registerIndex]);
                 // Determine assembly type based on the parameter type from the
                 // symbol table.
-                auto assemblyType = determineAssemblyType(
-                    std::make_shared<IR::VariableValue>(irParam));
+                IR::VariableValue irParamValue(irParam);
+                auto assemblyType = determineAssemblyType(&irParamValue);
                 // Generate a `Mov` instruction to move the
                 // parameter from the register to the stack.
                 instructions->emplace_back(
@@ -90,8 +89,8 @@ AssemblyGenerator::convertIRFunctionDefinitionToAssy(
                     stackOffset, std::make_shared<Assembly::BP>());
                 // Determine assembly type based on the parameter type from the
                 // symbol table.
-                auto assemblyType = determineAssemblyType(
-                    std::make_shared<IR::VariableValue>(irParam));
+                IR::VariableValue irParamValue(irParam);
+                auto assemblyType = determineAssemblyType(&irParamValue);
                 // Generate a `Mov` instruction to move the
                 // parameter from the stack to the register.
                 instructions->emplace_back(
@@ -107,8 +106,8 @@ AssemblyGenerator::convertIRFunctionDefinitionToAssy(
         functionIdentifier, functionGlobal, instructions, 0);
 
     // Generate assembly instructions for the function body.
-    for (auto irInstruction : *functionBody) {
-        convertIRInstructionToAssy(irInstruction,
+    for (const auto &irInstruction : functionBody) {
+        convertIRInstructionToAssy(*irInstruction,
                                    assyFunctionDefinition->getFunctionBody());
     }
 
@@ -117,20 +116,23 @@ AssemblyGenerator::convertIRFunctionDefinitionToAssy(
 
 std::shared_ptr<Assembly::StaticVariable>
 AssemblyGenerator::convertIRStaticVariableToAssy(
-    std::shared_ptr<IR::StaticVariable> irStaticVariable) {
-    auto identifier = irStaticVariable->getIdentifier();
-    auto global = irStaticVariable->isGlobal();
-    auto staticInit = irStaticVariable->getStaticInit();
+    const IR::StaticVariable &irStaticVariable) {
+    auto identifier = irStaticVariable.getIdentifier();
+    auto global = irStaticVariable.isGlobal();
+    auto staticInit = irStaticVariable.getStaticInit();
 
     // Convert the static initializer to an assembly static variable.
-    if (auto constInt = std::dynamic_pointer_cast<AST::IntInit>(staticInit)) {
+    if (auto constInt = dynamic_cast<const AST::IntInit *>(staticInit)) {
+        auto assyInit =
+            std::make_shared<AST::IntInit>(std::get<int>(constInt->getValue()));
         return std::make_shared<StaticVariable>(identifier, global, 4,
-                                                staticInit);
+                                                assyInit);
     }
-    else if (auto constLong =
-                 std::dynamic_pointer_cast<AST::LongInit>(staticInit)) {
+    else if (auto constLong = dynamic_cast<const AST::LongInit *>(staticInit)) {
+        auto assyInit = std::make_shared<AST::LongInit>(
+            std::get<long>(constLong->getValue()));
         return std::make_shared<StaticVariable>(identifier, global, 8,
-                                                staticInit);
+                                                assyInit);
     }
     else {
         throw std::logic_error("Unsupported static initializer type");
@@ -138,59 +140,58 @@ AssemblyGenerator::convertIRStaticVariableToAssy(
 }
 
 void AssemblyGenerator::convertIRInstructionToAssy(
-    std::shared_ptr<IR::Instruction> irInstruction,
+    const IR::Instruction &irInstruction,
     std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
         instructions) {
     if (auto returnInstr =
-            std::dynamic_pointer_cast<IR::ReturnInstruction>(irInstruction)) {
-        convertIRReturnInstructionToAssy(returnInstr, instructions);
+            dynamic_cast<const IR::ReturnInstruction *>(&irInstruction)) {
+        convertIRReturnInstructionToAssy(*returnInstr, instructions);
     }
-    else if (auto unaryInstr = std::dynamic_pointer_cast<IR::UnaryInstruction>(
-                 irInstruction)) {
-        convertIRUnaryInstructionToAssy(unaryInstr, instructions);
+    else if (auto unaryInstr =
+                 dynamic_cast<const IR::UnaryInstruction *>(&irInstruction)) {
+        convertIRUnaryInstructionToAssy(*unaryInstr, instructions);
     }
     else if (auto binaryInstr =
-                 std::dynamic_pointer_cast<IR::BinaryInstruction>(
-                     irInstruction)) {
-        convertIRBinaryInstructionToAssy(binaryInstr, instructions);
+                 dynamic_cast<const IR::BinaryInstruction *>(&irInstruction)) {
+        convertIRBinaryInstructionToAssy(*binaryInstr, instructions);
     }
-    else if (auto copyInstr = std::dynamic_pointer_cast<IR::CopyInstruction>(
-                 irInstruction)) {
-        convertIRCopyInstructionToAssy(copyInstr, instructions);
+    else if (auto copyInstr =
+                 dynamic_cast<const IR::CopyInstruction *>(&irInstruction)) {
+        convertIRCopyInstructionToAssy(*copyInstr, instructions);
     }
-    else if (auto jumpInstr = std::dynamic_pointer_cast<IR::JumpInstruction>(
-                 irInstruction)) {
-        convertIRJumpInstructionToAssy(jumpInstr, instructions);
+    else if (auto jumpInstr =
+                 dynamic_cast<const IR::JumpInstruction *>(&irInstruction)) {
+        convertIRJumpInstructionToAssy(*jumpInstr, instructions);
     }
     else if (auto jumpIfZeroInstr =
-                 std::dynamic_pointer_cast<IR::JumpIfZeroInstruction>(
-                     irInstruction)) {
-        convertIRJumpIfZeroInstructionToAssy(jumpIfZeroInstr, instructions);
+                 dynamic_cast<const IR::JumpIfZeroInstruction *>(
+                     &irInstruction)) {
+        convertIRJumpIfZeroInstructionToAssy(*jumpIfZeroInstr, instructions);
     }
     else if (auto jumpIfNotZeroInstr =
-                 std::dynamic_pointer_cast<IR::JumpIfNotZeroInstruction>(
-                     irInstruction)) {
-        convertIRJumpIfNotZeroInstructionToAssy(jumpIfNotZeroInstr,
+                 dynamic_cast<const IR::JumpIfNotZeroInstruction *>(
+                     &irInstruction)) {
+        convertIRJumpIfNotZeroInstructionToAssy(*jumpIfNotZeroInstr,
                                                 instructions);
     }
-    else if (auto labelInstr = std::dynamic_pointer_cast<IR::LabelInstruction>(
-                 irInstruction)) {
-        convertIRLabelInstructionToAssy(labelInstr, instructions);
+    else if (auto labelInstr =
+                 dynamic_cast<const IR::LabelInstruction *>(&irInstruction)) {
+        convertIRLabelInstructionToAssy(*labelInstr, instructions);
     }
     else if (auto functionCallInstr =
-                 std::dynamic_pointer_cast<IR::FunctionCallInstruction>(
-                     irInstruction)) {
-        convertIRFunctionCallInstructionToAssy(functionCallInstr, instructions);
+                 dynamic_cast<const IR::FunctionCallInstruction *>(
+                     &irInstruction)) {
+        convertIRFunctionCallInstructionToAssy(*functionCallInstr,
+                                               instructions);
     }
     else if (auto signExtendInstr =
-                 std::dynamic_pointer_cast<IR::SignExtendInstruction>(
-                     irInstruction)) {
-        convertIRSignExtendInstructionToAssy(signExtendInstr, instructions);
+                 dynamic_cast<const IR::SignExtendInstruction *>(
+                     &irInstruction)) {
+        convertIRSignExtendInstructionToAssy(*signExtendInstr, instructions);
     }
-    else if (auto truncateInstr =
-                 std::dynamic_pointer_cast<IR::TruncateInstruction>(
-                     irInstruction)) {
-        convertIRTruncateInstructionToAssy(truncateInstr, instructions);
+    else if (auto truncateInstr = dynamic_cast<const IR::TruncateInstruction *>(
+                 &irInstruction)) {
+        convertIRTruncateInstructionToAssy(*truncateInstr, instructions);
     }
     else {
         throw std::logic_error("Unsupported IR instruction type");
@@ -198,13 +199,13 @@ void AssemblyGenerator::convertIRInstructionToAssy(
 }
 
 void AssemblyGenerator::convertIRReturnInstructionToAssy(
-    std::shared_ptr<IR::ReturnInstruction> returnInstr,
+    const IR::ReturnInstruction &returnInstr,
     std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
         instructions) {
-    auto returnValue = convertValue(returnInstr->getReturnValue());
+    auto returnValue = convertValue(returnInstr.getReturnValue());
 
     // Determine the assembly type based on the return value.
-    auto assemblyType = determineAssemblyType(returnInstr->getReturnValue());
+    auto assemblyType = determineAssemblyType(returnInstr.getReturnValue());
 
     // Move the return value into the `AX` register.
     auto axReg = std::make_shared<Assembly::AX>();
@@ -217,24 +218,23 @@ void AssemblyGenerator::convertIRReturnInstructionToAssy(
 }
 
 void AssemblyGenerator::convertIRUnaryInstructionToAssy(
-    std::shared_ptr<IR::UnaryInstruction> unaryInstr,
+    const IR::UnaryInstruction &unaryInstr,
     std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
         instructions) {
     // Convert the source and destination operands to assembly operands.
-    auto srcOperand = convertValue(unaryInstr->getSrc());
-    auto dstOperand = convertValue(unaryInstr->getDst());
+    auto srcOperand = convertValue(unaryInstr.getSrc());
+    auto dstOperand = convertValue(unaryInstr.getDst());
 
     // Determine the assembly type of the source operand and the destination
     // operand based on the source and destination operands.
-    auto srcAssemblyType = determineAssemblyType(unaryInstr->getSrc());
-    auto dstAssemblyType = determineAssemblyType(unaryInstr->getDst());
+    auto srcAssemblyType = determineAssemblyType(unaryInstr.getSrc());
+    auto dstAssemblyType = determineAssemblyType(unaryInstr.getDst());
 
     // Get the unary operator from the IR unary instruction.
-    auto unaryIROperator = unaryInstr->getUnaryOperator();
+    auto unaryIROperator = unaryInstr.getUnaryOperator();
 
     // Generate the assembly instructions based on the unary operator.
-    if (auto notOperator =
-            std::dynamic_pointer_cast<IR::NotOperator>(unaryIROperator)) {
+    if (dynamic_cast<const IR::NotOperator *>(unaryIROperator)) {
         instructions->emplace_back(std::make_shared<Assembly::CmpInstruction>(
             srcAssemblyType, std::make_shared<Assembly::ImmediateOperand>(0),
             srcOperand));
@@ -249,16 +249,14 @@ void AssemblyGenerator::convertIRUnaryInstructionToAssy(
         instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
             srcAssemblyType, srcOperand, dstOperand));
         // Generate the assembly instructions based on the unary operator.
-        if (auto negateOperator = std::dynamic_pointer_cast<IR::NegateOperator>(
-                unaryIROperator)) {
+        if (dynamic_cast<const IR::NegateOperator *>(unaryIROperator)) {
             instructions->emplace_back(
                 std::make_shared<Assembly::UnaryInstruction>(
                     std::make_shared<Assembly::NegateOperator>(),
                     srcAssemblyType, dstOperand));
         }
-        else if (auto complementOperator =
-                     std::dynamic_pointer_cast<IR::ComplementOperator>(
-                         unaryIROperator)) {
+        else if (dynamic_cast<const IR::ComplementOperator *>(
+                     unaryIROperator)) {
             instructions->emplace_back(
                 std::make_shared<Assembly::UnaryInstruction>(
                     std::make_shared<Assembly::ComplementOperator>(),
@@ -268,21 +266,21 @@ void AssemblyGenerator::convertIRUnaryInstructionToAssy(
 }
 
 void AssemblyGenerator::convertIRBinaryInstructionToAssy(
-    std::shared_ptr<IR::BinaryInstruction> binaryInstr,
+    const IR::BinaryInstruction &binaryInstr,
     std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
         instructions) {
     // Convert the source operands to assembly operands.
-    auto src1Operand = convertValue(binaryInstr->getSrc1());
-    auto src2Operand = convertValue(binaryInstr->getSrc2());
-    auto dstOperand = convertValue(binaryInstr->getDst());
+    auto src1Operand = convertValue(binaryInstr.getSrc1());
+    auto src2Operand = convertValue(binaryInstr.getSrc2());
+    auto dstOperand = convertValue(binaryInstr.getDst());
 
-    auto src1AssemblyType = determineAssemblyType(binaryInstr->getSrc1());
-    auto dstAssemblyType = determineAssemblyType(binaryInstr->getDst());
+    auto src1AssemblyType = determineAssemblyType(binaryInstr.getSrc1());
+    auto dstAssemblyType = determineAssemblyType(binaryInstr.getDst());
 
     // Get the binary operator from the IR binary instruction.
-    auto binaryIROperator = binaryInstr->getBinaryOperator();
+    auto binaryIROperator = binaryInstr.getBinaryOperator();
     // Generate the assembly instructions based on the IR binary operator.
-    if (std::dynamic_pointer_cast<IR::AddOperator>(binaryIROperator)) {
+    if (dynamic_cast<const IR::AddOperator *>(binaryIROperator)) {
         instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
             src1AssemblyType, src1Operand, dstOperand));
         instructions->emplace_back(
@@ -290,8 +288,7 @@ void AssemblyGenerator::convertIRBinaryInstructionToAssy(
                 std::make_shared<Assembly::AddOperator>(), src1AssemblyType,
                 src2Operand, dstOperand));
     }
-    else if (std::dynamic_pointer_cast<IR::SubtractOperator>(
-                 binaryIROperator)) {
+    else if (dynamic_cast<const IR::SubtractOperator *>(binaryIROperator)) {
         instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
             src1AssemblyType, src1Operand, dstOperand));
         instructions->emplace_back(
@@ -299,8 +296,7 @@ void AssemblyGenerator::convertIRBinaryInstructionToAssy(
                 std::make_shared<Assembly::SubtractOperator>(),
                 src1AssemblyType, src2Operand, dstOperand));
     }
-    else if (std::dynamic_pointer_cast<IR::MultiplyOperator>(
-                 binaryIROperator)) {
+    else if (dynamic_cast<const IR::MultiplyOperator *>(binaryIROperator)) {
         instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
             src1AssemblyType, src1Operand, dstOperand));
         instructions->emplace_back(
@@ -308,7 +304,7 @@ void AssemblyGenerator::convertIRBinaryInstructionToAssy(
                 std::make_shared<Assembly::MultiplyOperator>(),
                 src1AssemblyType, src2Operand, dstOperand));
     }
-    else if (std::dynamic_pointer_cast<IR::DivideOperator>(binaryIROperator)) {
+    else if (dynamic_cast<const IR::DivideOperator *>(binaryIROperator)) {
         auto axReg = std::make_shared<Assembly::AX>();
         instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
             src1AssemblyType, src1Operand,
@@ -321,8 +317,7 @@ void AssemblyGenerator::convertIRBinaryInstructionToAssy(
             src1AssemblyType,
             std::make_shared<Assembly::RegisterOperand>(axReg), dstOperand));
     }
-    else if (std::dynamic_pointer_cast<IR::RemainderOperator>(
-                 binaryIROperator)) {
+    else if (dynamic_cast<const IR::RemainderOperator *>(binaryIROperator)) {
         auto axReg = std::make_shared<Assembly::AX>();
         auto dxReg = std::make_shared<Assembly::DX>();
         instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
@@ -336,7 +331,7 @@ void AssemblyGenerator::convertIRBinaryInstructionToAssy(
             src1AssemblyType,
             std::make_shared<Assembly::RegisterOperand>(dxReg), dstOperand));
     }
-    else if (std::dynamic_pointer_cast<IR::EqualOperator>(binaryIROperator)) {
+    else if (dynamic_cast<const IR::EqualOperator *>(binaryIROperator)) {
         instructions->emplace_back(std::make_shared<Assembly::CmpInstruction>(
             src1AssemblyType, src2Operand, src1Operand));
         instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
@@ -345,8 +340,7 @@ void AssemblyGenerator::convertIRBinaryInstructionToAssy(
         instructions->emplace_back(std::make_shared<Assembly::SetCCInstruction>(
             std::make_shared<Assembly::E>(), dstOperand));
     }
-    else if (std::dynamic_pointer_cast<IR::NotEqualOperator>(
-                 binaryIROperator)) {
+    else if (dynamic_cast<const IR::NotEqualOperator *>(binaryIROperator)) {
         instructions->emplace_back(std::make_shared<Assembly::CmpInstruction>(
             src1AssemblyType, src2Operand, src1Operand));
         instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
@@ -355,8 +349,7 @@ void AssemblyGenerator::convertIRBinaryInstructionToAssy(
         instructions->emplace_back(std::make_shared<Assembly::SetCCInstruction>(
             std::make_shared<Assembly::NE>(), dstOperand));
     }
-    else if (std::dynamic_pointer_cast<IR::LessThanOperator>(
-                 binaryIROperator)) {
+    else if (dynamic_cast<const IR::LessThanOperator *>(binaryIROperator)) {
         instructions->emplace_back(std::make_shared<Assembly::CmpInstruction>(
             src1AssemblyType, src2Operand, src1Operand));
         instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
@@ -365,7 +358,7 @@ void AssemblyGenerator::convertIRBinaryInstructionToAssy(
         instructions->emplace_back(std::make_shared<Assembly::SetCCInstruction>(
             std::make_shared<Assembly::L>(), dstOperand));
     }
-    else if (std::dynamic_pointer_cast<IR::LessThanOrEqualOperator>(
+    else if (dynamic_cast<const IR::LessThanOrEqualOperator *>(
                  binaryIROperator)) {
         instructions->emplace_back(std::make_shared<Assembly::CmpInstruction>(
             src1AssemblyType, src2Operand, src1Operand));
@@ -375,8 +368,7 @@ void AssemblyGenerator::convertIRBinaryInstructionToAssy(
         instructions->emplace_back(std::make_shared<Assembly::SetCCInstruction>(
             std::make_shared<Assembly::LE>(), dstOperand));
     }
-    else if (std::dynamic_pointer_cast<IR::GreaterThanOperator>(
-                 binaryIROperator)) {
+    else if (dynamic_cast<const IR::GreaterThanOperator *>(binaryIROperator)) {
         instructions->emplace_back(std::make_shared<Assembly::CmpInstruction>(
             src1AssemblyType, src2Operand, src1Operand));
         instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
@@ -385,7 +377,7 @@ void AssemblyGenerator::convertIRBinaryInstructionToAssy(
         instructions->emplace_back(std::make_shared<Assembly::SetCCInstruction>(
             std::make_shared<Assembly::G>(), dstOperand));
     }
-    else if (std::dynamic_pointer_cast<IR::GreaterThanOrEqualOperator>(
+    else if (dynamic_cast<const IR::GreaterThanOrEqualOperator *>(
                  binaryIROperator)) {
         instructions->emplace_back(std::make_shared<Assembly::CmpInstruction>(
             src1AssemblyType, src2Operand, src1Operand));
@@ -401,62 +393,62 @@ void AssemblyGenerator::convertIRBinaryInstructionToAssy(
 }
 
 void AssemblyGenerator::convertIRJumpInstructionToAssy(
-    std::shared_ptr<IR::JumpInstruction> jumpInstr,
+    const IR::JumpInstruction &jumpInstr,
     std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
         instructions) {
     // Generate a `Jmp` instruction to jump to the target (label).
     instructions->emplace_back(
-        std::make_shared<Assembly::JmpInstruction>(jumpInstr->getTarget()));
+        std::make_shared<Assembly::JmpInstruction>(jumpInstr.getTarget()));
 }
 
 void AssemblyGenerator::convertIRJumpIfZeroInstructionToAssy(
-    std::shared_ptr<IR::JumpIfZeroInstruction> jumpIfZeroInstr,
+    const IR::JumpIfZeroInstruction &jumpIfZeroInstr,
     std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
         instructions) {
     // Determine the assembly type based on the condition operand.
-    auto assemblyType = determineAssemblyType(jumpIfZeroInstr->getCondition());
+    auto assemblyType = determineAssemblyType(jumpIfZeroInstr.getCondition());
 
     // Generate a `Cmp` instruction to compare the condition with `0`.
     instructions->emplace_back(std::make_shared<Assembly::CmpInstruction>(
         assemblyType, std::make_shared<Assembly::ImmediateOperand>(0),
-        convertValue(jumpIfZeroInstr->getCondition())));
+        convertValue(jumpIfZeroInstr.getCondition())));
 
     // Generate a `JmpCC` instruction to conditionally jump to the target
     // (label).
     instructions->emplace_back(std::make_shared<Assembly::JmpCCInstruction>(
-        std::make_shared<Assembly::E>(), jumpIfZeroInstr->getTarget()));
+        std::make_shared<Assembly::E>(), jumpIfZeroInstr.getTarget()));
 }
 
 void AssemblyGenerator::convertIRJumpIfNotZeroInstructionToAssy(
-    std::shared_ptr<IR::JumpIfNotZeroInstruction> jumpIfNotZeroInstr,
+    const IR::JumpIfNotZeroInstruction &jumpIfNotZeroInstr,
     std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
         instructions) {
     // Determine the assembly type based on the condition operand.
     auto assemblyType =
-        determineAssemblyType(jumpIfNotZeroInstr->getCondition());
+        determineAssemblyType(jumpIfNotZeroInstr.getCondition());
 
     // Generate a `Cmp` instruction to compare the condition with `0`.
     instructions->emplace_back(std::make_shared<Assembly::CmpInstruction>(
         assemblyType, std::make_shared<Assembly::ImmediateOperand>(0),
-        convertValue(jumpIfNotZeroInstr->getCondition())));
+        convertValue(jumpIfNotZeroInstr.getCondition())));
 
     // Generate a `JmpCC` instruction to conditionally jump to the target
     // (label).
     instructions->emplace_back(std::make_shared<Assembly::JmpCCInstruction>(
-        std::make_shared<Assembly::NE>(), jumpIfNotZeroInstr->getTarget()));
+        std::make_shared<Assembly::NE>(), jumpIfNotZeroInstr.getTarget()));
 }
 
 void AssemblyGenerator::convertIRCopyInstructionToAssy(
-    std::shared_ptr<IR::CopyInstruction> copyInstr,
+    const IR::CopyInstruction &copyInstr,
     std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
         instructions) {
     // Convert the source and destination operands to assembly operands.
-    auto srcOperand = convertValue(copyInstr->getSrc());
-    auto dstOperand = convertValue(copyInstr->getDst());
+    auto srcOperand = convertValue(copyInstr.getSrc());
+    auto dstOperand = convertValue(copyInstr.getDst());
 
     // Determine the assembly type of the `Mov` instruction.
     auto assemblyType = determineMovType(
-        srcOperand, dstOperand, copyInstr->getSrc(), copyInstr->getDst());
+        srcOperand, dstOperand, copyInstr.getSrc(), copyInstr.getDst());
 
     // Generate a `Mov` instruction to copy the source operand to the
     // destination operand.
@@ -465,45 +457,43 @@ void AssemblyGenerator::convertIRCopyInstructionToAssy(
 }
 
 void AssemblyGenerator::convertIRLabelInstructionToAssy(
-    std::shared_ptr<IR::LabelInstruction> labelInstr,
+    const IR::LabelInstruction &labelInstr,
     std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
         instructions) {
     // Generate a `Label` instruction with the label name.
     instructions->emplace_back(
-        std::make_shared<Assembly::LabelInstruction>(labelInstr->getLabel()));
+        std::make_shared<Assembly::LabelInstruction>(labelInstr.getLabel()));
 }
 
 void AssemblyGenerator::convertIRFunctionCallInstructionToAssy(
-    std::shared_ptr<IR::FunctionCallInstruction> functionCallInstr,
+    const IR::FunctionCallInstruction &functionCallInstr,
     std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
         instructions) {
     std::vector<std::string> argRegistersInStr = {"DI", "SI", "DX",
                                                   "CX", "R8", "R9"};
     auto axReg = std::make_shared<Assembly::AX>();
 
-    auto irArgs = functionCallInstr->getArgs();
-    auto irRegisterArgs =
-        std::make_shared<std::vector<std::shared_ptr<IR::Value>>>();
-    auto irStackArgs =
-        std::make_shared<std::vector<std::shared_ptr<IR::Value>>>();
-    if (irArgs->size() < 6) {
-        for (size_t i = 0; i < irArgs->size(); ++i) {
-            irRegisterArgs->emplace_back(irArgs->at(i));
+    auto &irArgs = functionCallInstr.getArgs();
+    std::vector<const IR::Value *> irRegisterArgs;
+    std::vector<const IR::Value *> irStackArgs;
+    if (irArgs.size() < 6) {
+        for (const auto &arg : irArgs) {
+            irRegisterArgs.emplace_back(arg.get());
         }
     }
     else {
-        for (size_t i = 0; i < irArgs->size(); ++i) {
+        for (size_t i = 0; i < irArgs.size(); ++i) {
             if (i < 6) {
-                irRegisterArgs->emplace_back(irArgs->at(i));
+                irRegisterArgs.emplace_back(irArgs.at(i).get());
             }
             else {
-                irStackArgs->emplace_back(irArgs->at(i));
+                irStackArgs.emplace_back(irArgs.at(i).get());
             }
         }
     }
     // Adjust the stack alignment (if the number of arguments on the stack is
     // odd).
-    auto stackPadding = irStackArgs->size() % 2 != 0 ? 8 : 0;
+    auto stackPadding = irStackArgs.size() % 2 != 0 ? 8 : 0;
     if (stackPadding != 0) {
         instructions->emplace_back(
             std::make_shared<Assembly::BinaryInstruction>(
@@ -515,7 +505,7 @@ void AssemblyGenerator::convertIRFunctionCallInstructionToAssy(
 
     // Pass the arguments in registers.
     size_t registerIndex = 0;
-    for (auto irRegisterArg : *irRegisterArgs) {
+    for (auto irRegisterArg : irRegisterArgs) {
         auto registerOperand = std::make_shared<Assembly::RegisterOperand>(
             argRegistersInStr[registerIndex]);
         auto assyRegisterArg = convertValue(irRegisterArg);
@@ -528,8 +518,8 @@ void AssemblyGenerator::convertIRFunctionCallInstructionToAssy(
     // Pass the arguments on the stack.
     // Reverse the order of the stack arguments since
     // they should be pushed in the reverse order.
-    std::reverse(irStackArgs->begin(), irStackArgs->end());
-    for (auto irStackArg : *irStackArgs) {
+    std::reverse(irStackArgs.begin(), irStackArgs.end());
+    for (auto irStackArg : irStackArgs) {
         auto assyStackArg = convertValue(irStackArg);
         auto assemblyType = determineAssemblyType(irStackArg);
 
@@ -565,11 +555,11 @@ void AssemblyGenerator::convertIRFunctionCallInstructionToAssy(
 
     // Emit a `Call` instruction (to call the function).
     instructions->emplace_back(std::make_shared<Assembly::CallInstruction>(
-        functionCallInstr->getFunctionIdentifier()));
+        functionCallInstr.getFunctionIdentifier()));
 
     // Adjust the stack pointer (after the function call).
     auto bytesToPop =
-        8 * irStackArgs->size() + static_cast<size_t>(stackPadding);
+        8 * irStackArgs.size() + static_cast<size_t>(stackPadding);
     if (bytesToPop != 0) {
         instructions->emplace_back(
             std::make_shared<Assembly::BinaryInstruction>(
@@ -581,24 +571,23 @@ void AssemblyGenerator::convertIRFunctionCallInstructionToAssy(
     }
 
     // Retrieve the return value.
-    auto assyDst = convertValue(functionCallInstr->getDst());
+    auto assyDst = convertValue(functionCallInstr.getDst());
     // Determine the assembly type of the destination operand.
-    auto assemblyType = determineAssemblyType(functionCallInstr->getDst());
+    auto assemblyType = determineAssemblyType(functionCallInstr.getDst());
     instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
         assemblyType, std::make_shared<Assembly::RegisterOperand>(axReg),
         assyDst));
 }
 
 std::shared_ptr<Assembly::Operand>
-AssemblyGenerator::convertValue(std::shared_ptr<IR::Value> irValue) {
-    if (auto constantVal =
-            std::dynamic_pointer_cast<IR::ConstantValue>(irValue)) {
-        if (auto constInt = std::dynamic_pointer_cast<AST::ConstantInt>(
+AssemblyGenerator::convertValue(const IR::Value *irValue) {
+    if (auto constantVal = dynamic_cast<const IR::ConstantValue *>(irValue)) {
+        if (auto constInt = dynamic_cast<const AST::ConstantInt *>(
                 constantVal->getASTConstant())) {
             return std::make_shared<Assembly::ImmediateOperand>(
                 constInt->getValue());
         }
-        else if (auto constLong = std::dynamic_pointer_cast<AST::ConstantLong>(
+        else if (auto constLong = dynamic_cast<const AST::ConstantLong *>(
                      constantVal->getASTConstant())) {
             // For long constants, we need to handle the full 64-bit value.
             return std::make_shared<Assembly::ImmediateOperand>(
@@ -608,8 +597,7 @@ AssemblyGenerator::convertValue(std::shared_ptr<IR::Value> irValue) {
             throw std::logic_error("Unsupported constant type");
         }
     }
-    else if (auto varVal =
-                 std::dynamic_pointer_cast<IR::VariableValue>(irValue)) {
+    else if (auto varVal = dynamic_cast<const IR::VariableValue *>(irValue)) {
         return std::make_shared<Assembly::PseudoRegisterOperand>(
             varVal->getIdentifier());
     }
@@ -619,12 +607,12 @@ AssemblyGenerator::convertValue(std::shared_ptr<IR::Value> irValue) {
 }
 
 void AssemblyGenerator::convertIRSignExtendInstructionToAssy(
-    std::shared_ptr<IR::SignExtendInstruction> signExtendInstr,
+    const IR::SignExtendInstruction &signExtendInstr,
     std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
         instructions) {
     // Convert the source and destination operands to assembly operands.
-    auto srcOperand = convertValue(signExtendInstr->getSrc());
-    auto dstOperand = convertValue(signExtendInstr->getDst());
+    auto srcOperand = convertValue(signExtendInstr.getSrc());
+    auto dstOperand = convertValue(signExtendInstr.getDst());
 
     // Generate a `Movsx` instruction to sign extend from int to long.
     instructions->emplace_back(
@@ -632,12 +620,12 @@ void AssemblyGenerator::convertIRSignExtendInstructionToAssy(
 }
 
 void AssemblyGenerator::convertIRTruncateInstructionToAssy(
-    std::shared_ptr<IR::TruncateInstruction> truncateInstr,
+    const IR::TruncateInstruction &truncateInstr,
     std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
         instructions) {
     // Convert the source and destination operands to assembly operands.
-    auto srcOperand = convertValue(truncateInstr->getSrc());
-    auto dstOperand = convertValue(truncateInstr->getDst());
+    auto srcOperand = convertValue(truncateInstr.getSrc());
+    auto dstOperand = convertValue(truncateInstr.getDst());
 
     // Generate a `Mov` instruction with Longword type to truncate from long to
     // int. This moves the lowest 4 bytes of the source to the destination.
@@ -646,15 +634,14 @@ void AssemblyGenerator::convertIRTruncateInstructionToAssy(
 }
 
 std::shared_ptr<Assembly::AssemblyType>
-AssemblyGenerator::determineAssemblyType(std::shared_ptr<IR::Value> irValue) {
-    if (auto constantVal =
-            std::dynamic_pointer_cast<IR::ConstantValue>(irValue)) {
+AssemblyGenerator::determineAssemblyType(const IR::Value *irValue) {
+    if (auto constantVal = dynamic_cast<const IR::ConstantValue *>(irValue)) {
         // For constants, determine type based on the AST constant type.
-        if (auto constInt = std::dynamic_pointer_cast<AST::ConstantInt>(
+        if (auto constInt = dynamic_cast<const AST::ConstantInt *>(
                 constantVal->getASTConstant())) {
             return std::make_shared<Assembly::Longword>();
         }
-        else if (auto constLong = std::dynamic_pointer_cast<AST::ConstantLong>(
+        else if (auto constLong = dynamic_cast<const AST::ConstantLong *>(
                      constantVal->getASTConstant())) {
             return std::make_shared<Assembly::Quadword>();
         }
@@ -663,12 +650,11 @@ AssemblyGenerator::determineAssemblyType(std::shared_ptr<IR::Value> irValue) {
                 "Unsupported constant type for assembly type determination");
         }
     }
-    else if (auto varVal =
-                 std::dynamic_pointer_cast<IR::VariableValue>(irValue)) {
+    else if (auto varVal = dynamic_cast<const IR::VariableValue *>(irValue)) {
         // For variables, look up the type in the (frontend) symbol table.
         auto symbolIt = frontendSymbolTable.find(varVal->getIdentifier());
         if (symbolIt != frontendSymbolTable.end()) {
-            auto varType = symbolIt->second.first;
+            auto varType = symbolIt->second.first.get();
             return AssemblyGenerator::convertASTTypeToAssemblyType(varType);
         }
         // If not found in (frontend) symbol table, throw an error.
@@ -683,8 +669,10 @@ AssemblyGenerator::determineAssemblyType(std::shared_ptr<IR::Value> irValue) {
 }
 
 std::shared_ptr<Assembly::AssemblyType>
-AssemblyGenerator::convertASTTypeToAssemblyType(
-    std::shared_ptr<AST::Type> astType) {
+AssemblyGenerator::convertASTTypeToAssemblyType(const AST::Type *astType) {
+    if (!astType) {
+        throw std::logic_error("AST type is null");
+    }
     if (*astType == AST::IntType()) {
         return std::make_shared<Assembly::Longword>();
     }
@@ -700,8 +688,8 @@ AssemblyGenerator::convertASTTypeToAssemblyType(
 std::shared_ptr<Assembly::AssemblyType>
 AssemblyGenerator::determineMovType(std::shared_ptr<Assembly::Operand> src,
                                     std::shared_ptr<Assembly::Operand> dst,
-                                    std::shared_ptr<IR::Value> irSrc,
-                                    std::shared_ptr<IR::Value> irDst) {
+                                    const IR::Value *irSrc,
+                                    const IR::Value *irDst) {
     // Determine the assembly type based on the IR operands.
     auto srcType = determineAssemblyType(irSrc);
     auto dstType = determineAssemblyType(irDst);

--- a/src/backend/assemblyGenerator.cpp
+++ b/src/backend/assemblyGenerator.cpp
@@ -11,21 +11,21 @@ AssemblyGenerator::AssemblyGenerator(
     : irStaticVariables(irStaticVariables),
       frontendSymbolTable(frontendSymbolTable) {}
 
-std::shared_ptr<Assembly::Program>
+std::unique_ptr<Assembly::Program>
 AssemblyGenerator::generateAssembly(const IR::Program &irProgram) {
     auto &irTopLevels = irProgram.getTopLevels();
     auto assyTopLevels =
-        std::make_shared<std::vector<std::shared_ptr<TopLevel>>>();
+        std::make_unique<std::vector<std::unique_ptr<TopLevel>>>();
 
     // Generate assembly instructions for each IR top-level function definition.
     for (const auto &irTopLevel : irTopLevels) {
         if (auto *irFunctionDefinition =
                 dynamic_cast<IR::FunctionDefinition *>(irTopLevel.get())) {
-            auto instructions = std::make_shared<
-                std::vector<std::shared_ptr<Assembly::Instruction>>>();
+            auto instructions = std::make_unique<
+                std::vector<std::unique_ptr<Assembly::Instruction>>>();
             auto assyFunctionDefinition = convertIRFunctionDefinitionToAssy(
-                *irFunctionDefinition, instructions);
-            assyTopLevels->emplace_back(assyFunctionDefinition);
+                *irFunctionDefinition, std::move(instructions));
+            assyTopLevels->emplace_back(std::move(assyFunctionDefinition));
         }
         else {
             throw std::logic_error("Unsupported top-level element");
@@ -37,16 +37,16 @@ AssemblyGenerator::generateAssembly(const IR::Program &irProgram) {
     for (const auto &irStaticVariable : irStaticVariables) {
         auto assyStaticVariable =
             convertIRStaticVariableToAssy(*irStaticVariable);
-        assyTopLevels->emplace_back(assyStaticVariable);
+        assyTopLevels->emplace_back(std::move(assyStaticVariable));
     }
 
-    return std::make_shared<Program>(assyTopLevels);
+    return std::make_unique<Program>(std::move(assyTopLevels));
 }
 
-std::shared_ptr<Assembly::FunctionDefinition>
+std::unique_ptr<Assembly::FunctionDefinition>
 AssemblyGenerator::convertIRFunctionDefinitionToAssy(
     const IR::FunctionDefinition &irFunctionDefinition,
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
+    std::unique_ptr<std::vector<std::unique_ptr<Assembly::Instruction>>>
         instructions) {
     auto functionIdentifier = irFunctionDefinition.getFunctionIdentifier();
     auto functionGlobal = irFunctionDefinition.isGlobal();
@@ -62,10 +62,10 @@ AssemblyGenerator::convertIRFunctionDefinitionToAssy(
         for (size_t i = 0; i < irParameters.size(); ++i) {
             auto irParam = irParameters.at(i);
             auto irParamOperand =
-                std::make_shared<Assembly::PseudoRegisterOperand>(irParam);
+                std::make_unique<Assembly::PseudoRegisterOperand>(irParam);
             if (i < 6) { // First six parameters from registers.
                 auto registerOperand =
-                    std::make_shared<Assembly::RegisterOperand>(
+                    std::make_unique<Assembly::RegisterOperand>(
                         argRegistersInStr[registerIndex]);
                 // Determine assembly type based on the parameter type from the
                 // symbol table.
@@ -74,8 +74,9 @@ AssemblyGenerator::convertIRFunctionDefinitionToAssy(
                 // Generate a `Mov` instruction to move the
                 // parameter from the register to the stack.
                 instructions->emplace_back(
-                    std::make_shared<Assembly::MovInstruction>(
-                        assemblyType, registerOperand, irParamOperand));
+                    std::make_unique<Assembly::MovInstruction>(
+                        std::move(assemblyType), std::move(registerOperand),
+                        std::move(irParamOperand)));
                 registerIndex++;
             }
             else { // Remaining parameters from the stack.
@@ -85,8 +86,8 @@ AssemblyGenerator::convertIRFunctionDefinitionToAssy(
                 // `(%rbp + 16)` stores the first stack parameter (if any).
                 // ...
                 auto stackOffset = 8 * (i - 6 + 2);
-                auto stackOperand = std::make_shared<Assembly::StackOperand>(
-                    stackOffset, std::make_shared<Assembly::BP>());
+                auto stackOperand = std::make_unique<Assembly::StackOperand>(
+                    stackOffset, std::make_unique<Assembly::BP>());
                 // Determine assembly type based on the parameter type from the
                 // symbol table.
                 IR::VariableValue irParamValue(irParam);
@@ -94,16 +95,17 @@ AssemblyGenerator::convertIRFunctionDefinitionToAssy(
                 // Generate a `Mov` instruction to move the
                 // parameter from the stack to the register.
                 instructions->emplace_back(
-                    std::make_shared<Assembly::MovInstruction>(
-                        assemblyType, stackOperand, irParamOperand));
+                    std::make_unique<Assembly::MovInstruction>(
+                        std::move(assemblyType), std::move(stackOperand),
+                        std::move(irParamOperand)));
             }
         }
     }
 
     // Generate function definition that is corresponding to the IR function
     // definition (after conversion).
-    auto assyFunctionDefinition = std::make_shared<FunctionDefinition>(
-        functionIdentifier, functionGlobal, instructions, 0);
+    auto assyFunctionDefinition = std::make_unique<FunctionDefinition>(
+        functionIdentifier, functionGlobal, std::move(instructions), 0);
 
     // Generate assembly instructions for the function body.
     for (const auto &irInstruction : functionBody) {
@@ -114,7 +116,7 @@ AssemblyGenerator::convertIRFunctionDefinitionToAssy(
     return assyFunctionDefinition;
 }
 
-std::shared_ptr<Assembly::StaticVariable>
+std::unique_ptr<Assembly::StaticVariable>
 AssemblyGenerator::convertIRStaticVariableToAssy(
     const IR::StaticVariable &irStaticVariable) {
     auto identifier = irStaticVariable.getIdentifier();
@@ -124,15 +126,15 @@ AssemblyGenerator::convertIRStaticVariableToAssy(
     // Convert the static initializer to an assembly static variable.
     if (auto constInt = dynamic_cast<const AST::IntInit *>(staticInit)) {
         auto assyInit =
-            std::make_shared<AST::IntInit>(std::get<int>(constInt->getValue()));
-        return std::make_shared<StaticVariable>(identifier, global, 4,
-                                                assyInit);
+            std::make_unique<AST::IntInit>(std::get<int>(constInt->getValue()));
+        return std::make_unique<StaticVariable>(identifier, global, 4,
+                                                std::move(assyInit));
     }
     else if (auto constLong = dynamic_cast<const AST::LongInit *>(staticInit)) {
-        auto assyInit = std::make_shared<AST::LongInit>(
+        auto assyInit = std::make_unique<AST::LongInit>(
             std::get<long>(constLong->getValue()));
-        return std::make_shared<StaticVariable>(identifier, global, 8,
-                                                assyInit);
+        return std::make_unique<StaticVariable>(identifier, global, 8,
+                                                std::move(assyInit));
     }
     else {
         throw std::logic_error("Unsupported static initializer type");
@@ -141,8 +143,7 @@ AssemblyGenerator::convertIRStaticVariableToAssy(
 
 void AssemblyGenerator::convertIRInstructionToAssy(
     const IR::Instruction &irInstruction,
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions) {
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions) {
     if (auto returnInstr =
             dynamic_cast<const IR::ReturnInstruction *>(&irInstruction)) {
         convertIRReturnInstructionToAssy(*returnInstr, instructions);
@@ -200,192 +201,213 @@ void AssemblyGenerator::convertIRInstructionToAssy(
 
 void AssemblyGenerator::convertIRReturnInstructionToAssy(
     const IR::ReturnInstruction &returnInstr,
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions) {
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions) {
     auto returnValue = convertValue(returnInstr.getReturnValue());
 
     // Determine the assembly type based on the return value.
     auto assemblyType = determineAssemblyType(returnInstr.getReturnValue());
 
     // Move the return value into the `AX` register.
-    auto axReg = std::make_shared<Assembly::AX>();
-    instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
-        assemblyType, returnValue,
-        std::make_shared<Assembly::RegisterOperand>(axReg)));
+    instructions.emplace_back(std::make_unique<Assembly::MovInstruction>(
+        std::move(assemblyType), std::move(returnValue),
+        std::make_unique<Assembly::RegisterOperand>("AX")));
 
     // Generate a `Ret` instruction to return from the function.
-    instructions->emplace_back(std::make_shared<Assembly::RetInstruction>());
+    instructions.emplace_back(std::make_unique<Assembly::RetInstruction>());
 }
 
 void AssemblyGenerator::convertIRUnaryInstructionToAssy(
     const IR::UnaryInstruction &unaryInstr,
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions) {
-    // Convert the source and destination operands to assembly operands.
-    auto srcOperand = convertValue(unaryInstr.getSrc());
-    auto dstOperand = convertValue(unaryInstr.getDst());
-
-    // Determine the assembly type of the source operand and the destination
-    // operand based on the source and destination operands.
-    auto srcAssemblyType = determineAssemblyType(unaryInstr.getSrc());
-    auto dstAssemblyType = determineAssemblyType(unaryInstr.getDst());
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions) {
 
     // Get the unary operator from the IR unary instruction.
     auto unaryIROperator = unaryInstr.getUnaryOperator();
 
     // Generate the assembly instructions based on the unary operator.
     if (dynamic_cast<const IR::NotOperator *>(unaryIROperator)) {
-        instructions->emplace_back(std::make_shared<Assembly::CmpInstruction>(
-            srcAssemblyType, std::make_shared<Assembly::ImmediateOperand>(0),
-            srcOperand));
-        instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
-            dstAssemblyType, std::make_shared<Assembly::ImmediateOperand>(0),
-            dstOperand));
-        instructions->emplace_back(std::make_shared<Assembly::SetCCInstruction>(
-            std::make_shared<Assembly::E>(), dstOperand));
+        instructions.emplace_back(std::make_unique<Assembly::CmpInstruction>(
+            determineAssemblyType(unaryInstr.getSrc()),
+            std::make_unique<Assembly::ImmediateOperand>(0),
+            convertValue(unaryInstr.getSrc())));
+        instructions.emplace_back(std::make_unique<Assembly::MovInstruction>(
+            determineAssemblyType(unaryInstr.getDst()),
+            std::make_unique<Assembly::ImmediateOperand>(0),
+            convertValue(unaryInstr.getDst())));
+        instructions.emplace_back(std::make_unique<Assembly::SetCCInstruction>(
+            std::make_unique<Assembly::E>(),
+            convertValue(unaryInstr.getDst())));
     }
     else {
         // Move the source operand to the destination operand.
-        instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
-            srcAssemblyType, srcOperand, dstOperand));
+        instructions.emplace_back(std::make_unique<Assembly::MovInstruction>(
+            determineAssemblyType(unaryInstr.getSrc()),
+            convertValue(unaryInstr.getSrc()),
+            convertValue(unaryInstr.getDst())));
         // Generate the assembly instructions based on the unary operator.
         if (dynamic_cast<const IR::NegateOperator *>(unaryIROperator)) {
-            instructions->emplace_back(
-                std::make_shared<Assembly::UnaryInstruction>(
-                    std::make_shared<Assembly::NegateOperator>(),
-                    srcAssemblyType, dstOperand));
+            instructions.emplace_back(
+                std::make_unique<Assembly::UnaryInstruction>(
+                    std::make_unique<Assembly::NegateOperator>(),
+                    determineAssemblyType(unaryInstr.getSrc()),
+                    convertValue(unaryInstr.getDst())));
         }
         else if (dynamic_cast<const IR::ComplementOperator *>(
                      unaryIROperator)) {
-            instructions->emplace_back(
-                std::make_shared<Assembly::UnaryInstruction>(
-                    std::make_shared<Assembly::ComplementOperator>(),
-                    srcAssemblyType, dstOperand));
+            instructions.emplace_back(
+                std::make_unique<Assembly::UnaryInstruction>(
+                    std::make_unique<Assembly::ComplementOperator>(),
+                    determineAssemblyType(unaryInstr.getSrc()),
+                    convertValue(unaryInstr.getDst())));
         }
     }
 }
 
 void AssemblyGenerator::convertIRBinaryInstructionToAssy(
     const IR::BinaryInstruction &binaryInstr,
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions) {
-    // Convert the source operands to assembly operands.
-    auto src1Operand = convertValue(binaryInstr.getSrc1());
-    auto src2Operand = convertValue(binaryInstr.getSrc2());
-    auto dstOperand = convertValue(binaryInstr.getDst());
-
-    auto src1AssemblyType = determineAssemblyType(binaryInstr.getSrc1());
-    auto dstAssemblyType = determineAssemblyType(binaryInstr.getDst());
-
-    // Get the binary operator from the IR binary instruction.
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions) {
     auto binaryIROperator = binaryInstr.getBinaryOperator();
-    // Generate the assembly instructions based on the IR binary operator.
     if (dynamic_cast<const IR::AddOperator *>(binaryIROperator)) {
-        instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
-            src1AssemblyType, src1Operand, dstOperand));
-        instructions->emplace_back(
-            std::make_shared<Assembly::BinaryInstruction>(
-                std::make_shared<Assembly::AddOperator>(), src1AssemblyType,
-                src2Operand, dstOperand));
+        instructions.emplace_back(std::make_unique<Assembly::MovInstruction>(
+            determineAssemblyType(binaryInstr.getSrc1()),
+            convertValue(binaryInstr.getSrc1()),
+            convertValue(binaryInstr.getDst())));
+        instructions.emplace_back(std::make_unique<Assembly::BinaryInstruction>(
+            std::make_unique<Assembly::AddOperator>(),
+            determineAssemblyType(binaryInstr.getSrc1()),
+            convertValue(binaryInstr.getSrc2()),
+            convertValue(binaryInstr.getDst())));
     }
     else if (dynamic_cast<const IR::SubtractOperator *>(binaryIROperator)) {
-        instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
-            src1AssemblyType, src1Operand, dstOperand));
-        instructions->emplace_back(
-            std::make_shared<Assembly::BinaryInstruction>(
-                std::make_shared<Assembly::SubtractOperator>(),
-                src1AssemblyType, src2Operand, dstOperand));
+        instructions.emplace_back(std::make_unique<Assembly::MovInstruction>(
+            determineAssemblyType(binaryInstr.getSrc1()),
+            convertValue(binaryInstr.getSrc1()),
+            convertValue(binaryInstr.getDst())));
+        instructions.emplace_back(std::make_unique<Assembly::BinaryInstruction>(
+            std::make_unique<Assembly::SubtractOperator>(),
+            determineAssemblyType(binaryInstr.getSrc1()),
+            convertValue(binaryInstr.getSrc2()),
+            convertValue(binaryInstr.getDst())));
     }
     else if (dynamic_cast<const IR::MultiplyOperator *>(binaryIROperator)) {
-        instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
-            src1AssemblyType, src1Operand, dstOperand));
-        instructions->emplace_back(
-            std::make_shared<Assembly::BinaryInstruction>(
-                std::make_shared<Assembly::MultiplyOperator>(),
-                src1AssemblyType, src2Operand, dstOperand));
+        instructions.emplace_back(std::make_unique<Assembly::MovInstruction>(
+            determineAssemblyType(binaryInstr.getSrc1()),
+            convertValue(binaryInstr.getSrc1()),
+            convertValue(binaryInstr.getDst())));
+        instructions.emplace_back(std::make_unique<Assembly::BinaryInstruction>(
+            std::make_unique<Assembly::MultiplyOperator>(),
+            determineAssemblyType(binaryInstr.getSrc1()),
+            convertValue(binaryInstr.getSrc2()),
+            convertValue(binaryInstr.getDst())));
     }
     else if (dynamic_cast<const IR::DivideOperator *>(binaryIROperator)) {
-        auto axReg = std::make_shared<Assembly::AX>();
-        instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
-            src1AssemblyType, src1Operand,
-            std::make_shared<Assembly::RegisterOperand>(axReg)));
-        instructions->emplace_back(
-            std::make_shared<Assembly::CdqInstruction>(src1AssemblyType));
-        instructions->emplace_back(std::make_shared<Assembly::IdivInstruction>(
-            src1AssemblyType, src2Operand));
-        instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
-            src1AssemblyType,
-            std::make_shared<Assembly::RegisterOperand>(axReg), dstOperand));
+        instructions.emplace_back(std::make_unique<Assembly::MovInstruction>(
+            determineAssemblyType(binaryInstr.getSrc1()),
+            convertValue(binaryInstr.getSrc1()),
+            std::make_unique<Assembly::RegisterOperand>("AX")));
+        instructions.emplace_back(std::make_unique<Assembly::CdqInstruction>(
+            determineAssemblyType(binaryInstr.getSrc1())));
+        instructions.emplace_back(std::make_unique<Assembly::IdivInstruction>(
+            determineAssemblyType(binaryInstr.getSrc1()),
+            convertValue(binaryInstr.getSrc2())));
+        instructions.emplace_back(std::make_unique<Assembly::MovInstruction>(
+            determineAssemblyType(binaryInstr.getSrc1()),
+            std::make_unique<Assembly::RegisterOperand>("AX"),
+            convertValue(binaryInstr.getDst())));
     }
     else if (dynamic_cast<const IR::RemainderOperator *>(binaryIROperator)) {
-        auto axReg = std::make_shared<Assembly::AX>();
-        auto dxReg = std::make_shared<Assembly::DX>();
-        instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
-            src1AssemblyType, src1Operand,
-            std::make_shared<Assembly::RegisterOperand>(axReg)));
-        instructions->emplace_back(
-            std::make_shared<Assembly::CdqInstruction>(src1AssemblyType));
-        instructions->emplace_back(std::make_shared<Assembly::IdivInstruction>(
-            src1AssemblyType, src2Operand));
-        instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
-            src1AssemblyType,
-            std::make_shared<Assembly::RegisterOperand>(dxReg), dstOperand));
+        instructions.emplace_back(std::make_unique<Assembly::MovInstruction>(
+            determineAssemblyType(binaryInstr.getSrc1()),
+            convertValue(binaryInstr.getSrc1()),
+            std::make_unique<Assembly::RegisterOperand>("AX")));
+        instructions.emplace_back(std::make_unique<Assembly::CdqInstruction>(
+            determineAssemblyType(binaryInstr.getSrc1())));
+        instructions.emplace_back(std::make_unique<Assembly::IdivInstruction>(
+            determineAssemblyType(binaryInstr.getSrc1()),
+            convertValue(binaryInstr.getSrc2())));
+        instructions.emplace_back(std::make_unique<Assembly::MovInstruction>(
+            determineAssemblyType(binaryInstr.getSrc1()),
+            std::make_unique<Assembly::RegisterOperand>("DX"),
+            convertValue(binaryInstr.getDst())));
     }
     else if (dynamic_cast<const IR::EqualOperator *>(binaryIROperator)) {
-        instructions->emplace_back(std::make_shared<Assembly::CmpInstruction>(
-            src1AssemblyType, src2Operand, src1Operand));
-        instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
-            dstAssemblyType, std::make_shared<Assembly::ImmediateOperand>(0),
-            dstOperand));
-        instructions->emplace_back(std::make_shared<Assembly::SetCCInstruction>(
-            std::make_shared<Assembly::E>(), dstOperand));
+        instructions.emplace_back(std::make_unique<Assembly::CmpInstruction>(
+            determineAssemblyType(binaryInstr.getSrc1()),
+            convertValue(binaryInstr.getSrc2()),
+            convertValue(binaryInstr.getSrc1())));
+        instructions.emplace_back(std::make_unique<Assembly::MovInstruction>(
+            determineAssemblyType(binaryInstr.getDst()),
+            std::make_unique<Assembly::ImmediateOperand>(0),
+            convertValue(binaryInstr.getDst())));
+        instructions.emplace_back(std::make_unique<Assembly::SetCCInstruction>(
+            std::make_unique<Assembly::E>(),
+            convertValue(binaryInstr.getDst())));
     }
     else if (dynamic_cast<const IR::NotEqualOperator *>(binaryIROperator)) {
-        instructions->emplace_back(std::make_shared<Assembly::CmpInstruction>(
-            src1AssemblyType, src2Operand, src1Operand));
-        instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
-            dstAssemblyType, std::make_shared<Assembly::ImmediateOperand>(0),
-            dstOperand));
-        instructions->emplace_back(std::make_shared<Assembly::SetCCInstruction>(
-            std::make_shared<Assembly::NE>(), dstOperand));
+        instructions.emplace_back(std::make_unique<Assembly::CmpInstruction>(
+            determineAssemblyType(binaryInstr.getSrc1()),
+            convertValue(binaryInstr.getSrc2()),
+            convertValue(binaryInstr.getSrc1())));
+        instructions.emplace_back(std::make_unique<Assembly::MovInstruction>(
+            determineAssemblyType(binaryInstr.getDst()),
+            std::make_unique<Assembly::ImmediateOperand>(0),
+            convertValue(binaryInstr.getDst())));
+        instructions.emplace_back(std::make_unique<Assembly::SetCCInstruction>(
+            std::make_unique<Assembly::NE>(),
+            convertValue(binaryInstr.getDst())));
     }
     else if (dynamic_cast<const IR::LessThanOperator *>(binaryIROperator)) {
-        instructions->emplace_back(std::make_shared<Assembly::CmpInstruction>(
-            src1AssemblyType, src2Operand, src1Operand));
-        instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
-            dstAssemblyType, std::make_shared<Assembly::ImmediateOperand>(0),
-            dstOperand));
-        instructions->emplace_back(std::make_shared<Assembly::SetCCInstruction>(
-            std::make_shared<Assembly::L>(), dstOperand));
+        instructions.emplace_back(std::make_unique<Assembly::CmpInstruction>(
+            determineAssemblyType(binaryInstr.getSrc1()),
+            convertValue(binaryInstr.getSrc2()),
+            convertValue(binaryInstr.getSrc1())));
+        instructions.emplace_back(std::make_unique<Assembly::MovInstruction>(
+            determineAssemblyType(binaryInstr.getDst()),
+            std::make_unique<Assembly::ImmediateOperand>(0),
+            convertValue(binaryInstr.getDst())));
+        instructions.emplace_back(std::make_unique<Assembly::SetCCInstruction>(
+            std::make_unique<Assembly::L>(),
+            convertValue(binaryInstr.getDst())));
     }
     else if (dynamic_cast<const IR::LessThanOrEqualOperator *>(
                  binaryIROperator)) {
-        instructions->emplace_back(std::make_shared<Assembly::CmpInstruction>(
-            src1AssemblyType, src2Operand, src1Operand));
-        instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
-            dstAssemblyType, std::make_shared<Assembly::ImmediateOperand>(0),
-            dstOperand));
-        instructions->emplace_back(std::make_shared<Assembly::SetCCInstruction>(
-            std::make_shared<Assembly::LE>(), dstOperand));
+        instructions.emplace_back(std::make_unique<Assembly::CmpInstruction>(
+            determineAssemblyType(binaryInstr.getSrc1()),
+            convertValue(binaryInstr.getSrc2()),
+            convertValue(binaryInstr.getSrc1())));
+        instructions.emplace_back(std::make_unique<Assembly::MovInstruction>(
+            determineAssemblyType(binaryInstr.getDst()),
+            std::make_unique<Assembly::ImmediateOperand>(0),
+            convertValue(binaryInstr.getDst())));
+        instructions.emplace_back(std::make_unique<Assembly::SetCCInstruction>(
+            std::make_unique<Assembly::LE>(),
+            convertValue(binaryInstr.getDst())));
     }
     else if (dynamic_cast<const IR::GreaterThanOperator *>(binaryIROperator)) {
-        instructions->emplace_back(std::make_shared<Assembly::CmpInstruction>(
-            src1AssemblyType, src2Operand, src1Operand));
-        instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
-            dstAssemblyType, std::make_shared<Assembly::ImmediateOperand>(0),
-            dstOperand));
-        instructions->emplace_back(std::make_shared<Assembly::SetCCInstruction>(
-            std::make_shared<Assembly::G>(), dstOperand));
+        instructions.emplace_back(std::make_unique<Assembly::CmpInstruction>(
+            determineAssemblyType(binaryInstr.getSrc1()),
+            convertValue(binaryInstr.getSrc2()),
+            convertValue(binaryInstr.getSrc1())));
+        instructions.emplace_back(std::make_unique<Assembly::MovInstruction>(
+            determineAssemblyType(binaryInstr.getDst()),
+            std::make_unique<Assembly::ImmediateOperand>(0),
+            convertValue(binaryInstr.getDst())));
+        instructions.emplace_back(std::make_unique<Assembly::SetCCInstruction>(
+            std::make_unique<Assembly::G>(),
+            convertValue(binaryInstr.getDst())));
     }
     else if (dynamic_cast<const IR::GreaterThanOrEqualOperator *>(
                  binaryIROperator)) {
-        instructions->emplace_back(std::make_shared<Assembly::CmpInstruction>(
-            src1AssemblyType, src2Operand, src1Operand));
-        instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
-            dstAssemblyType, std::make_shared<Assembly::ImmediateOperand>(0),
-            dstOperand));
-        instructions->emplace_back(std::make_shared<Assembly::SetCCInstruction>(
-            std::make_shared<Assembly::GE>(), dstOperand));
+        instructions.emplace_back(std::make_unique<Assembly::CmpInstruction>(
+            determineAssemblyType(binaryInstr.getSrc1()),
+            convertValue(binaryInstr.getSrc2()),
+            convertValue(binaryInstr.getSrc1())));
+        instructions.emplace_back(std::make_unique<Assembly::MovInstruction>(
+            determineAssemblyType(binaryInstr.getDst()),
+            std::make_unique<Assembly::ImmediateOperand>(0),
+            convertValue(binaryInstr.getDst())));
+        instructions.emplace_back(std::make_unique<Assembly::SetCCInstruction>(
+            std::make_unique<Assembly::GE>(),
+            convertValue(binaryInstr.getDst())));
     }
     else {
         throw std::logic_error("Unsupported IR binary operator type");
@@ -394,84 +416,73 @@ void AssemblyGenerator::convertIRBinaryInstructionToAssy(
 
 void AssemblyGenerator::convertIRJumpInstructionToAssy(
     const IR::JumpInstruction &jumpInstr,
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions) {
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions) {
     // Generate a `Jmp` instruction to jump to the target (label).
-    instructions->emplace_back(
-        std::make_shared<Assembly::JmpInstruction>(jumpInstr.getTarget()));
+    instructions.emplace_back(
+        std::make_unique<Assembly::JmpInstruction>(jumpInstr.getTarget()));
 }
 
 void AssemblyGenerator::convertIRJumpIfZeroInstructionToAssy(
     const IR::JumpIfZeroInstruction &jumpIfZeroInstr,
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions) {
-    // Determine the assembly type based on the condition operand.
-    auto assemblyType = determineAssemblyType(jumpIfZeroInstr.getCondition());
-
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions) {
     // Generate a `Cmp` instruction to compare the condition with `0`.
-    instructions->emplace_back(std::make_shared<Assembly::CmpInstruction>(
-        assemblyType, std::make_shared<Assembly::ImmediateOperand>(0),
+    instructions.emplace_back(std::make_unique<Assembly::CmpInstruction>(
+        determineAssemblyType(jumpIfZeroInstr.getCondition()),
+        std::make_unique<Assembly::ImmediateOperand>(0),
         convertValue(jumpIfZeroInstr.getCondition())));
 
     // Generate a `JmpCC` instruction to conditionally jump to the target
     // (label).
-    instructions->emplace_back(std::make_shared<Assembly::JmpCCInstruction>(
-        std::make_shared<Assembly::E>(), jumpIfZeroInstr.getTarget()));
+    instructions.emplace_back(std::make_unique<Assembly::JmpCCInstruction>(
+        std::make_unique<Assembly::E>(), jumpIfZeroInstr.getTarget()));
 }
 
 void AssemblyGenerator::convertIRJumpIfNotZeroInstructionToAssy(
     const IR::JumpIfNotZeroInstruction &jumpIfNotZeroInstr,
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions) {
-    // Determine the assembly type based on the condition operand.
-    auto assemblyType =
-        determineAssemblyType(jumpIfNotZeroInstr.getCondition());
-
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions) {
     // Generate a `Cmp` instruction to compare the condition with `0`.
-    instructions->emplace_back(std::make_shared<Assembly::CmpInstruction>(
-        assemblyType, std::make_shared<Assembly::ImmediateOperand>(0),
+    instructions.emplace_back(std::make_unique<Assembly::CmpInstruction>(
+        determineAssemblyType(jumpIfNotZeroInstr.getCondition()),
+        std::make_unique<Assembly::ImmediateOperand>(0),
         convertValue(jumpIfNotZeroInstr.getCondition())));
 
     // Generate a `JmpCC` instruction to conditionally jump to the target
     // (label).
-    instructions->emplace_back(std::make_shared<Assembly::JmpCCInstruction>(
-        std::make_shared<Assembly::NE>(), jumpIfNotZeroInstr.getTarget()));
+    instructions.emplace_back(std::make_unique<Assembly::JmpCCInstruction>(
+        std::make_unique<Assembly::NE>(), jumpIfNotZeroInstr.getTarget()));
 }
 
 void AssemblyGenerator::convertIRCopyInstructionToAssy(
     const IR::CopyInstruction &copyInstr,
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions) {
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions) {
     // Convert the source and destination operands to assembly operands.
     auto srcOperand = convertValue(copyInstr.getSrc());
     auto dstOperand = convertValue(copyInstr.getDst());
 
     // Determine the assembly type of the `Mov` instruction.
-    auto assemblyType = determineMovType(
-        srcOperand, dstOperand, copyInstr.getSrc(), copyInstr.getDst());
+    auto assemblyType =
+        determineMovType(srcOperand.get(), dstOperand.get(), copyInstr.getSrc(),
+                         copyInstr.getDst());
 
     // Generate a `Mov` instruction to copy the source operand to the
     // destination operand.
-    instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
-        assemblyType, srcOperand, dstOperand));
+    instructions.emplace_back(std::make_unique<Assembly::MovInstruction>(
+        std::move(assemblyType), std::move(srcOperand), std::move(dstOperand)));
 }
 
 void AssemblyGenerator::convertIRLabelInstructionToAssy(
     const IR::LabelInstruction &labelInstr,
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions) {
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions) {
     // Generate a `Label` instruction with the label name.
-    instructions->emplace_back(
-        std::make_shared<Assembly::LabelInstruction>(labelInstr.getLabel()));
+    instructions.emplace_back(
+        std::make_unique<Assembly::LabelInstruction>(labelInstr.getLabel()));
 }
 
 void AssemblyGenerator::convertIRFunctionCallInstructionToAssy(
     const IR::FunctionCallInstruction &functionCallInstr,
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions) {
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions) {
     std::vector<std::string> argRegistersInStr = {"DI", "SI", "DX",
                                                   "CX", "R8", "R9"};
-    auto axReg = std::make_shared<Assembly::AX>();
 
     auto &irArgs = functionCallInstr.getArgs();
     std::vector<const IR::Value *> irRegisterArgs;
@@ -495,23 +506,23 @@ void AssemblyGenerator::convertIRFunctionCallInstructionToAssy(
     // odd).
     auto stackPadding = irStackArgs.size() % 2 != 0 ? 8 : 0;
     if (stackPadding != 0) {
-        instructions->emplace_back(
-            std::make_shared<Assembly::BinaryInstruction>(
-                std::make_shared<Assembly::SubtractOperator>(),
-                std::make_shared<Assembly::Quadword>(),
-                std::make_shared<Assembly::ImmediateOperand>(stackPadding),
-                std::make_shared<Assembly::RegisterOperand>("RSP")));
+        instructions.emplace_back(std::make_unique<Assembly::BinaryInstruction>(
+            std::make_unique<Assembly::SubtractOperator>(),
+            std::make_unique<Assembly::Quadword>(),
+            std::make_unique<Assembly::ImmediateOperand>(stackPadding),
+            std::make_unique<Assembly::RegisterOperand>("RSP")));
     }
 
     // Pass the arguments in registers.
     size_t registerIndex = 0;
     for (auto irRegisterArg : irRegisterArgs) {
-        auto registerOperand = std::make_shared<Assembly::RegisterOperand>(
+        auto registerOperand = std::make_unique<Assembly::RegisterOperand>(
             argRegistersInStr[registerIndex]);
         auto assyRegisterArg = convertValue(irRegisterArg);
         auto assemblyType = determineAssemblyType(irRegisterArg);
-        instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
-            assemblyType, assyRegisterArg, registerOperand));
+        instructions.emplace_back(std::make_unique<Assembly::MovInstruction>(
+            std::move(assemblyType), std::move(assyRegisterArg),
+            std::move(registerOperand)));
         registerIndex++;
     }
 
@@ -525,72 +536,68 @@ void AssemblyGenerator::convertIRFunctionCallInstructionToAssy(
 
         // Check if the operand is a register or needs to be moved to a register
         // first.
-        if (std::dynamic_pointer_cast<Assembly::RegisterOperand>(
-                assyStackArg)) {
+        if (dynamic_cast<Assembly::RegisterOperand *>(assyStackArg.get())) {
             // If it's already a register, push it directly.
-            instructions->emplace_back(
-                std::make_shared<Assembly::PushInstruction>(assyStackArg));
+            instructions.emplace_back(
+                std::make_unique<Assembly::PushInstruction>(
+                    std::move(assyStackArg)));
         }
         else {
             // For immediates, stack operands, or data operands, move to a
             // register first. Use R10 for quadword values, AX for longword
             // values.
-            std::shared_ptr<Assembly::Register> tempReg;
-            if (std::dynamic_pointer_cast<Assembly::Quadword>(assemblyType)) {
-                tempReg = std::make_shared<Assembly::R10>();
-            }
-            else {
-                tempReg = std::make_shared<Assembly::AX>();
-            }
-
-            instructions->emplace_back(
-                std::make_shared<Assembly::MovInstruction>(
-                    assemblyType, assyStackArg,
-                    std::make_shared<Assembly::RegisterOperand>(tempReg)));
-            instructions->emplace_back(
-                std::make_shared<Assembly::PushInstruction>(
-                    std::make_shared<Assembly::RegisterOperand>(tempReg)));
+            bool isQuadword =
+                dynamic_cast<Assembly::Quadword *>(assemblyType.get());
+            auto tempRegisterName = isQuadword ? "R10" : "AX";
+            instructions.emplace_back(
+                std::make_unique<Assembly::MovInstruction>(
+                    std::move(assemblyType), std::move(assyStackArg),
+                    std::make_unique<Assembly::RegisterOperand>(
+                        tempRegisterName)));
+            instructions.emplace_back(
+                std::make_unique<Assembly::PushInstruction>(
+                    std::make_unique<Assembly::RegisterOperand>(
+                        tempRegisterName)));
         }
     }
 
     // Emit a `Call` instruction (to call the function).
-    instructions->emplace_back(std::make_shared<Assembly::CallInstruction>(
+    instructions.emplace_back(std::make_unique<Assembly::CallInstruction>(
         functionCallInstr.getFunctionIdentifier()));
 
     // Adjust the stack pointer (after the function call).
     auto bytesToPop =
         8 * irStackArgs.size() + static_cast<size_t>(stackPadding);
     if (bytesToPop != 0) {
-        instructions->emplace_back(
-            std::make_shared<Assembly::BinaryInstruction>(
-                std::make_shared<Assembly::AddOperator>(),
-                std::make_shared<Assembly::Quadword>(),
-                std::make_shared<Assembly::ImmediateOperand>(
-                    static_cast<long>(bytesToPop)),
-                std::make_shared<Assembly::RegisterOperand>("RSP")));
+        instructions.emplace_back(std::make_unique<Assembly::BinaryInstruction>(
+            std::make_unique<Assembly::AddOperator>(),
+            std::make_unique<Assembly::Quadword>(),
+            std::make_unique<Assembly::ImmediateOperand>(
+                static_cast<long>(bytesToPop)),
+            std::make_unique<Assembly::RegisterOperand>("RSP")));
     }
 
     // Retrieve the return value.
     auto assyDst = convertValue(functionCallInstr.getDst());
     // Determine the assembly type of the destination operand.
     auto assemblyType = determineAssemblyType(functionCallInstr.getDst());
-    instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
-        assemblyType, std::make_shared<Assembly::RegisterOperand>(axReg),
-        assyDst));
+    instructions.emplace_back(std::make_unique<Assembly::MovInstruction>(
+        std::move(assemblyType),
+        std::make_unique<Assembly::RegisterOperand>("AX"), std::move(assyDst)));
 }
 
-std::shared_ptr<Assembly::Operand>
+std::unique_ptr<Assembly::Operand>
 AssemblyGenerator::convertValue(const IR::Value *irValue) {
     if (auto constantVal = dynamic_cast<const IR::ConstantValue *>(irValue)) {
         if (auto constInt = dynamic_cast<const AST::ConstantInt *>(
                 constantVal->getASTConstant())) {
-            return std::make_shared<Assembly::ImmediateOperand>(
+            return std::make_unique<Assembly::ImmediateOperand>(
                 constInt->getValue());
         }
         else if (auto constLong = dynamic_cast<const AST::ConstantLong *>(
                      constantVal->getASTConstant())) {
             // For long constants, we need to handle the full 64-bit value.
-            return std::make_shared<Assembly::ImmediateOperand>(
+            return std::make_unique<Assembly::ImmediateOperand>(
                 constLong->getValue());
         }
         else {
@@ -598,7 +605,7 @@ AssemblyGenerator::convertValue(const IR::Value *irValue) {
         }
     }
     else if (auto varVal = dynamic_cast<const IR::VariableValue *>(irValue)) {
-        return std::make_shared<Assembly::PseudoRegisterOperand>(
+        return std::make_unique<Assembly::PseudoRegisterOperand>(
             varVal->getIdentifier());
     }
     else {
@@ -608,42 +615,41 @@ AssemblyGenerator::convertValue(const IR::Value *irValue) {
 
 void AssemblyGenerator::convertIRSignExtendInstructionToAssy(
     const IR::SignExtendInstruction &signExtendInstr,
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions) {
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions) {
     // Convert the source and destination operands to assembly operands.
     auto srcOperand = convertValue(signExtendInstr.getSrc());
     auto dstOperand = convertValue(signExtendInstr.getDst());
 
     // Generate a `Movsx` instruction to sign extend from int to long.
-    instructions->emplace_back(
-        std::make_shared<Assembly::MovsxInstruction>(srcOperand, dstOperand));
+    instructions.emplace_back(std::make_unique<Assembly::MovsxInstruction>(
+        std::move(srcOperand), std::move(dstOperand)));
 }
 
 void AssemblyGenerator::convertIRTruncateInstructionToAssy(
     const IR::TruncateInstruction &truncateInstr,
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions) {
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions) {
     // Convert the source and destination operands to assembly operands.
     auto srcOperand = convertValue(truncateInstr.getSrc());
     auto dstOperand = convertValue(truncateInstr.getDst());
 
     // Generate a `Mov` instruction with Longword type to truncate from long to
     // int. This moves the lowest 4 bytes of the source to the destination.
-    instructions->emplace_back(std::make_shared<Assembly::MovInstruction>(
-        std::make_shared<Assembly::Longword>(), srcOperand, dstOperand));
+    instructions.emplace_back(std::make_unique<Assembly::MovInstruction>(
+        std::make_unique<Assembly::Longword>(), std::move(srcOperand),
+        std::move(dstOperand)));
 }
 
-std::shared_ptr<Assembly::AssemblyType>
+std::unique_ptr<Assembly::AssemblyType>
 AssemblyGenerator::determineAssemblyType(const IR::Value *irValue) {
     if (auto constantVal = dynamic_cast<const IR::ConstantValue *>(irValue)) {
         // For constants, determine type based on the AST constant type.
-        if (auto constInt = dynamic_cast<const AST::ConstantInt *>(
+        if (dynamic_cast<const AST::ConstantInt *>(
                 constantVal->getASTConstant())) {
-            return std::make_shared<Assembly::Longword>();
+            return std::make_unique<Assembly::Longword>();
         }
-        else if (auto constLong = dynamic_cast<const AST::ConstantLong *>(
+        else if (dynamic_cast<const AST::ConstantLong *>(
                      constantVal->getASTConstant())) {
-            return std::make_shared<Assembly::Quadword>();
+            return std::make_unique<Assembly::Quadword>();
         }
         else {
             throw std::logic_error(
@@ -668,16 +674,16 @@ AssemblyGenerator::determineAssemblyType(const IR::Value *irValue) {
     }
 }
 
-std::shared_ptr<Assembly::AssemblyType>
+std::unique_ptr<Assembly::AssemblyType>
 AssemblyGenerator::convertASTTypeToAssemblyType(const AST::Type *astType) {
     if (!astType) {
         throw std::logic_error("AST type is null");
     }
     if (*astType == AST::IntType()) {
-        return std::make_shared<Assembly::Longword>();
+        return std::make_unique<Assembly::Longword>();
     }
     else if (*astType == AST::LongType()) {
-        return std::make_shared<Assembly::Quadword>();
+        return std::make_unique<Assembly::Quadword>();
     }
     else {
         throw std::logic_error(
@@ -685,38 +691,34 @@ AssemblyGenerator::convertASTTypeToAssemblyType(const AST::Type *astType) {
     }
 }
 
-std::shared_ptr<Assembly::AssemblyType>
-AssemblyGenerator::determineMovType(std::shared_ptr<Assembly::Operand> src,
-                                    std::shared_ptr<Assembly::Operand> dst,
-                                    const IR::Value *irSrc,
-                                    const IR::Value *irDst) {
+std::unique_ptr<Assembly::AssemblyType> AssemblyGenerator::determineMovType(
+    const Assembly::Operand *src, const Assembly::Operand *dst,
+    const IR::Value *irSrc, const IR::Value *irDst) {
     // Determine the assembly type based on the IR operands.
     auto srcType = determineAssemblyType(irSrc);
     auto dstType = determineAssemblyType(irDst);
 
     // Use the larger type as base.
-    std::shared_ptr<Assembly::AssemblyType> baseType;
-    if (std::dynamic_pointer_cast<Assembly::Quadword>(srcType) ||
-        std::dynamic_pointer_cast<Assembly::Quadword>(dstType)) {
-        baseType = std::make_shared<Assembly::Quadword>();
+    std::unique_ptr<Assembly::AssemblyType> baseType;
+    if (dynamic_cast<Assembly::Quadword *>(srcType.get()) ||
+        dynamic_cast<Assembly::Quadword *>(dstType.get())) {
+        baseType = std::make_unique<Assembly::Quadword>();
     }
     else {
-        baseType = std::make_shared<Assembly::Longword>();
+        baseType = std::make_unique<Assembly::Longword>();
     }
 
     // Check if we can optimize to `movl` when using `quadword` type.
     // This is only safe when the destination is a register and the immediate
     // is non-negative, as `movl` zero-extends to 64 bits and does not write
     // the upper 4 bytes of memory destinations.
-    if (std::dynamic_pointer_cast<Assembly::Quadword>(baseType)) {
-        auto dstReg = std::dynamic_pointer_cast<Assembly::RegisterOperand>(dst);
-        if (dstReg) {
+    if (dynamic_cast<Assembly::Quadword *>(baseType.get())) {
+        if (dynamic_cast<const Assembly::RegisterOperand *>(dst)) {
             if (auto srcImm =
-                    std::dynamic_pointer_cast<Assembly::ImmediateOperand>(
-                        src)) {
+                    dynamic_cast<const Assembly::ImmediateOperand *>(src)) {
                 long value = srcImm->getImmediateLong();
                 if (value >= 0 && value <= std::numeric_limits<int>::max()) {
-                    return std::make_shared<Assembly::Longword>();
+                    return std::make_unique<Assembly::Longword>();
                 }
             }
         }

--- a/src/backend/assemblyGenerator.h
+++ b/src/backend/assemblyGenerator.h
@@ -31,7 +31,7 @@ class AssemblyGenerator {
      * @param irProgram The IR program to generate assembly from.
      * @return The generated assembly.
      */
-    [[nodiscard]] std::shared_ptr<Assembly::Program>
+    [[nodiscard]] std::unique_ptr<Assembly::Program>
     generateAssembly(const IR::Program &irProgram);
 
   private:
@@ -48,10 +48,10 @@ class AssemblyGenerator {
     /**
      * Convert an IR function definition to assembly.
      */
-    [[nodiscard]] std::shared_ptr<Assembly::FunctionDefinition>
+    [[nodiscard]] std::unique_ptr<Assembly::FunctionDefinition>
     convertIRFunctionDefinitionToAssy(
         const IR::FunctionDefinition &irFunctionDefinition,
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
+        std::unique_ptr<std::vector<std::unique_ptr<Assembly::Instruction>>>
             instructions);
 
     /**
@@ -60,7 +60,7 @@ class AssemblyGenerator {
      * @param irStaticVariable The IR static variable to convert.
      * @return The converted assembly static variable.
      */
-    [[nodiscard]] std::shared_ptr<Assembly::StaticVariable>
+    [[nodiscard]] std::unique_ptr<Assembly::StaticVariable>
     convertIRStaticVariableToAssy(const IR::StaticVariable &irStaticVariable);
 
     /**
@@ -71,8 +71,7 @@ class AssemblyGenerator {
      */
     void convertIRInstructionToAssy(
         const IR::Instruction &irInstruction,
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions);
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions);
 
     /**
      * Convert an IR return instruction to assembly.
@@ -82,8 +81,7 @@ class AssemblyGenerator {
      */
     void convertIRReturnInstructionToAssy(
         const IR::ReturnInstruction &returnInstr,
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions);
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions);
 
     /**
      * Convert an IR unary instruction to assembly.
@@ -93,8 +91,7 @@ class AssemblyGenerator {
      */
     void convertIRUnaryInstructionToAssy(
         const IR::UnaryInstruction &unaryInstr,
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions);
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions);
 
     /**
      * Convert an IR binary instruction to assembly.
@@ -104,8 +101,7 @@ class AssemblyGenerator {
      */
     void convertIRBinaryInstructionToAssy(
         const IR::BinaryInstruction &binaryInstr,
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions);
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions);
 
     /**
      * Convert an IR label instruction to assembly.
@@ -115,8 +111,7 @@ class AssemblyGenerator {
      */
     void convertIRLabelInstructionToAssy(
         const IR::LabelInstruction &labelInstr,
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions);
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions);
 
     /**
      * Convert an IR jump instruction to assembly.
@@ -126,8 +121,7 @@ class AssemblyGenerator {
      */
     void convertIRJumpInstructionToAssy(
         const IR::JumpInstruction &jumpInstr,
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions);
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions);
 
     /**
      * Convert an IR jump-if-zero instruction to assembly.
@@ -137,8 +131,7 @@ class AssemblyGenerator {
      */
     void convertIRJumpIfZeroInstructionToAssy(
         const IR::JumpIfZeroInstruction &jumpIfZeroInstr,
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions);
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions);
 
     /**
      * Convert an IR jump-if-not-zero instruction to assembly.
@@ -148,8 +141,7 @@ class AssemblyGenerator {
      */
     void convertIRJumpIfNotZeroInstructionToAssy(
         const IR::JumpIfNotZeroInstruction &jumpIfNotZeroInstr,
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions);
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions);
 
     /**
      * Convert an IR copy instruction to assembly.
@@ -159,8 +151,7 @@ class AssemblyGenerator {
      */
     void convertIRCopyInstructionToAssy(
         const IR::CopyInstruction &copyInstr,
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions);
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions);
 
     /**
      * Convert an IR sign-extend instruction to assembly.
@@ -170,8 +161,7 @@ class AssemblyGenerator {
      */
     void convertIRSignExtendInstructionToAssy(
         const IR::SignExtendInstruction &signExtendInstr,
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions);
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions);
 
     /**
      * Convert an IR truncate instruction to assembly.
@@ -181,8 +171,7 @@ class AssemblyGenerator {
      */
     void convertIRTruncateInstructionToAssy(
         const IR::TruncateInstruction &truncateInstr,
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions);
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions);
 
     /**
      * Convert an IR function-call instruction to assembly.
@@ -192,8 +181,7 @@ class AssemblyGenerator {
      */
     void convertIRFunctionCallInstructionToAssy(
         const IR::FunctionCallInstruction &functionCallInstr,
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions);
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions);
 
     /**
      * Convert an IR value to an assembly operand.
@@ -201,7 +189,7 @@ class AssemblyGenerator {
      * @param value The IR value to convert.
      * @return The converted assembly operand.
      */
-    [[nodiscard]] std::shared_ptr<Assembly::Operand>
+    [[nodiscard]] std::unique_ptr<Assembly::Operand>
     convertValue(const IR::Value *value);
 
     /**
@@ -210,7 +198,7 @@ class AssemblyGenerator {
      * @param value The IR value to determine the assembly type of.
      * @return The assembly type of the IR value.
      */
-    [[nodiscard]] std::shared_ptr<Assembly::AssemblyType>
+    [[nodiscard]] std::unique_ptr<Assembly::AssemblyType>
     determineAssemblyType(const IR::Value *value);
 
     /**
@@ -222,9 +210,8 @@ class AssemblyGenerator {
      * @param irDst The IR destination value of the move instruction.
      * @return The assembly type of the move instruction.
      */
-    [[nodiscard]] std::shared_ptr<Assembly::AssemblyType>
-    determineMovType(std::shared_ptr<Assembly::Operand> src,
-                     std::shared_ptr<Assembly::Operand> dst,
+    [[nodiscard]] std::unique_ptr<Assembly::AssemblyType>
+    determineMovType(const Assembly::Operand *src, const Assembly::Operand *dst,
                      const IR::Value *irSrc, const IR::Value *irDst);
 
   public:
@@ -234,7 +221,7 @@ class AssemblyGenerator {
      * @param astType The AST type to convert.
      * @return The converted assembly type.
      */
-    [[nodiscard]] static std::shared_ptr<Assembly::AssemblyType>
+    [[nodiscard]] static std::unique_ptr<Assembly::AssemblyType>
     convertASTTypeToAssemblyType(const AST::Type *astType);
 };
 } // namespace Assembly

--- a/src/backend/assemblyGenerator.h
+++ b/src/backend/assemblyGenerator.h
@@ -21,8 +21,8 @@ class AssemblyGenerator {
      * @param frontendSymbolTable The frontend symbol table.
      */
     explicit AssemblyGenerator(
-        std::shared_ptr<std::vector<std::shared_ptr<IR::StaticVariable>>>
-            irStaticVariables,
+        const std::vector<std::unique_ptr<IR::StaticVariable>>
+            &irStaticVariables,
         const AST::FrontendSymbolTable &frontendSymbolTable);
 
     /**
@@ -32,14 +32,13 @@ class AssemblyGenerator {
      * @return The generated assembly.
      */
     [[nodiscard]] std::shared_ptr<Assembly::Program>
-    generateAssembly(std::shared_ptr<IR::Program> irProgram);
+    generateAssembly(const IR::Program &irProgram);
 
   private:
     /**
      * The IR static variables.
      */
-    std::shared_ptr<std::vector<std::shared_ptr<IR::StaticVariable>>>
-        irStaticVariables;
+    const std::vector<std::unique_ptr<IR::StaticVariable>> &irStaticVariables;
 
     /**
      * The frontend symbol table.
@@ -51,7 +50,7 @@ class AssemblyGenerator {
      */
     [[nodiscard]] std::shared_ptr<Assembly::FunctionDefinition>
     convertIRFunctionDefinitionToAssy(
-        std::shared_ptr<IR::FunctionDefinition> irFunctionDefinition,
+        const IR::FunctionDefinition &irFunctionDefinition,
         std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
             instructions);
 
@@ -62,8 +61,7 @@ class AssemblyGenerator {
      * @return The converted assembly static variable.
      */
     [[nodiscard]] std::shared_ptr<Assembly::StaticVariable>
-    convertIRStaticVariableToAssy(
-        std::shared_ptr<IR::StaticVariable> irStaticVariable);
+    convertIRStaticVariableToAssy(const IR::StaticVariable &irStaticVariable);
 
     /**
      * Convert an IR instruction to assembly.
@@ -72,7 +70,7 @@ class AssemblyGenerator {
      * @param instructions The assembly instructions.
      */
     void convertIRInstructionToAssy(
-        std::shared_ptr<IR::Instruction> irInstruction,
+        const IR::Instruction &irInstruction,
         std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
             instructions);
 
@@ -83,7 +81,7 @@ class AssemblyGenerator {
      * @param instructions The assembly instructions.
      */
     void convertIRReturnInstructionToAssy(
-        std::shared_ptr<IR::ReturnInstruction> returnInstr,
+        const IR::ReturnInstruction &returnInstr,
         std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
             instructions);
 
@@ -94,7 +92,7 @@ class AssemblyGenerator {
      * @param instructions The assembly instructions.
      */
     void convertIRUnaryInstructionToAssy(
-        std::shared_ptr<IR::UnaryInstruction> unaryInstr,
+        const IR::UnaryInstruction &unaryInstr,
         std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
             instructions);
 
@@ -105,7 +103,7 @@ class AssemblyGenerator {
      * @param instructions The assembly instructions.
      */
     void convertIRBinaryInstructionToAssy(
-        std::shared_ptr<IR::BinaryInstruction> binaryInstr,
+        const IR::BinaryInstruction &binaryInstr,
         std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
             instructions);
 
@@ -116,7 +114,7 @@ class AssemblyGenerator {
      * @param instructions The assembly instructions.
      */
     void convertIRLabelInstructionToAssy(
-        std::shared_ptr<IR::LabelInstruction> labelInstr,
+        const IR::LabelInstruction &labelInstr,
         std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
             instructions);
 
@@ -127,7 +125,7 @@ class AssemblyGenerator {
      * @param instructions The assembly instructions.
      */
     void convertIRJumpInstructionToAssy(
-        std::shared_ptr<IR::JumpInstruction> jumpInstr,
+        const IR::JumpInstruction &jumpInstr,
         std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
             instructions);
 
@@ -138,7 +136,7 @@ class AssemblyGenerator {
      * @param instructions The assembly instructions.
      */
     void convertIRJumpIfZeroInstructionToAssy(
-        std::shared_ptr<IR::JumpIfZeroInstruction> jumpIfZeroInstr,
+        const IR::JumpIfZeroInstruction &jumpIfZeroInstr,
         std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
             instructions);
 
@@ -149,7 +147,7 @@ class AssemblyGenerator {
      * @param instructions The assembly instructions.
      */
     void convertIRJumpIfNotZeroInstructionToAssy(
-        std::shared_ptr<IR::JumpIfNotZeroInstruction> jumpIfNotZeroInstr,
+        const IR::JumpIfNotZeroInstruction &jumpIfNotZeroInstr,
         std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
             instructions);
 
@@ -160,7 +158,7 @@ class AssemblyGenerator {
      * @param instructions The assembly instructions.
      */
     void convertIRCopyInstructionToAssy(
-        std::shared_ptr<IR::CopyInstruction> copyInstr,
+        const IR::CopyInstruction &copyInstr,
         std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
             instructions);
 
@@ -171,7 +169,7 @@ class AssemblyGenerator {
      * @param instructions The assembly instructions.
      */
     void convertIRSignExtendInstructionToAssy(
-        std::shared_ptr<IR::SignExtendInstruction> signExtendInstr,
+        const IR::SignExtendInstruction &signExtendInstr,
         std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
             instructions);
 
@@ -182,7 +180,7 @@ class AssemblyGenerator {
      * @param instructions The assembly instructions.
      */
     void convertIRTruncateInstructionToAssy(
-        std::shared_ptr<IR::TruncateInstruction> truncateInstr,
+        const IR::TruncateInstruction &truncateInstr,
         std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
             instructions);
 
@@ -193,7 +191,7 @@ class AssemblyGenerator {
      * @param instructions The assembly instructions.
      */
     void convertIRFunctionCallInstructionToAssy(
-        std::shared_ptr<IR::FunctionCallInstruction> functionCallInstr,
+        const IR::FunctionCallInstruction &functionCallInstr,
         std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
             instructions);
 
@@ -204,7 +202,7 @@ class AssemblyGenerator {
      * @return The converted assembly operand.
      */
     [[nodiscard]] std::shared_ptr<Assembly::Operand>
-    convertValue(std::shared_ptr<IR::Value> value);
+    convertValue(const IR::Value *value);
 
     /**
      * Determine the assembly type of an IR value.
@@ -213,7 +211,7 @@ class AssemblyGenerator {
      * @return The assembly type of the IR value.
      */
     [[nodiscard]] std::shared_ptr<Assembly::AssemblyType>
-    determineAssemblyType(std::shared_ptr<IR::Value> value);
+    determineAssemblyType(const IR::Value *value);
 
     /**
      * Determine the assembly type of a mov instruction.
@@ -227,8 +225,7 @@ class AssemblyGenerator {
     [[nodiscard]] std::shared_ptr<Assembly::AssemblyType>
     determineMovType(std::shared_ptr<Assembly::Operand> src,
                      std::shared_ptr<Assembly::Operand> dst,
-                     std::shared_ptr<IR::Value> irSrc,
-                     std::shared_ptr<IR::Value> irDst);
+                     const IR::Value *irSrc, const IR::Value *irDst);
 
   public:
     /**
@@ -238,7 +235,7 @@ class AssemblyGenerator {
      * @return The converted assembly type.
      */
     [[nodiscard]] static std::shared_ptr<Assembly::AssemblyType>
-    convertASTTypeToAssemblyType(std::shared_ptr<AST::Type> astType);
+    convertASTTypeToAssemblyType(const AST::Type *astType);
 };
 } // namespace Assembly
 

--- a/src/backend/backendSymbolTable.cpp
+++ b/src/backend/backendSymbolTable.cpp
@@ -9,19 +9,17 @@ void convertFrontendToBackendSymbolTable(
     // Convert each entry from a frontend symbol table to a backend symbol
     // table.
     for (const auto &[identifier, entry] : frontendSymbolTable) {
-        auto astType = entry.first;
-        auto identifierAttribute = entry.second;
+        auto astType = entry.first.get();
+        auto identifierAttribute = entry.second.get();
 
         if (auto functionAttribute =
-                std::dynamic_pointer_cast<AST::FunctionAttribute>(
-                    identifierAttribute)) {
+                dynamic_cast<AST::FunctionAttribute *>(identifierAttribute)) {
             auto funEntry =
                 std::make_shared<FunEntry>(functionAttribute->isDefined());
             backendSymbolTable[identifier] = funEntry;
         }
-        else if (auto staticAttribute =
-                     std::dynamic_pointer_cast<AST::StaticAttribute>(
-                         identifierAttribute)) {
+        else if (auto staticAttribute = dynamic_cast<AST::StaticAttribute *>(
+                     identifierAttribute)) {
             auto assemblyType =
                 AssemblyGenerator::convertASTTypeToAssemblyType(astType);
             auto objEntry = std::make_shared<ObjEntry>(
@@ -29,8 +27,7 @@ void convertFrontendToBackendSymbolTable(
             backendSymbolTable[identifier] = objEntry;
         }
         else if (auto localAttribute =
-                     std::dynamic_pointer_cast<AST::LocalAttribute>(
-                         identifierAttribute)) {
+                     dynamic_cast<AST::LocalAttribute *>(identifierAttribute)) {
             auto assemblyType =
                 AssemblyGenerator::convertASTTypeToAssemblyType(astType);
             auto objEntry = std::make_shared<ObjEntry>(

--- a/src/backend/backendSymbolTable.cpp
+++ b/src/backend/backendSymbolTable.cpp
@@ -15,25 +15,23 @@ void convertFrontendToBackendSymbolTable(
         if (auto functionAttribute =
                 dynamic_cast<AST::FunctionAttribute *>(identifierAttribute)) {
             auto funEntry =
-                std::make_shared<FunEntry>(functionAttribute->isDefined());
-            backendSymbolTable[identifier] = funEntry;
+                std::make_unique<FunEntry>(functionAttribute->isDefined());
+            backendSymbolTable[identifier] = std::move(funEntry);
         }
-        else if (auto staticAttribute = dynamic_cast<AST::StaticAttribute *>(
-                     identifierAttribute)) {
+        else if (dynamic_cast<AST::StaticAttribute *>(identifierAttribute)) {
             auto assemblyType =
                 AssemblyGenerator::convertASTTypeToAssemblyType(astType);
-            auto objEntry = std::make_shared<ObjEntry>(
-                assemblyType, true); // true for static storage.
-            backendSymbolTable[identifier] = objEntry;
+            auto objEntry = std::make_unique<ObjEntry>(
+                std::move(assemblyType), true); // true for static storage.
+            backendSymbolTable[identifier] = std::move(objEntry);
         }
-        else if (auto localAttribute =
-                     dynamic_cast<AST::LocalAttribute *>(identifierAttribute)) {
+        else if (dynamic_cast<AST::LocalAttribute *>(identifierAttribute)) {
             auto assemblyType =
                 AssemblyGenerator::convertASTTypeToAssemblyType(astType);
-            auto objEntry = std::make_shared<ObjEntry>(
-                assemblyType,
+            auto objEntry = std::make_unique<ObjEntry>(
+                std::move(assemblyType),
                 false); // false for non-static storage.
-            backendSymbolTable[identifier] = objEntry;
+            backendSymbolTable[identifier] = std::move(objEntry);
         }
         else {
             throw std::logic_error("Unsupported identifier attribute type for "

--- a/src/backend/backendSymbolTable.h
+++ b/src/backend/backendSymbolTable.h
@@ -30,16 +30,16 @@ class ObjEntry : public BackendSymbolTableEntry {
      * @param assemblyType The assembly type of the object.
      * @param isStatic Whether the object is static.
      */
-    explicit ObjEntry(std::shared_ptr<AssemblyType> assemblyType, bool isStatic)
-        : assemblyType(assemblyType), isStatic(isStatic) {}
+    explicit ObjEntry(std::unique_ptr<AssemblyType> assemblyType, bool isStatic)
+        : assemblyType(std::move(assemblyType)), isStatic(isStatic) {}
 
     /**
      * Get the assembly type of the object.
      *
      * @return The assembly type of the object.
      */
-    [[nodiscard]] std::shared_ptr<AssemblyType> getAssemblyType() const {
-        return assemblyType;
+    [[nodiscard]] const AssemblyType *getAssemblyType() const {
+        return assemblyType.get();
     }
 
     /**
@@ -53,7 +53,7 @@ class ObjEntry : public BackendSymbolTableEntry {
     /**
      * The assembly type of the object.
      */
-    std::shared_ptr<AssemblyType> assemblyType;
+    std::unique_ptr<AssemblyType> assemblyType;
 
     /**
      * Boolean indicating whether the object is static storage.
@@ -91,10 +91,10 @@ class FunEntry : public BackendSymbolTableEntry {
  * Type alias for the backend symbol table.
  *
  * The key is the identifier (variable or function name), and the value is a
- * shared pointer to the backend symbol table entry.
+ * unique pointer to the backend symbol table entry.
  */
 using BackendSymbolTable =
-    std::unordered_map<std::string, std::shared_ptr<BackendSymbolTableEntry>>;
+    std::unordered_map<std::string, std::unique_ptr<BackendSymbolTableEntry>>;
 
 /**
  * Convert a frontend symbol table to a backend symbol table.

--- a/src/backend/fixupPass.cpp
+++ b/src/backend/fixupPass.cpp
@@ -2,33 +2,144 @@
 #include <limits>
 
 namespace Assembly {
-void FixupPass::fixup(
-    std::shared_ptr<std::vector<std::shared_ptr<TopLevel>>> topLevels) {
-    for (auto topLevel : *topLevels) {
-        if (auto functionDefinition =
-                std::dynamic_pointer_cast<FunctionDefinition>(topLevel)) {
-            rewriteFunctionDefinition(functionDefinition);
+namespace {
+std::unique_ptr<Assembly::AssemblyType>
+cloneAssemblyType(const Assembly::AssemblyType *type) {
+    if (!type) {
+        throw std::logic_error("Cloning null AssemblyType");
+    }
+    if (dynamic_cast<const Assembly::Longword *>(type)) {
+        return std::make_unique<Assembly::Longword>();
+    }
+    if (dynamic_cast<const Assembly::Quadword *>(type)) {
+        return std::make_unique<Assembly::Quadword>();
+    }
+    throw std::logic_error("Unsupported AssemblyType in cloneAssemblyType");
+}
+
+std::unique_ptr<Assembly::Operand>
+cloneOperand(const Assembly::Operand *operand) {
+    if (!operand) {
+        throw std::logic_error("Cloning null Operand");
+    }
+    if (auto imm = dynamic_cast<const Assembly::ImmediateOperand *>(operand)) {
+        return std::make_unique<Assembly::ImmediateOperand>(
+            imm->getImmediateLong());
+    }
+    if (auto regOp = dynamic_cast<const Assembly::RegisterOperand *>(operand)) {
+        auto reg = regOp->getRegister();
+        if (dynamic_cast<const Assembly::AX *>(reg)) {
+            return std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::AX>());
+        }
+        if (dynamic_cast<const Assembly::CX *>(reg)) {
+            return std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::CX>());
+        }
+        if (dynamic_cast<const Assembly::DX *>(reg)) {
+            return std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::DX>());
+        }
+        if (dynamic_cast<const Assembly::DI *>(reg)) {
+            return std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::DI>());
+        }
+        if (dynamic_cast<const Assembly::SI *>(reg)) {
+            return std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::SI>());
+        }
+        if (dynamic_cast<const Assembly::R8 *>(reg)) {
+            return std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R8>());
+        }
+        if (dynamic_cast<const Assembly::R9 *>(reg)) {
+            return std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R9>());
+        }
+        if (dynamic_cast<const Assembly::R10 *>(reg)) {
+            return std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R10>());
+        }
+        if (dynamic_cast<const Assembly::R11 *>(reg)) {
+            return std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R11>());
+        }
+        if (dynamic_cast<const Assembly::SP *>(reg)) {
+            return std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::SP>());
+        }
+        if (dynamic_cast<const Assembly::BP *>(reg)) {
+            return std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::BP>());
+        }
+        throw std::logic_error("Unsupported register in cloneOperand");
+    }
+    if (auto stackOp = dynamic_cast<const Assembly::StackOperand *>(operand)) {
+        auto reservedReg = stackOp->getReservedRegister();
+        if (dynamic_cast<const Assembly::SP *>(reservedReg)) {
+            return std::make_unique<Assembly::StackOperand>(
+                stackOp->getOffset(), std::make_unique<Assembly::SP>());
+        }
+        if (dynamic_cast<const Assembly::BP *>(reservedReg)) {
+            return std::make_unique<Assembly::StackOperand>(
+                stackOp->getOffset(), std::make_unique<Assembly::BP>());
+        }
+        throw std::logic_error("Unsupported reserved register in cloneOperand");
+    }
+    if (auto dataOp = dynamic_cast<const Assembly::DataOperand *>(operand)) {
+        return std::make_unique<Assembly::DataOperand>(dataOp->getIdentifier());
+    }
+    if (auto pseudoOp =
+            dynamic_cast<const Assembly::PseudoRegisterOperand *>(operand)) {
+        return std::make_unique<Assembly::PseudoRegisterOperand>(
+            pseudoOp->getPseudoRegister());
+    }
+    throw std::logic_error("Unsupported Operand in cloneOperand");
+}
+
+std::unique_ptr<Assembly::BinaryOperator>
+cloneBinaryOperator(const Assembly::BinaryOperator *binaryOperator) {
+    if (!binaryOperator) {
+        throw std::logic_error("Cloning null BinaryOperator");
+    }
+    if (dynamic_cast<const Assembly::AddOperator *>(binaryOperator)) {
+        return std::make_unique<Assembly::AddOperator>();
+    }
+    if (dynamic_cast<const Assembly::SubtractOperator *>(binaryOperator)) {
+        return std::make_unique<Assembly::SubtractOperator>();
+    }
+    if (dynamic_cast<const Assembly::MultiplyOperator *>(binaryOperator)) {
+        return std::make_unique<Assembly::MultiplyOperator>();
+    }
+    throw std::logic_error("Unsupported BinaryOperator in cloneBinaryOperator");
+}
+} // namespace
+
+void FixupPass::fixup(std::vector<std::unique_ptr<TopLevel>> &topLevels) {
+    for (auto &topLevel : topLevels) {
+        if (auto *functionDefinition =
+                dynamic_cast<FunctionDefinition *>(topLevel.get())) {
+            rewriteFunctionDefinition(*functionDefinition);
         }
     }
 }
 
 void FixupPass::insertAllocateStackInstruction(
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions,
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions,
     int stackSize) {
-    instructions->insert(instructions->begin(),
-                         std::make_shared<BinaryInstruction>(
-                             std::make_shared<SubtractOperator>(),
-                             std::make_shared<Quadword>(),
-                             std::make_shared<ImmediateOperand>(stackSize),
-                             std::make_shared<Assembly::RegisterOperand>(
-                                 std::make_shared<Assembly::SP>())));
+    instructions.insert(instructions.begin(),
+                        std::make_unique<BinaryInstruction>(
+                            std::make_unique<SubtractOperator>(),
+                            std::make_unique<Quadword>(),
+                            std::make_unique<ImmediateOperand>(stackSize),
+                            std::make_unique<Assembly::RegisterOperand>(
+                                std::make_unique<Assembly::SP>())));
 }
 
 void FixupPass::rewriteFunctionDefinition(
-    std::shared_ptr<FunctionDefinition> functionDefinition) {
-    auto instructions = functionDefinition->getFunctionBody();
-    auto preAlignedStackSize = functionDefinition->getStackSize();
+    FunctionDefinition &functionDefinition) {
+    auto &instructions = functionDefinition.getFunctionBody();
+    auto preAlignedStackSize = functionDefinition.getStackSize();
     // Align the stack size to the next multiple of 16.
     // Reference: https://math.stackexchange.com/a/291494.
     auto alignedStackSize = ((preAlignedStackSize - 1) | 15) + 1;
@@ -38,104 +149,97 @@ void FixupPass::rewriteFunctionDefinition(
                                    static_cast<int>(alignedStackSize));
     // Traverse the instructions (associated with (included in) the
     // function) and rewrite invalid instructions.
-    for (auto it = instructions->begin(); it != instructions->end(); it++) {
+    for (auto it = instructions.begin(); it != instructions.end(); it++) {
         if (auto movInstr =
-                std::dynamic_pointer_cast<Assembly::MovInstruction>(*it)) {
+                dynamic_cast<Assembly::MovInstruction *>(it->get())) {
             // If the mov instruction is invalid, rewrite it.
             // Replace the invalid `mov` instruction with two valid ones using
             // R10.
             // Replace the iterator with the new iterator returned by
             // `rewriteInvalidMov`.
-            if (isInvalidMov(movInstr)) {
-                it = rewriteInvalidMov(instructions, it, movInstr);
+            if (isInvalidMov(*movInstr)) {
+                it = rewriteInvalidMov(instructions, it, *movInstr);
             }
             // Check for large immediate values in mov instructions.
-            else if (isInvalidLargeImmediateMov(movInstr)) {
-                it =
-                    rewriteInvalidLargeImmediateMov(instructions, it, movInstr);
+            else if (isInvalidLargeImmediateMov(*movInstr)) {
+                it = rewriteInvalidLargeImmediateMov(instructions, it,
+                                                     *movInstr);
             }
             // Check for 8-byte immediate values in movl instructions.
-            else if (isInvalidLongwordImmediateMov(movInstr)) {
+            else if (isInvalidLongwordImmediateMov(*movInstr)) {
                 it = rewriteInvalidLongwordImmediateMov(instructions, it,
-                                                        movInstr);
+                                                        *movInstr);
             }
         }
         else if (auto movsxInstr =
-                     std::dynamic_pointer_cast<Assembly::MovsxInstruction>(
-                         *it)) {
-            if (isInvalidMovsx(movsxInstr)) {
-                it = rewriteInvalidMovsx(instructions, it, movsxInstr);
+                     dynamic_cast<Assembly::MovsxInstruction *>(it->get())) {
+            if (isInvalidMovsx(*movsxInstr)) {
+                it = rewriteInvalidMovsx(instructions, it, *movsxInstr);
             }
         }
         else if (auto binInstr =
-                     std::dynamic_pointer_cast<Assembly::BinaryInstruction>(
-                         *it)) {
-            if (isInvalidLargeImmediateBinary(binInstr)) {
+                     dynamic_cast<Assembly::BinaryInstruction *>(it->get())) {
+            if (isInvalidLargeImmediateBinary(*binInstr)) {
                 it = rewriteInvalidLargeImmediateBinary(instructions, it,
-                                                        binInstr);
+                                                        *binInstr);
             }
-            else if (isInvalidBinary(binInstr)) {
-                it = rewriteInvalidBinary(instructions, it, binInstr);
+            else if (isInvalidBinary(*binInstr)) {
+                it = rewriteInvalidBinary(instructions, it, *binInstr);
             }
         }
         else if (auto idivInstr =
-                     std::dynamic_pointer_cast<Assembly::IdivInstruction>(
-                         *it)) {
-            if (isInvalidIdiv(idivInstr)) {
-                it = rewriteInvalidIdiv(instructions, it, idivInstr);
+                     dynamic_cast<Assembly::IdivInstruction *>(it->get())) {
+            if (isInvalidIdiv(*idivInstr)) {
+                it = rewriteInvalidIdiv(instructions, it, *idivInstr);
             }
         }
         else if (auto cmpInstr =
-                     std::dynamic_pointer_cast<Assembly::CmpInstruction>(*it)) {
-            if (isInvalidLargeImmediateCmp(cmpInstr)) {
-                it =
-                    rewriteInvalidLargeImmediateCmp(instructions, it, cmpInstr);
+                     dynamic_cast<Assembly::CmpInstruction *>(it->get())) {
+            if (isInvalidLargeImmediateCmp(*cmpInstr)) {
+                it = rewriteInvalidLargeImmediateCmp(instructions, it,
+                                                     *cmpInstr);
             }
-            else if (isInvalidCmp(cmpInstr)) {
-                it = rewriteInvalidCmp(instructions, it, cmpInstr);
+            else if (isInvalidCmp(*cmpInstr)) {
+                it = rewriteInvalidCmp(instructions, it, *cmpInstr);
             }
         }
         else if (auto pushInstr =
-                     std::dynamic_pointer_cast<Assembly::PushInstruction>(
-                         *it)) {
-            if (isInvalidLargeImmediatePush(pushInstr)) {
+                     dynamic_cast<Assembly::PushInstruction *>(it->get())) {
+            if (isInvalidLargeImmediatePush(*pushInstr)) {
                 it = rewriteInvalidLargeImmediatePush(instructions, it,
-                                                      pushInstr);
+                                                      *pushInstr);
             }
         }
     }
 }
 
-bool FixupPass::isInvalidMov(
-    std::shared_ptr<Assembly::MovInstruction> movInstr) {
+bool FixupPass::isInvalidMov(const Assembly::MovInstruction &movInstr) {
     // Stack operands and data operands are memory addresses (memory-address
     // operands).
-    return (std::dynamic_pointer_cast<Assembly::StackOperand>(
-                movInstr->getSrc()) != nullptr ||
-            std::dynamic_pointer_cast<Assembly::DataOperand>(
-                movInstr->getSrc()) != nullptr) &&
-           (std::dynamic_pointer_cast<Assembly::StackOperand>(
-                movInstr->getDst()) != nullptr ||
-            std::dynamic_pointer_cast<Assembly::DataOperand>(
-                movInstr->getDst()) != nullptr);
+    auto src = movInstr.getSrc();
+    auto dst = movInstr.getDst();
+    return (dynamic_cast<const Assembly::StackOperand *>(src) != nullptr ||
+            dynamic_cast<const Assembly::DataOperand *>(src) != nullptr) &&
+           (dynamic_cast<const Assembly::StackOperand *>(dst) != nullptr ||
+            dynamic_cast<const Assembly::DataOperand *>(dst) != nullptr);
 }
 
 bool FixupPass::isInvalidLargeImmediateMov(
-    std::shared_ptr<Assembly::MovInstruction> movInstr) {
+    const Assembly::MovInstruction &movInstr) {
     // Check if it's a quadword mov with large immediate to memory.
     auto quadwordType =
-        std::dynamic_pointer_cast<Assembly::Quadword>(movInstr->getType());
+        dynamic_cast<const Assembly::Quadword *>(movInstr.getType());
     if (!quadwordType)
         return false;
 
-    auto immediateSrc = std::dynamic_pointer_cast<Assembly::ImmediateOperand>(
-        movInstr->getSrc());
+    auto immediateSrc =
+        dynamic_cast<const Assembly::ImmediateOperand *>(movInstr.getSrc());
     if (!immediateSrc)
         return false;
 
     auto memoryDst =
-        std::dynamic_pointer_cast<Assembly::StackOperand>(movInstr->getDst()) ||
-        std::dynamic_pointer_cast<Assembly::DataOperand>(movInstr->getDst());
+        dynamic_cast<const Assembly::StackOperand *>(movInstr.getDst()) ||
+        dynamic_cast<const Assembly::DataOperand *>(movInstr.getDst());
     if (!memoryDst)
         return false;
 
@@ -146,15 +250,15 @@ bool FixupPass::isInvalidLargeImmediateMov(
 }
 
 bool FixupPass::isInvalidLongwordImmediateMov(
-    std::shared_ptr<Assembly::MovInstruction> movInstr) {
+    const Assembly::MovInstruction &movInstr) {
     // Check if it's a longword mov with 8-byte immediate value.
     auto longwordType =
-        std::dynamic_pointer_cast<Assembly::Longword>(movInstr->getType());
+        dynamic_cast<const Assembly::Longword *>(movInstr.getType());
     if (!longwordType)
         return false;
 
-    auto immediateSrc = std::dynamic_pointer_cast<Assembly::ImmediateOperand>(
-        movInstr->getSrc());
+    auto immediateSrc =
+        dynamic_cast<const Assembly::ImmediateOperand *>(movInstr.getSrc());
     if (!immediateSrc)
         return false;
 
@@ -163,59 +267,58 @@ bool FixupPass::isInvalidLongwordImmediateMov(
     return value > std::numeric_limits<unsigned int>::max() || value < 0;
 }
 
-bool FixupPass::isInvalidMovsx(
-    std::shared_ptr<Assembly::MovsxInstruction> movsxInstr) {
+bool FixupPass::isInvalidMovsx(const Assembly::MovsxInstruction &movsxInstr) {
     // Movsx can't use a memory address as a destination or an immediate value
     // as a source.
-    bool invalidSrc = std::dynamic_pointer_cast<Assembly::ImmediateOperand>(
-                          movsxInstr->getSrc()) != nullptr;
-    bool invalidDst = std::dynamic_pointer_cast<Assembly::StackOperand>(
-                          movsxInstr->getDst()) != nullptr ||
-                      std::dynamic_pointer_cast<Assembly::DataOperand>(
-                          movsxInstr->getDst()) != nullptr;
+    bool invalidSrc = dynamic_cast<const Assembly::ImmediateOperand *>(
+                          movsxInstr.getSrc()) != nullptr;
+    bool invalidDst =
+        dynamic_cast<const Assembly::StackOperand *>(movsxInstr.getDst()) !=
+            nullptr ||
+        dynamic_cast<const Assembly::DataOperand *>(movsxInstr.getDst()) !=
+            nullptr;
     return invalidSrc || invalidDst;
 }
 
-bool FixupPass::isInvalidBinary(
-    std::shared_ptr<Assembly::BinaryInstruction> binInstr) {
-    if (std::dynamic_pointer_cast<Assembly::AddOperator>(
-            binInstr->getBinaryOperator()) ||
-        std::dynamic_pointer_cast<Assembly::SubtractOperator>(
-            binInstr->getBinaryOperator())) {
-        return (std::dynamic_pointer_cast<Assembly::StackOperand>(
-                    binInstr->getOperand1()) != nullptr ||
-                std::dynamic_pointer_cast<Assembly::DataOperand>(
-                    binInstr->getOperand1()) != nullptr) &&
-               (std::dynamic_pointer_cast<Assembly::StackOperand>(
-                    binInstr->getOperand2()) != nullptr ||
-                std::dynamic_pointer_cast<Assembly::DataOperand>(
-                    binInstr->getOperand2()) != nullptr);
+bool FixupPass::isInvalidBinary(const Assembly::BinaryInstruction &binInstr) {
+    if (dynamic_cast<const Assembly::AddOperator *>(
+            binInstr.getBinaryOperator()) ||
+        dynamic_cast<const Assembly::SubtractOperator *>(
+            binInstr.getBinaryOperator())) {
+        return (dynamic_cast<const Assembly::StackOperand *>(
+                    binInstr.getOperand1()) != nullptr ||
+                dynamic_cast<const Assembly::DataOperand *>(
+                    binInstr.getOperand1()) != nullptr) &&
+               (dynamic_cast<const Assembly::StackOperand *>(
+                    binInstr.getOperand2()) != nullptr ||
+                dynamic_cast<const Assembly::DataOperand *>(
+                    binInstr.getOperand2()) != nullptr);
     }
-    else if (std::dynamic_pointer_cast<Assembly::MultiplyOperator>(
-                 binInstr->getBinaryOperator())) {
-        return std::dynamic_pointer_cast<Assembly::StackOperand>(
-                   binInstr->getOperand2()) != nullptr ||
-               std::dynamic_pointer_cast<Assembly::DataOperand>(
-                   binInstr->getOperand2()) != nullptr;
+    else if (dynamic_cast<const Assembly::MultiplyOperator *>(
+                 binInstr.getBinaryOperator())) {
+        return dynamic_cast<const Assembly::StackOperand *>(
+                   binInstr.getOperand2()) != nullptr ||
+               dynamic_cast<const Assembly::DataOperand *>(
+                   binInstr.getOperand2()) != nullptr;
     }
     return false;
 }
 
 bool FixupPass::isInvalidLargeImmediateBinary(
-    std::shared_ptr<Assembly::BinaryInstruction> binInstr) {
+    const Assembly::BinaryInstruction &binInstr) {
     // Check if it's a `Quadword` `Binary` instruction with a large immediate
     // value.
     auto quadwordType =
-        std::dynamic_pointer_cast<Assembly::Quadword>(binInstr->getType());
+        dynamic_cast<const Assembly::Quadword *>(binInstr.getType());
     if (!quadwordType)
         return false;
 
-    auto immediateOp1 = std::dynamic_pointer_cast<Assembly::ImmediateOperand>(
-        binInstr->getOperand1());
-    auto immediateOp2 = std::dynamic_pointer_cast<Assembly::ImmediateOperand>(
-        binInstr->getOperand2());
+    auto immediateOp1 = dynamic_cast<const Assembly::ImmediateOperand *>(
+        binInstr.getOperand1());
+    auto immediateOp2 = dynamic_cast<const Assembly::ImmediateOperand *>(
+        binInstr.getOperand2());
 
-    std::shared_ptr<Assembly::ImmediateOperand> immediateOp = nullptr;
+    const Assembly::ImmediateOperand *immediateOp = nullptr;
     if (immediateOp1) {
         immediateOp = immediateOp1;
     }
@@ -233,46 +336,40 @@ bool FixupPass::isInvalidLargeImmediateBinary(
            value < std::numeric_limits<int>::min();
 }
 
-bool FixupPass::isInvalidIdiv(
-    std::shared_ptr<Assembly::IdivInstruction> idivInstr) {
-    return std::dynamic_pointer_cast<Assembly::ImmediateOperand>(
-               idivInstr->getOperand()) != nullptr;
+bool FixupPass::isInvalidIdiv(const Assembly::IdivInstruction &idivInstr) {
+    return dynamic_cast<const Assembly::ImmediateOperand *>(
+               idivInstr.getOperand()) != nullptr;
 }
 
-bool FixupPass::isInvalidCmp(
-    std::shared_ptr<Assembly::CmpInstruction> cmpInstr) {
-    if ((std::dynamic_pointer_cast<Assembly::StackOperand>(
-             cmpInstr->getOperand1()) ||
-         std::dynamic_pointer_cast<Assembly::DataOperand>(
-             cmpInstr->getOperand1())) &&
-        (std::dynamic_pointer_cast<Assembly::StackOperand>(
-             cmpInstr->getOperand2()) ||
-         std::dynamic_pointer_cast<Assembly::DataOperand>(
-             cmpInstr->getOperand2()))) {
+bool FixupPass::isInvalidCmp(const Assembly::CmpInstruction &cmpInstr) {
+    if ((dynamic_cast<const Assembly::StackOperand *>(cmpInstr.getOperand1()) ||
+         dynamic_cast<const Assembly::DataOperand *>(cmpInstr.getOperand1())) &&
+        (dynamic_cast<const Assembly::StackOperand *>(cmpInstr.getOperand2()) ||
+         dynamic_cast<const Assembly::DataOperand *>(cmpInstr.getOperand2()))) {
         return true;
     }
-    else if (std::dynamic_pointer_cast<Assembly::ImmediateOperand>(
-                 cmpInstr->getOperand2())) {
+    else if (dynamic_cast<const Assembly::ImmediateOperand *>(
+                 cmpInstr.getOperand2())) {
         return true;
     }
     return false;
 }
 
 bool FixupPass::isInvalidLargeImmediateCmp(
-    std::shared_ptr<Assembly::CmpInstruction> cmpInstr) {
+    const Assembly::CmpInstruction &cmpInstr) {
     // Check if it's a `Quadword` `Cmp` instruction with a large immediate
     // value.
     auto quadwordType =
-        std::dynamic_pointer_cast<Assembly::Quadword>(cmpInstr->getType());
+        dynamic_cast<const Assembly::Quadword *>(cmpInstr.getType());
     if (!quadwordType)
         return false;
 
-    auto immediateOp1 = std::dynamic_pointer_cast<Assembly::ImmediateOperand>(
-        cmpInstr->getOperand1());
-    auto immediateOp2 = std::dynamic_pointer_cast<Assembly::ImmediateOperand>(
-        cmpInstr->getOperand2());
+    auto immediateOp1 = dynamic_cast<const Assembly::ImmediateOperand *>(
+        cmpInstr.getOperand1());
+    auto immediateOp2 = dynamic_cast<const Assembly::ImmediateOperand *>(
+        cmpInstr.getOperand2());
 
-    std::shared_ptr<Assembly::ImmediateOperand> immediateOp = nullptr;
+    const Assembly::ImmediateOperand *immediateOp = nullptr;
     if (immediateOp1) {
         immediateOp = immediateOp1;
     }
@@ -291,9 +388,9 @@ bool FixupPass::isInvalidLargeImmediateCmp(
 }
 
 bool FixupPass::isInvalidLargeImmediatePush(
-    std::shared_ptr<Assembly::PushInstruction> pushInstr) {
-    auto immediateOp = std::dynamic_pointer_cast<Assembly::ImmediateOperand>(
-        pushInstr->getOperand());
+    const Assembly::PushInstruction &pushInstr) {
+    auto immediateOp = dynamic_cast<const Assembly::ImmediateOperand *>(
+        pushInstr.getOperand());
     if (!immediateOp)
         return false;
 
@@ -304,220 +401,228 @@ bool FixupPass::isInvalidLargeImmediatePush(
            value < std::numeric_limits<int>::min();
 }
 
-std::vector<std::shared_ptr<Assembly::Instruction>>::iterator
+std::vector<std::unique_ptr<Assembly::Instruction>>::iterator
 FixupPass::rewriteInvalidMov(
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions,
-    std::vector<std::shared_ptr<Assembly::Instruction>>::iterator it,
-    std::shared_ptr<Assembly::MovInstruction> movInst) {
-    // Create a new register operand for R10 ("r10d").
-    auto r10d = std::make_shared<Assembly::RegisterOperand>(
-        std::make_shared<Assembly::R10>());
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions,
+    std::vector<std::unique_ptr<Assembly::Instruction>>::iterator it,
+    const Assembly::MovInstruction &movInst) {
+    auto newMov1 = std::make_unique<Assembly::MovInstruction>(
+        cloneAssemblyType(movInst.getType()), cloneOperand(movInst.getSrc()),
+        std::make_unique<Assembly::RegisterOperand>(
+            std::make_unique<Assembly::R10>()));
+    auto newMov2 = std::make_unique<Assembly::MovInstruction>(
+        cloneAssemblyType(movInst.getType()),
+        std::make_unique<Assembly::RegisterOperand>(
+            std::make_unique<Assembly::R10>()),
+        cloneOperand(movInst.getDst()));
 
-    // Create two new movInstructions using `r10d` as an intermediate register
-    // based on the original source and destination operands.
-    auto newMov1 = std::make_shared<Assembly::MovInstruction>(
-        movInst->getType(), movInst->getSrc(), r10d);
-    auto newMov2 = std::make_shared<Assembly::MovInstruction>(
-        movInst->getType(), r10d, movInst->getDst());
-
-    // Replace the original `mov` instruction with the first new `mov`
-    // instruction.
-    *it = newMov1;
-    // Insert the second new `mov` instruction after the first one.
-    it = instructions->insert(it + 1, newMov2);
-
-    // Return the new iterator pointing to the second `mov` instruction.
+    *it = std::move(newMov1);
+    it = instructions.insert(it + 1, std::move(newMov2));
     return it;
 }
 
-std::vector<std::shared_ptr<Assembly::Instruction>>::iterator
+std::vector<std::unique_ptr<Assembly::Instruction>>::iterator
 FixupPass::rewriteInvalidMovsx(
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions,
-    std::vector<std::shared_ptr<Assembly::Instruction>>::iterator it,
-    std::shared_ptr<Assembly::MovsxInstruction> movsxInst) {
-    auto src = movsxInst->getSrc();
-    auto dst = movsxInst->getDst();
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions,
+    std::vector<std::unique_ptr<Assembly::Instruction>>::iterator it,
+    const Assembly::MovsxInstruction &movsxInst) {
+    auto src = movsxInst.getSrc();
+    auto dst = movsxInst.getDst();
 
     bool invalidSrc =
-        std::dynamic_pointer_cast<Assembly::ImmediateOperand>(src) != nullptr;
+        dynamic_cast<const Assembly::ImmediateOperand *>(src) != nullptr;
     bool invalidDst =
-        std::dynamic_pointer_cast<Assembly::StackOperand>(dst) != nullptr ||
-        std::dynamic_pointer_cast<Assembly::DataOperand>(dst) != nullptr;
+        dynamic_cast<const Assembly::StackOperand *>(dst) != nullptr ||
+        dynamic_cast<const Assembly::DataOperand *>(dst) != nullptr;
 
     if (invalidSrc && invalidDst) {
-        auto r10d = std::make_shared<Assembly::RegisterOperand>(
-            std::make_shared<Assembly::R10>());
-        auto r11d = std::make_shared<Assembly::RegisterOperand>(
-            std::make_shared<Assembly::R11>());
+        auto newMov1 = std::make_unique<Assembly::MovInstruction>(
+            std::make_unique<Assembly::Longword>(), cloneOperand(src),
+            std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R10>()));
+        auto newMovsx = std::make_unique<Assembly::MovsxInstruction>(
+            std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R10>()),
+            std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R11>()));
+        auto newMov2 = std::make_unique<Assembly::MovInstruction>(
+            std::make_unique<Assembly::Quadword>(),
+            std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R11>()),
+            cloneOperand(dst));
 
-        auto newMov1 = std::make_shared<Assembly::MovInstruction>(
-            std::make_shared<Assembly::Longword>(), src, r10d);
-
-        auto newMovsx =
-            std::make_shared<Assembly::MovsxInstruction>(r10d, r11d);
-
-        auto newMov2 = std::make_shared<Assembly::MovInstruction>(
-            std::make_shared<Assembly::Quadword>(), r11d, dst);
-
-        *it = newMov1;
-        it = instructions->insert(it + 1, newMovsx);
-        it = instructions->insert(it + 1, newMov2);
+        *it = std::move(newMov1);
+        it = instructions.insert(it + 1, std::move(newMovsx));
+        it = instructions.insert(it + 1, std::move(newMov2));
     }
     else if (invalidSrc) {
-        auto r10d = std::make_shared<Assembly::RegisterOperand>(
-            std::make_shared<Assembly::R10>());
+        auto newMov = std::make_unique<Assembly::MovInstruction>(
+            std::make_unique<Assembly::Longword>(), cloneOperand(src),
+            std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R10>()));
+        auto newMovsx = std::make_unique<Assembly::MovsxInstruction>(
+            std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R10>()),
+            cloneOperand(dst));
 
-        auto newMov = std::make_shared<Assembly::MovInstruction>(
-            std::make_shared<Assembly::Longword>(), src, r10d);
-
-        auto newMovsx = std::make_shared<Assembly::MovsxInstruction>(r10d, dst);
-
-        *it = newMov;
-        it = instructions->insert(it + 1, newMovsx);
+        *it = std::move(newMov);
+        it = instructions.insert(it + 1, std::move(newMovsx));
     }
     else if (invalidDst) {
-        auto r11d = std::make_shared<Assembly::RegisterOperand>(
-            std::make_shared<Assembly::R11>());
+        auto newMovsx = std::make_unique<Assembly::MovsxInstruction>(
+            cloneOperand(src), std::make_unique<Assembly::RegisterOperand>(
+                                   std::make_unique<Assembly::R11>()));
+        auto newMov = std::make_unique<Assembly::MovInstruction>(
+            std::make_unique<Assembly::Quadword>(),
+            std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R11>()),
+            cloneOperand(dst));
 
-        auto newMovsx = std::make_shared<Assembly::MovsxInstruction>(src, r11d);
-
-        auto newMov = std::make_shared<Assembly::MovInstruction>(
-            std::make_shared<Assembly::Quadword>(), r11d, dst);
-
-        *it = newMovsx;
-        it = instructions->insert(it + 1, newMov);
+        *it = std::move(newMovsx);
+        it = instructions.insert(it + 1, std::move(newMov));
     }
 
     return it;
 }
 
-std::vector<std::shared_ptr<Assembly::Instruction>>::iterator
+std::vector<std::unique_ptr<Assembly::Instruction>>::iterator
 FixupPass::rewriteInvalidBinary(
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions,
-    std::vector<std::shared_ptr<Assembly::Instruction>>::iterator it,
-    std::shared_ptr<Assembly::BinaryInstruction> binInstr) {
-    if (std::dynamic_pointer_cast<Assembly::AddOperator>(
-            binInstr->getBinaryOperator()) ||
-        std::dynamic_pointer_cast<Assembly::SubtractOperator>(
-            binInstr->getBinaryOperator())) {
-        auto r10d = std::make_shared<Assembly::RegisterOperand>(
-            std::make_shared<Assembly::R10>());
-        auto newMov = std::make_shared<Assembly::MovInstruction>(
-            binInstr->getType(), binInstr->getOperand1(), r10d);
-        auto newBin = std::make_shared<Assembly::BinaryInstruction>(
-            binInstr->getBinaryOperator(), binInstr->getType(), r10d,
-            binInstr->getOperand2());
-        *it = newMov;
-        it = instructions->insert(it + 1, newBin);
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions,
+    std::vector<std::unique_ptr<Assembly::Instruction>>::iterator it,
+    const Assembly::BinaryInstruction &binInstr) {
+    if (dynamic_cast<const Assembly::AddOperator *>(
+            binInstr.getBinaryOperator()) ||
+        dynamic_cast<const Assembly::SubtractOperator *>(
+            binInstr.getBinaryOperator())) {
+        auto newMov = std::make_unique<Assembly::MovInstruction>(
+            cloneAssemblyType(binInstr.getType()),
+            cloneOperand(binInstr.getOperand1()),
+            std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R10>()));
+        auto newBin = std::make_unique<Assembly::BinaryInstruction>(
+            cloneBinaryOperator(binInstr.getBinaryOperator()),
+            cloneAssemblyType(binInstr.getType()),
+            std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R10>()),
+            cloneOperand(binInstr.getOperand2()));
+        *it = std::move(newMov);
+        it = instructions.insert(it + 1, std::move(newBin));
     }
-    else if (std::dynamic_pointer_cast<Assembly::MultiplyOperator>(
-                 binInstr->getBinaryOperator())) {
-        auto r11d = std::make_shared<Assembly::RegisterOperand>(
-            std::make_shared<Assembly::R11>());
-        auto newMov1 = std::make_shared<Assembly::MovInstruction>(
-            binInstr->getType(), binInstr->getOperand2(), r11d);
-        auto newImul = std::make_shared<Assembly::BinaryInstruction>(
-            binInstr->getBinaryOperator(), binInstr->getType(),
-            binInstr->getOperand1(), r11d);
-        auto newMov2 = std::make_shared<Assembly::MovInstruction>(
-            binInstr->getType(), r11d, binInstr->getOperand2());
-        *it = newMov1;
-        it = instructions->insert(it + 1, newImul);
-        it = instructions->insert(it + 1, newMov2);
+    else if (dynamic_cast<const Assembly::MultiplyOperator *>(
+                 binInstr.getBinaryOperator())) {
+        auto newMov1 = std::make_unique<Assembly::MovInstruction>(
+            cloneAssemblyType(binInstr.getType()),
+            cloneOperand(binInstr.getOperand2()),
+            std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R11>()));
+        auto newImul = std::make_unique<Assembly::BinaryInstruction>(
+            cloneBinaryOperator(binInstr.getBinaryOperator()),
+            cloneAssemblyType(binInstr.getType()),
+            cloneOperand(binInstr.getOperand1()),
+            std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R11>()));
+        auto newMov2 = std::make_unique<Assembly::MovInstruction>(
+            cloneAssemblyType(binInstr.getType()),
+            std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R11>()),
+            cloneOperand(binInstr.getOperand2()));
+        *it = std::move(newMov1);
+        it = instructions.insert(it + 1, std::move(newImul));
+        it = instructions.insert(it + 1, std::move(newMov2));
     }
 
     return it;
 }
 
-std::vector<std::shared_ptr<Assembly::Instruction>>::iterator
+std::vector<std::unique_ptr<Assembly::Instruction>>::iterator
 FixupPass::rewriteInvalidIdiv(
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions,
-    std::vector<std::shared_ptr<Assembly::Instruction>>::iterator it,
-    std::shared_ptr<Assembly::IdivInstruction> idivInstr) {
-    auto r10d = std::make_shared<Assembly::RegisterOperand>(
-        std::make_shared<Assembly::R10>());
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions,
+    std::vector<std::unique_ptr<Assembly::Instruction>>::iterator it,
+    const Assembly::IdivInstruction &idivInstr) {
+    auto newMov = std::make_unique<Assembly::MovInstruction>(
+        cloneAssemblyType(idivInstr.getType()),
+        cloneOperand(idivInstr.getOperand()),
+        std::make_unique<Assembly::RegisterOperand>(
+            std::make_unique<Assembly::R10>()));
+    auto newIdiv = std::make_unique<Assembly::IdivInstruction>(
+        cloneAssemblyType(idivInstr.getType()),
+        std::make_unique<Assembly::RegisterOperand>(
+            std::make_unique<Assembly::R10>()));
 
-    auto newMov = std::make_shared<Assembly::MovInstruction>(
-        idivInstr->getType(), idivInstr->getOperand(), r10d);
-    auto newIdiv =
-        std::make_shared<Assembly::IdivInstruction>(idivInstr->getType(), r10d);
-
-    *it = newMov;
-    it = instructions->insert(it + 1, newIdiv);
-
+    *it = std::move(newMov);
+    it = instructions.insert(it + 1, std::move(newIdiv));
     return it;
 }
 
-std::vector<std::shared_ptr<Assembly::Instruction>>::iterator
+std::vector<std::unique_ptr<Assembly::Instruction>>::iterator
 FixupPass::rewriteInvalidCmp(
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions,
-    std::vector<std::shared_ptr<Assembly::Instruction>>::iterator it,
-    std::shared_ptr<Assembly::CmpInstruction> cmpInstr) {
-    if ((std::dynamic_pointer_cast<Assembly::StackOperand>(
-             cmpInstr->getOperand1()) ||
-         std::dynamic_pointer_cast<Assembly::DataOperand>(
-             cmpInstr->getOperand1())) &&
-        (std::dynamic_pointer_cast<Assembly::StackOperand>(
-             cmpInstr->getOperand2()) ||
-         std::dynamic_pointer_cast<Assembly::DataOperand>(
-             cmpInstr->getOperand2()))) {
-        auto r10d = std::make_shared<Assembly::RegisterOperand>(
-            std::make_shared<Assembly::R10>());
-        auto newMov = std::make_shared<Assembly::MovInstruction>(
-            cmpInstr->getType(), cmpInstr->getOperand1(), r10d);
-        auto newCmp = std::make_shared<Assembly::CmpInstruction>(
-            cmpInstr->getType(), r10d, cmpInstr->getOperand2());
-        *it = newMov;
-        it = instructions->insert(it + 1, newCmp);
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions,
+    std::vector<std::unique_ptr<Assembly::Instruction>>::iterator it,
+    const Assembly::CmpInstruction &cmpInstr) {
+    if ((dynamic_cast<const Assembly::StackOperand *>(cmpInstr.getOperand1()) ||
+         dynamic_cast<const Assembly::DataOperand *>(cmpInstr.getOperand1())) &&
+        (dynamic_cast<const Assembly::StackOperand *>(cmpInstr.getOperand2()) ||
+         dynamic_cast<const Assembly::DataOperand *>(cmpInstr.getOperand2()))) {
+        auto newMov = std::make_unique<Assembly::MovInstruction>(
+            cloneAssemblyType(cmpInstr.getType()),
+            cloneOperand(cmpInstr.getOperand1()),
+            std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R10>()));
+        auto newCmp = std::make_unique<Assembly::CmpInstruction>(
+            cloneAssemblyType(cmpInstr.getType()),
+            std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R10>()),
+            cloneOperand(cmpInstr.getOperand2()));
+        *it = std::move(newMov);
+        it = instructions.insert(it + 1, std::move(newCmp));
     }
-    else if (std::dynamic_pointer_cast<Assembly::ImmediateOperand>(
-                 cmpInstr->getOperand2())) {
-        auto r11d = std::make_shared<Assembly::RegisterOperand>(
-            std::make_shared<Assembly::R11>());
-        auto newMov = std::make_shared<Assembly::MovInstruction>(
-            cmpInstr->getType(), cmpInstr->getOperand2(), r11d);
-        auto newCmp = std::make_shared<Assembly::CmpInstruction>(
-            cmpInstr->getType(), cmpInstr->getOperand1(), r11d);
-        *it = newMov;
-        it = instructions->insert(it + 1, newCmp);
+    else if (dynamic_cast<const Assembly::ImmediateOperand *>(
+                 cmpInstr.getOperand2())) {
+        auto newMov = std::make_unique<Assembly::MovInstruction>(
+            cloneAssemblyType(cmpInstr.getType()),
+            cloneOperand(cmpInstr.getOperand2()),
+            std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R11>()));
+        auto newCmp = std::make_unique<Assembly::CmpInstruction>(
+            cloneAssemblyType(cmpInstr.getType()),
+            cloneOperand(cmpInstr.getOperand1()),
+            std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R11>()));
+        *it = std::move(newMov);
+        it = instructions.insert(it + 1, std::move(newCmp));
     }
 
     return it;
 }
 
-std::vector<std::shared_ptr<Assembly::Instruction>>::iterator
+std::vector<std::unique_ptr<Assembly::Instruction>>::iterator
 FixupPass::rewriteInvalidLargeImmediateMov(
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions,
-    std::vector<std::shared_ptr<Assembly::Instruction>>::iterator it,
-    std::shared_ptr<Assembly::MovInstruction> movInst) {
-    auto r10d = std::make_shared<Assembly::RegisterOperand>(
-        std::make_shared<Assembly::R10>());
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions,
+    std::vector<std::unique_ptr<Assembly::Instruction>>::iterator it,
+    const Assembly::MovInstruction &movInst) {
+    auto newMov1 = std::make_unique<Assembly::MovInstruction>(
+        cloneAssemblyType(movInst.getType()), cloneOperand(movInst.getSrc()),
+        std::make_unique<Assembly::RegisterOperand>(
+            std::make_unique<Assembly::R10>()));
+    auto newMov2 = std::make_unique<Assembly::MovInstruction>(
+        cloneAssemblyType(movInst.getType()),
+        std::make_unique<Assembly::RegisterOperand>(
+            std::make_unique<Assembly::R10>()),
+        cloneOperand(movInst.getDst()));
 
-    auto newMov1 = std::make_shared<Assembly::MovInstruction>(
-        movInst->getType(), movInst->getSrc(), r10d);
-    auto newMov2 = std::make_shared<Assembly::MovInstruction>(
-        movInst->getType(), r10d, movInst->getDst());
-
-    *it = newMov1;
-    it = instructions->insert(it + 1, newMov2);
-
+    *it = std::move(newMov1);
+    it = instructions.insert(it + 1, std::move(newMov2));
     return it;
 }
 
-std::vector<std::shared_ptr<Assembly::Instruction>>::iterator
+std::vector<std::unique_ptr<Assembly::Instruction>>::iterator
 FixupPass::rewriteInvalidLongwordImmediateMov(
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions [[maybe_unused]],
-    std::vector<std::shared_ptr<Assembly::Instruction>>::iterator it,
-    std::shared_ptr<Assembly::MovInstruction> movInst) {
-    auto immediateSrc = std::dynamic_pointer_cast<Assembly::ImmediateOperand>(
-        movInst->getSrc());
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions
+    [[maybe_unused]],
+    std::vector<std::unique_ptr<Assembly::Instruction>>::iterator it,
+    const Assembly::MovInstruction &movInst) {
+    auto immediateSrc =
+        dynamic_cast<const Assembly::ImmediateOperand *>(movInst.getSrc());
     long originalValue = immediateSrc->getImmediateLong();
 
     // Truncate the immediate value to 32 bits.
@@ -526,158 +631,166 @@ FixupPass::rewriteInvalidLongwordImmediateMov(
                           std::numeric_limits<unsigned int>::max());
 
     auto newImmediate =
-        std::make_shared<Assembly::ImmediateOperand>(truncatedValue);
-    auto newMov = std::make_shared<Assembly::MovInstruction>(
-        movInst->getType(), newImmediate, movInst->getDst());
+        std::make_unique<Assembly::ImmediateOperand>(truncatedValue);
+    auto newMov = std::make_unique<Assembly::MovInstruction>(
+        cloneAssemblyType(movInst.getType()), std::move(newImmediate),
+        cloneOperand(movInst.getDst()));
 
-    *it = newMov;
+    *it = std::move(newMov);
     return it;
 }
 
-std::vector<std::shared_ptr<Assembly::Instruction>>::iterator
+std::vector<std::unique_ptr<Assembly::Instruction>>::iterator
 FixupPass::rewriteInvalidLargeImmediateBinary(
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions,
-    std::vector<std::shared_ptr<Assembly::Instruction>>::iterator it,
-    std::shared_ptr<Assembly::BinaryInstruction> binInstr) {
-    auto r10d = std::make_shared<Assembly::RegisterOperand>(
-        std::make_shared<Assembly::R10>());
-
-    auto immediateOp = std::dynamic_pointer_cast<Assembly::ImmediateOperand>(
-        binInstr->getOperand1());
-    auto otherOp = binInstr->getOperand2();
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions,
+    std::vector<std::unique_ptr<Assembly::Instruction>>::iterator it,
+    const Assembly::BinaryInstruction &binInstr) {
+    const Assembly::AssemblyType *binType = binInstr.getType();
+    const Assembly::BinaryOperator *binOperator = binInstr.getBinaryOperator();
+    auto immediateOp = dynamic_cast<const Assembly::ImmediateOperand *>(
+        binInstr.getOperand1());
+    auto otherOp = binInstr.getOperand2();
     bool isFirstOperand = true;
     if (!immediateOp) {
-        immediateOp = std::dynamic_pointer_cast<Assembly::ImmediateOperand>(
-            binInstr->getOperand2());
-        otherOp = binInstr->getOperand1();
+        immediateOp = dynamic_cast<const Assembly::ImmediateOperand *>(
+            binInstr.getOperand2());
+        otherOp = binInstr.getOperand1();
         isFirstOperand = false;
     }
 
-    auto newMov = std::make_shared<Assembly::MovInstruction>(
-        binInstr->getType(), immediateOp, r10d);
+    bool otherIsMemory =
+        dynamic_cast<const Assembly::StackOperand *>(otherOp) ||
+        dynamic_cast<const Assembly::DataOperand *>(otherOp);
+    auto otherOpCloneForLoad = otherIsMemory ? cloneOperand(otherOp) : nullptr;
+    auto otherOpCloneForBin = cloneOperand(otherOp);
+    auto otherOpCloneForStore = otherIsMemory ? cloneOperand(otherOp) : nullptr;
+    auto immediateOpClone = cloneOperand(immediateOp);
+    auto typeForMov = cloneAssemblyType(binType);
+    auto typeForLoad = otherIsMemory ? cloneAssemblyType(binType) : nullptr;
+    auto typeForBin = cloneAssemblyType(binType);
+    auto typeForStore = otherIsMemory ? cloneAssemblyType(binType) : nullptr;
+    auto newMov = std::make_unique<Assembly::MovInstruction>(
+        std::move(typeForMov), std::move(immediateOpClone),
+        std::make_unique<Assembly::RegisterOperand>(
+            std::make_unique<Assembly::R10>()));
 
-    // Check if `otherOp` is a memory operand (stack or data).
-    // If it is, load it into a register first.
-    auto otherStackOp =
-        std::dynamic_pointer_cast<Assembly::StackOperand>(otherOp);
-    auto otherDataOp =
-        std::dynamic_pointer_cast<Assembly::DataOperand>(otherOp);
-    std::shared_ptr<Assembly::RegisterOperand> otherRegOp = nullptr;
-    if (otherStackOp || otherDataOp) {
-        auto r11d = std::make_shared<Assembly::RegisterOperand>(
-            std::make_shared<Assembly::R11>());
-        auto loadOtherMov = std::make_shared<Assembly::MovInstruction>(
-            binInstr->getType(), otherOp, r11d);
-        *it = newMov;
-        it = instructions->insert(it + 1, loadOtherMov);
-        otherRegOp = r11d;
-    }
-    else {
-        *it = newMov;
-    }
-
-    std::shared_ptr<Assembly::BinaryInstruction> newBin;
-    std::shared_ptr<Assembly::Operand> finalOtherOp =
-        otherRegOp ? std::static_pointer_cast<Assembly::Operand>(otherRegOp)
-                   : otherOp;
-    if (isFirstOperand) {
-        newBin = std::make_shared<Assembly::BinaryInstruction>(
-            binInstr->getBinaryOperator(), binInstr->getType(), r10d,
-            finalOtherOp);
-    }
-    else {
-        newBin = std::make_shared<Assembly::BinaryInstruction>(
-            binInstr->getBinaryOperator(), binInstr->getType(), finalOtherOp,
-            r10d);
+    bool otherInRegister = false;
+    std::unique_ptr<Assembly::Instruction> loadOtherMov;
+    if (otherIsMemory) {
+        loadOtherMov = std::make_unique<Assembly::MovInstruction>(
+            std::move(typeForLoad), std::move(otherOpCloneForLoad),
+            std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R11>()));
+        otherInRegister = true;
     }
 
-    it = instructions->insert(it + 1, newBin);
+    std::unique_ptr<Assembly::Operand> otherOperandForBin =
+        otherInRegister ? std::make_unique<Assembly::RegisterOperand>(
+                              std::make_unique<Assembly::R11>())
+                        : std::move(otherOpCloneForBin);
 
-    // If we loaded `otherOp` into a register, store it back to memory.
-    if (otherRegOp) {
-        auto storeMov = std::make_shared<Assembly::MovInstruction>(
-            binInstr->getType(), otherRegOp, otherOp);
-        it = instructions->insert(it + 1, storeMov);
+    auto newBin = std::make_unique<Assembly::BinaryInstruction>(
+        cloneBinaryOperator(binOperator), std::move(typeForBin),
+        isFirstOperand ? std::make_unique<Assembly::RegisterOperand>(
+                             std::make_unique<Assembly::R10>())
+                       : std::move(otherOperandForBin),
+        isFirstOperand ? std::move(otherOperandForBin)
+                       : std::make_unique<Assembly::RegisterOperand>(
+                             std::make_unique<Assembly::R10>()));
+
+    *it = std::move(newMov);
+    if (loadOtherMov) {
+        it = instructions.insert(it + 1, std::move(loadOtherMov));
+    }
+    it = instructions.insert(it + 1, std::move(newBin));
+
+    if (otherInRegister) {
+        auto storeMov = std::make_unique<Assembly::MovInstruction>(
+            std::move(typeForStore),
+            std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R11>()),
+            std::move(otherOpCloneForStore));
+        it = instructions.insert(it + 1, std::move(storeMov));
     }
 
     return it;
 }
 
-std::vector<std::shared_ptr<Assembly::Instruction>>::iterator
+std::vector<std::unique_ptr<Assembly::Instruction>>::iterator
 FixupPass::rewriteInvalidLargeImmediateCmp(
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions,
-    std::vector<std::shared_ptr<Assembly::Instruction>>::iterator it,
-    std::shared_ptr<Assembly::CmpInstruction> cmpInstr) {
-    auto r10d = std::make_shared<Assembly::RegisterOperand>(
-        std::make_shared<Assembly::R10>());
-
-    auto immediateOp = std::dynamic_pointer_cast<Assembly::ImmediateOperand>(
-        cmpInstr->getOperand1());
-    auto otherOp = cmpInstr->getOperand2();
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions,
+    std::vector<std::unique_ptr<Assembly::Instruction>>::iterator it,
+    const Assembly::CmpInstruction &cmpInstr) {
+    const Assembly::AssemblyType *cmpType = cmpInstr.getType();
+    auto immediateOp = dynamic_cast<const Assembly::ImmediateOperand *>(
+        cmpInstr.getOperand1());
+    auto otherOp = cmpInstr.getOperand2();
     bool isFirstOperand = true;
     if (!immediateOp) {
-        immediateOp = std::dynamic_pointer_cast<Assembly::ImmediateOperand>(
-            cmpInstr->getOperand2());
-        otherOp = cmpInstr->getOperand1();
+        immediateOp = dynamic_cast<const Assembly::ImmediateOperand *>(
+            cmpInstr.getOperand2());
+        otherOp = cmpInstr.getOperand1();
         isFirstOperand = false;
     }
 
-    auto newMov = std::make_shared<Assembly::MovInstruction>(
-        cmpInstr->getType(), immediateOp, r10d);
+    auto immediateOpClone = cloneOperand(immediateOp);
+    auto otherOpCloneForMov = cloneOperand(otherOp);
+    auto otherOpCloneForCmp = cloneOperand(otherOp);
+    auto newMov = std::make_unique<Assembly::MovInstruction>(
+        cloneAssemblyType(cmpType), std::move(immediateOpClone),
+        std::make_unique<Assembly::RegisterOperand>(
+            std::make_unique<Assembly::R10>()));
 
-    // Check if `otherOp` is also an immediate (even a small one).
-    // If it is, load it into a register first.
-    auto otherImmediateOp =
-        std::dynamic_pointer_cast<Assembly::ImmediateOperand>(otherOp);
-    std::shared_ptr<Assembly::RegisterOperand> otherRegOp = nullptr;
-    if (otherImmediateOp) {
-        auto r11d = std::make_shared<Assembly::RegisterOperand>(
-            std::make_shared<Assembly::R11>());
-        auto otherMov = std::make_shared<Assembly::MovInstruction>(
-            cmpInstr->getType(), otherImmediateOp, r11d);
-        *it = newMov;
-        it = instructions->insert(it + 1, otherMov);
-        otherRegOp = r11d;
-    }
-    else {
-        *it = newMov;
-    }
-
-    std::shared_ptr<Assembly::CmpInstruction> newCmp;
-    std::shared_ptr<Assembly::Operand> finalOtherOp =
-        otherRegOp ? std::static_pointer_cast<Assembly::Operand>(otherRegOp)
-                   : otherOp;
-    if (isFirstOperand) {
-        newCmp = std::make_shared<Assembly::CmpInstruction>(cmpInstr->getType(),
-                                                            r10d, finalOtherOp);
-    }
-    else {
-        newCmp = std::make_shared<Assembly::CmpInstruction>(cmpInstr->getType(),
-                                                            finalOtherOp, r10d);
+    bool otherIsImmediate =
+        dynamic_cast<const Assembly::ImmediateOperand *>(otherOp) != nullptr;
+    bool otherInRegister = false;
+    std::unique_ptr<Assembly::Instruction> otherMov;
+    if (otherIsImmediate) {
+        otherMov = std::make_unique<Assembly::MovInstruction>(
+            cloneAssemblyType(cmpType), std::move(otherOpCloneForMov),
+            std::make_unique<Assembly::RegisterOperand>(
+                std::make_unique<Assembly::R11>()));
+        otherInRegister = true;
     }
 
-    it = instructions->insert(it + 1, newCmp);
+    std::unique_ptr<Assembly::Operand> otherForCmp =
+        otherInRegister ? std::make_unique<Assembly::RegisterOperand>(
+                              std::make_unique<Assembly::R11>())
+                        : std::move(otherOpCloneForCmp);
 
+    auto newCmp = std::make_unique<Assembly::CmpInstruction>(
+        cloneAssemblyType(cmpType),
+        isFirstOperand ? std::make_unique<Assembly::RegisterOperand>(
+                             std::make_unique<Assembly::R10>())
+                       : std::move(otherForCmp),
+        isFirstOperand ? std::move(otherForCmp)
+                       : std::make_unique<Assembly::RegisterOperand>(
+                             std::make_unique<Assembly::R10>()));
+
+    *it = std::move(newMov);
+    if (otherMov) {
+        it = instructions.insert(it + 1, std::move(otherMov));
+    }
+    it = instructions.insert(it + 1, std::move(newCmp));
     return it;
 }
 
-std::vector<std::shared_ptr<Assembly::Instruction>>::iterator
+std::vector<std::unique_ptr<Assembly::Instruction>>::iterator
 FixupPass::rewriteInvalidLargeImmediatePush(
-    std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-        instructions,
-    std::vector<std::shared_ptr<Assembly::Instruction>>::iterator it,
-    std::shared_ptr<Assembly::PushInstruction> pushInstr) {
-    auto r10d = std::make_shared<Assembly::RegisterOperand>(
-        std::make_shared<Assembly::R10>());
-    auto newMov = std::make_shared<Assembly::MovInstruction>(
-        std::make_shared<Assembly::Quadword>(), pushInstr->getOperand(), r10d);
-    auto newPush = std::make_shared<Assembly::PushInstruction>(r10d);
+    std::vector<std::unique_ptr<Assembly::Instruction>> &instructions,
+    std::vector<std::unique_ptr<Assembly::Instruction>>::iterator it,
+    const Assembly::PushInstruction &pushInstr) {
+    auto newMov = std::make_unique<Assembly::MovInstruction>(
+        std::make_unique<Assembly::Quadword>(),
+        cloneOperand(pushInstr.getOperand()),
+        std::make_unique<Assembly::RegisterOperand>(
+            std::make_unique<Assembly::R10>()));
+    auto newPush = std::make_unique<Assembly::PushInstruction>(
+        std::make_unique<Assembly::RegisterOperand>(
+            std::make_unique<Assembly::R10>()));
 
-    *it = newMov;
-    it = instructions->insert(it + 1, newPush);
-
+    *it = std::move(newMov);
+    it = instructions.insert(it + 1, std::move(newPush));
     return it;
 }
 } // Namespace Assembly

--- a/src/backend/fixupPass.h
+++ b/src/backend/fixupPass.h
@@ -15,8 +15,7 @@ class FixupPass {
      *
      * @param topLevels The top-levels of the assembly program.
      */
-    void
-    fixup(std::shared_ptr<std::vector<std::shared_ptr<TopLevel>>> topLevels);
+    void fixup(std::vector<std::unique_ptr<TopLevel>> &topLevels);
 
   private:
     /**
@@ -29,8 +28,7 @@ class FixupPass {
      * @param stackSize The stack size of the function.
      */
     void insertAllocateStackInstruction(
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions,
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions,
         int stackSize);
 
     /**
@@ -41,8 +39,7 @@ class FixupPass {
      *
      * @param functionDefinition The function definition to rewrite.
      */
-    void rewriteFunctionDefinition(
-        std::shared_ptr<FunctionDefinition> functionDefinition);
+    void rewriteFunctionDefinition(FunctionDefinition &functionDefinition);
 
     /**
      * Check if a mov instruction is invalid.
@@ -50,8 +47,7 @@ class FixupPass {
      * @param movInstr The mov instruction to check.
      * @return True if the mov instruction is invalid, false otherwise.
      */
-    [[nodiscard]] bool
-    isInvalidMov(std::shared_ptr<Assembly::MovInstruction> movInstr);
+    [[nodiscard]] bool isInvalidMov(const Assembly::MovInstruction &movInstr);
 
     /**
      * Check if a mov instruction has a large immediate value.
@@ -60,8 +56,8 @@ class FixupPass {
      * @return True if the mov instruction has a large immediate value, false
      * otherwise.
      */
-    [[nodiscard]] bool isInvalidLargeImmediateMov(
-        std::shared_ptr<Assembly::MovInstruction> movInstr);
+    [[nodiscard]] bool
+    isInvalidLargeImmediateMov(const Assembly::MovInstruction &movInstr);
 
     /**
      * Check if a mov instruction is an invalid longword immediate mov
@@ -71,8 +67,8 @@ class FixupPass {
      * @return True if the mov instruction is an invalid longword immediate mov
      * instruction, false otherwise.
      */
-    [[nodiscard]] bool isInvalidLongwordImmediateMov(
-        std::shared_ptr<Assembly::MovInstruction> movInstr);
+    [[nodiscard]] bool
+    isInvalidLongwordImmediateMov(const Assembly::MovInstruction &movInstr);
 
     /**
      * Check if a movsx instruction is invalid.
@@ -81,7 +77,7 @@ class FixupPass {
      * @return True if the movsx instruction is invalid, false otherwise.
      */
     [[nodiscard]] bool
-    isInvalidMovsx(std::shared_ptr<Assembly::MovsxInstruction> movsxInstr);
+    isInvalidMovsx(const Assembly::MovsxInstruction &movsxInstr);
 
     /**
      * Check if a binary instruction is invalid.
@@ -90,7 +86,7 @@ class FixupPass {
      * @return True if the binary instruction is invalid, false otherwise.
      */
     [[nodiscard]] bool
-    isInvalidBinary(std::shared_ptr<Assembly::BinaryInstruction> binInstr);
+    isInvalidBinary(const Assembly::BinaryInstruction &binInstr);
 
     /**
      * Check if a binary instruction has a large immediate value.
@@ -99,8 +95,8 @@ class FixupPass {
      * @return True if the binary instruction has a large immediate value, false
      * otherwise.
      */
-    [[nodiscard]] bool isInvalidLargeImmediateBinary(
-        std::shared_ptr<Assembly::BinaryInstruction> binInstr);
+    [[nodiscard]] bool
+    isInvalidLargeImmediateBinary(const Assembly::BinaryInstruction &binInstr);
 
     /**
      * Check if an idiv instruction is invalid.
@@ -109,7 +105,7 @@ class FixupPass {
      * @return True if the idiv instruction is invalid, false otherwise.
      */
     [[nodiscard]] bool
-    isInvalidIdiv(std::shared_ptr<Assembly::IdivInstruction> idivInstr);
+    isInvalidIdiv(const Assembly::IdivInstruction &idivInstr);
 
     /**
      * Check if a cmp instruction is invalid.
@@ -117,8 +113,7 @@ class FixupPass {
      * @param cmpInstr The cmp instruction to check.
      * @return True if the cmp instruction is invalid, false otherwise.
      */
-    [[nodiscard]] bool
-    isInvalidCmp(std::shared_ptr<Assembly::CmpInstruction> cmpInstr);
+    [[nodiscard]] bool isInvalidCmp(const Assembly::CmpInstruction &cmpInstr);
 
     /**
      * Check if a cmp instruction has a large immediate value.
@@ -127,8 +122,8 @@ class FixupPass {
      * @return True if the cmp instruction has a large immediate value, false
      * otherwise.
      */
-    [[nodiscard]] bool isInvalidLargeImmediateCmp(
-        std::shared_ptr<Assembly::CmpInstruction> cmpInstr);
+    [[nodiscard]] bool
+    isInvalidLargeImmediateCmp(const Assembly::CmpInstruction &cmpInstr);
 
     /**
      * Check if a push instruction has a large immediate value.
@@ -137,8 +132,8 @@ class FixupPass {
      * @return True if the push instruction has a large immediate value, false
      * otherwise.
      */
-    [[nodiscard]] bool isInvalidLargeImmediatePush(
-        std::shared_ptr<Assembly::PushInstruction> pushInstr);
+    [[nodiscard]] bool
+    isInvalidLargeImmediatePush(const Assembly::PushInstruction &pushInstr);
 
     /**
      * Rewrite an invalid mov instruction.
@@ -152,12 +147,12 @@ class FixupPass {
      * @param movInst The mov instruction to rewrite.
      * @return The iterator to the new mov instruction.
      */
-    [[nodiscard]] std::vector<std::shared_ptr<Assembly::Instruction>>::iterator
+    [[nodiscard]]
+    std::vector<std::unique_ptr<Assembly::Instruction>>::iterator
     rewriteInvalidMov(
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions,
-        std::vector<std::shared_ptr<Assembly::Instruction>>::iterator it,
-        std::shared_ptr<Assembly::MovInstruction> movInst);
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions,
+        std::vector<std::unique_ptr<Assembly::Instruction>>::iterator it,
+        const Assembly::MovInstruction &movInst);
 
     /**
      * Rewrite an invalid large immediate mov instruction.
@@ -171,12 +166,12 @@ class FixupPass {
      * @param movInst The mov instruction to rewrite.
      * @return The iterator to the new mov instruction.
      */
-    [[nodiscard]] std::vector<std::shared_ptr<Assembly::Instruction>>::iterator
+    [[nodiscard]]
+    std::vector<std::unique_ptr<Assembly::Instruction>>::iterator
     rewriteInvalidLargeImmediateMov(
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions,
-        std::vector<std::shared_ptr<Assembly::Instruction>>::iterator it,
-        std::shared_ptr<Assembly::MovInstruction> movInst);
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions,
+        std::vector<std::unique_ptr<Assembly::Instruction>>::iterator it,
+        const Assembly::MovInstruction &movInst);
 
     /**
      * Rewrite an invalid longword immediate mov instruction.
@@ -189,12 +184,12 @@ class FixupPass {
      * @param movInst The mov instruction to rewrite.
      * @return The iterator to the new mov instruction.
      */
-    [[nodiscard]] std::vector<std::shared_ptr<Assembly::Instruction>>::iterator
+    [[nodiscard]]
+    std::vector<std::unique_ptr<Assembly::Instruction>>::iterator
     rewriteInvalidLongwordImmediateMov(
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions,
-        std::vector<std::shared_ptr<Assembly::Instruction>>::iterator it,
-        std::shared_ptr<Assembly::MovInstruction> movInst);
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions,
+        std::vector<std::unique_ptr<Assembly::Instruction>>::iterator it,
+        const Assembly::MovInstruction &movInst);
 
     /**
      * Rewrite an invalid movsx instruction.
@@ -208,12 +203,12 @@ class FixupPass {
      * @param movsxInst The movsx instruction to rewrite.
      * @return The iterator to the new movsx instruction.
      */
-    [[nodiscard]] std::vector<std::shared_ptr<Assembly::Instruction>>::iterator
+    [[nodiscard]]
+    std::vector<std::unique_ptr<Assembly::Instruction>>::iterator
     rewriteInvalidMovsx(
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions,
-        std::vector<std::shared_ptr<Assembly::Instruction>>::iterator it,
-        std::shared_ptr<Assembly::MovsxInstruction> movsxInst);
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions,
+        std::vector<std::unique_ptr<Assembly::Instruction>>::iterator it,
+        const Assembly::MovsxInstruction &movsxInst);
 
     /**
      * Rewrite an invalid binary instruction.
@@ -227,12 +222,12 @@ class FixupPass {
      * @param binInstr The binary instruction to rewrite.
      * @return The iterator to the new binary instruction.
      */
-    [[nodiscard]] std::vector<std::shared_ptr<Assembly::Instruction>>::iterator
+    [[nodiscard]]
+    std::vector<std::unique_ptr<Assembly::Instruction>>::iterator
     rewriteInvalidBinary(
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions,
-        std::vector<std::shared_ptr<Assembly::Instruction>>::iterator it,
-        std::shared_ptr<Assembly::BinaryInstruction> binInstr);
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions,
+        std::vector<std::unique_ptr<Assembly::Instruction>>::iterator it,
+        const Assembly::BinaryInstruction &binInstr);
 
     /**
      * Rewrite an invalid large immediate binary instruction.
@@ -246,12 +241,12 @@ class FixupPass {
      * @param binInstr The binary instruction to rewrite.
      * @return The iterator to the new binary instruction.
      */
-    [[nodiscard]] std::vector<std::shared_ptr<Assembly::Instruction>>::iterator
+    [[nodiscard]]
+    std::vector<std::unique_ptr<Assembly::Instruction>>::iterator
     rewriteInvalidLargeImmediateBinary(
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions,
-        std::vector<std::shared_ptr<Assembly::Instruction>>::iterator it,
-        std::shared_ptr<Assembly::BinaryInstruction> binInstr);
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions,
+        std::vector<std::unique_ptr<Assembly::Instruction>>::iterator it,
+        const Assembly::BinaryInstruction &binInstr);
 
     /**
      * Rewrite an invalid idiv instruction.
@@ -264,12 +259,12 @@ class FixupPass {
      * @param idivInst The idiv instruction to rewrite.
      * @return The iterator to the new idiv instruction.
      */
-    [[nodiscard]] std::vector<std::shared_ptr<Assembly::Instruction>>::iterator
+    [[nodiscard]]
+    std::vector<std::unique_ptr<Assembly::Instruction>>::iterator
     rewriteInvalidIdiv(
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions,
-        std::vector<std::shared_ptr<Assembly::Instruction>>::iterator it,
-        std::shared_ptr<Assembly::IdivInstruction> idivInstr);
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions,
+        std::vector<std::unique_ptr<Assembly::Instruction>>::iterator it,
+        const Assembly::IdivInstruction &idivInstr);
 
     /**
      * Rewrite an invalid cmp instruction.
@@ -283,12 +278,12 @@ class FixupPass {
      * @param cmpInst The cmp instruction to rewrite.
      * @return The iterator to the new cmp instruction.
      */
-    [[nodiscard]] std::vector<std::shared_ptr<Assembly::Instruction>>::iterator
+    [[nodiscard]]
+    std::vector<std::unique_ptr<Assembly::Instruction>>::iterator
     rewriteInvalidCmp(
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions,
-        std::vector<std::shared_ptr<Assembly::Instruction>>::iterator it,
-        std::shared_ptr<Assembly::CmpInstruction> cmpInstr);
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions,
+        std::vector<std::unique_ptr<Assembly::Instruction>>::iterator it,
+        const Assembly::CmpInstruction &cmpInstr);
 
     /**
      * Rewrite an invalid large immediate cmp instruction.
@@ -301,12 +296,12 @@ class FixupPass {
      * @param cmpInst The cmp instruction to rewrite.
      * @return The iterator to the new cmp instruction.
      */
-    [[nodiscard]] std::vector<std::shared_ptr<Assembly::Instruction>>::iterator
+    [[nodiscard]]
+    std::vector<std::unique_ptr<Assembly::Instruction>>::iterator
     rewriteInvalidLargeImmediateCmp(
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions,
-        std::vector<std::shared_ptr<Assembly::Instruction>>::iterator it,
-        std::shared_ptr<Assembly::CmpInstruction> cmpInstr);
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions,
+        std::vector<std::unique_ptr<Assembly::Instruction>>::iterator it,
+        const Assembly::CmpInstruction &cmpInstr);
 
     /**
      * Rewrite an invalid large immediate push instruction.
@@ -319,12 +314,12 @@ class FixupPass {
      * @param pushInst The push instruction to rewrite.
      * @return The iterator to the new push instruction.
      */
-    [[nodiscard]] std::vector<std::shared_ptr<Assembly::Instruction>>::iterator
+    [[nodiscard]]
+    std::vector<std::unique_ptr<Assembly::Instruction>>::iterator
     rewriteInvalidLargeImmediatePush(
-        std::shared_ptr<std::vector<std::shared_ptr<Assembly::Instruction>>>
-            instructions,
-        std::vector<std::shared_ptr<Assembly::Instruction>>::iterator it,
-        std::shared_ptr<Assembly::PushInstruction> pushInstr);
+        std::vector<std::unique_ptr<Assembly::Instruction>> &instructions,
+        std::vector<std::unique_ptr<Assembly::Instruction>>::iterator it,
+        const Assembly::PushInstruction &pushInstr);
 };
 } // Namespace Assembly
 

--- a/src/backend/pseudoToStackPass.h
+++ b/src/backend/pseudoToStackPass.h
@@ -24,7 +24,7 @@ class PseudoToStackPass {
      * @param backendSymbolTable The backend symbol table.
      */
     void replacePseudoWithStackAndAssociateStackSize(
-        std::shared_ptr<std::vector<std::shared_ptr<TopLevel>>> &topLevels,
+        std::vector<std::unique_ptr<TopLevel>> &topLevels,
         const BackendSymbolTable &backendSymbolTable);
 
   private:
@@ -36,7 +36,7 @@ class PseudoToStackPass {
      * @param backendSymbolTable The backend symbol table.
      */
     void
-    replacePseudoWithStack(std::shared_ptr<Assembly::Instruction> &instruction,
+    replacePseudoWithStack(std::unique_ptr<Assembly::Instruction> &instruction,
                            const BackendSymbolTable &backendSymbolTable);
 
     /**
@@ -46,8 +46,8 @@ class PseudoToStackPass {
      * @param backendSymbolTable The backend symbol table.
      * @return The replaced operand.
      */
-    [[nodiscard]] std::shared_ptr<Assembly::Operand>
-    replaceOperand(std::shared_ptr<Assembly::Operand> operand,
+    [[nodiscard]] std::unique_ptr<Assembly::Operand>
+    replaceOperand(const Assembly::Operand *operand,
                    const BackendSymbolTable &backendSymbolTable);
 
     /**
@@ -57,7 +57,7 @@ class PseudoToStackPass {
      * @param functionDefinition The function definition to check.
      */
     void checkPseudoRegistersInFunctionDefinitionReplaced(
-        std::shared_ptr<Assembly::FunctionDefinition> functionDefinition);
+        const Assembly::FunctionDefinition &functionDefinition);
 
     /**
      * A map from pseudo registers to stack offsets.

--- a/src/frontend/block.cpp
+++ b/src/frontend/block.cpp
@@ -2,22 +2,21 @@
 
 namespace AST {
 Block::Block(
-    std::shared_ptr<std::vector<std::shared_ptr<BlockItem>>> blockItems)
-    : blockItems(blockItems) {}
+    std::unique_ptr<std::vector<std::unique_ptr<BlockItem>>> blockItems)
+    : blockItems(std::move(blockItems)) {}
 
 void Block::accept(Visitor &visitor) { visitor.visit(*this); }
 
-const std::shared_ptr<std::vector<std::shared_ptr<BlockItem>>> &
-Block::getBlockItems() const {
-    return blockItems;
+const std::vector<std::unique_ptr<BlockItem>> &Block::getBlockItems() const {
+    return *blockItems;
 }
 
 void Block::setBlockItems(
-    std::shared_ptr<std::vector<std::shared_ptr<BlockItem>>> newBlockItems) {
-    this->blockItems = newBlockItems;
+    std::unique_ptr<std::vector<std::unique_ptr<BlockItem>>> newBlockItems) {
+    this->blockItems = std::move(newBlockItems);
 }
 
-void Block::addBlockItem(std::shared_ptr<BlockItem> blockItem) {
-    blockItems->push_back(blockItem);
+void Block::addBlockItem(std::unique_ptr<BlockItem> blockItem) {
+    blockItems->push_back(std::move(blockItem));
 }
 } // namespace AST

--- a/src/frontend/block.h
+++ b/src/frontend/block.h
@@ -16,29 +16,28 @@ class Block : public AST {
      * @param blockItems The list of block items in the block.
      */
     explicit Block(
-        std::shared_ptr<std::vector<std::shared_ptr<BlockItem>>> blockItems);
+        std::unique_ptr<std::vector<std::unique_ptr<BlockItem>>> blockItems);
 
     void accept(Visitor &visitor) override;
 
-    [[nodiscard]] const std::shared_ptr<
-        std::vector<std::shared_ptr<BlockItem>>> &
+    [[nodiscard]] const std::vector<std::unique_ptr<BlockItem>> &
     getBlockItems() const;
 
     void setBlockItems(
-        std::shared_ptr<std::vector<std::shared_ptr<BlockItem>>> blockItems);
+        std::unique_ptr<std::vector<std::unique_ptr<BlockItem>>> blockItems);
 
     /**
      * Adds a block item to the block.
      *
      * @param blockItem The block item to add.
      */
-    void addBlockItem(std::shared_ptr<BlockItem> blockItem);
+    void addBlockItem(std::unique_ptr<BlockItem> blockItem);
 
   private:
     /**
      * The list of block items in the block.
      */
-    std::shared_ptr<std::vector<std::shared_ptr<BlockItem>>> blockItems;
+    std::unique_ptr<std::vector<std::unique_ptr<BlockItem>>> blockItems;
 };
 } // namespace AST
 

--- a/src/frontend/blockItem.cpp
+++ b/src/frontend/blockItem.cpp
@@ -2,29 +2,25 @@
 #include "visitor.h"
 
 namespace AST {
-SBlockItem::SBlockItem(std::shared_ptr<Statement> statement)
-    : statement(statement) {}
+SBlockItem::SBlockItem(std::unique_ptr<Statement> statement)
+    : statement(std::move(statement)) {}
 
 void SBlockItem::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<Statement> SBlockItem::getStatement() const {
-    return statement;
+Statement *SBlockItem::getStatement() const { return statement.get(); }
+
+void SBlockItem::setStatement(std::unique_ptr<Statement> newStatement) {
+    this->statement = std::move(newStatement);
 }
 
-void SBlockItem::setStatement(std::shared_ptr<Statement> newStatement) {
-    this->statement = newStatement;
-}
-
-DBlockItem::DBlockItem(std::shared_ptr<Declaration> declaration)
-    : declaration(declaration) {}
+DBlockItem::DBlockItem(std::unique_ptr<Declaration> declaration)
+    : declaration(std::move(declaration)) {}
 
 void DBlockItem::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<Declaration> DBlockItem::getDeclaration() const {
-    return declaration;
-}
+Declaration *DBlockItem::getDeclaration() const { return declaration.get(); }
 
-void DBlockItem::setDeclaration(std::shared_ptr<Declaration> newDeclaration) {
-    this->declaration = newDeclaration;
+void DBlockItem::setDeclaration(std::unique_ptr<Declaration> newDeclaration) {
+    this->declaration = std::move(newDeclaration);
 }
 } // Namespace AST

--- a/src/frontend/blockItem.h
+++ b/src/frontend/blockItem.h
@@ -29,19 +29,19 @@ class SBlockItem : public BlockItem {
      *
      * @param statement The statement encapsulated by the block item.
      */
-    explicit SBlockItem(std::shared_ptr<Statement> statement);
+    explicit SBlockItem(std::unique_ptr<Statement> statement);
 
     void accept(Visitor &visitor) override;
 
-    [[nodiscard]] std::shared_ptr<Statement> getStatement() const;
+    [[nodiscard]] Statement *getStatement() const;
 
-    void setStatement(std::shared_ptr<Statement> statement);
+    void setStatement(std::unique_ptr<Statement> statement);
 
   private:
     /**
      * The statement encapsulated by the block item.
      */
-    std::shared_ptr<Statement> statement;
+    std::unique_ptr<Statement> statement;
 };
 
 /**
@@ -54,19 +54,19 @@ class DBlockItem : public BlockItem {
      *
      * @param declaration The declaration encapsulated by the block item.
      */
-    explicit DBlockItem(std::shared_ptr<Declaration> declaration);
+    explicit DBlockItem(std::unique_ptr<Declaration> declaration);
 
     void accept(Visitor &visitor) override;
 
-    [[nodiscard]] std::shared_ptr<Declaration> getDeclaration() const;
+    [[nodiscard]] Declaration *getDeclaration() const;
 
-    void setDeclaration(std::shared_ptr<Declaration> declaration);
+    void setDeclaration(std::unique_ptr<Declaration> declaration);
 
   private:
     /**
      * The declaration encapsulated by the block item.
      */
-    std::shared_ptr<Declaration> declaration;
+    std::unique_ptr<Declaration> declaration;
 };
 } // namespace AST
 

--- a/src/frontend/declaration.cpp
+++ b/src/frontend/declaration.cpp
@@ -33,6 +33,10 @@ const std::string &VariableDeclaration::getIdentifier() const {
     return identifier;
 }
 
+void VariableDeclaration::setIdentifier(std::string_view newIdentifier) {
+    identifier = newIdentifier;
+}
+
 Expression *VariableDeclaration::getOptInitializer() const {
     return optInitializer.get();
 }

--- a/src/frontend/declaration.h
+++ b/src/frontend/declaration.h
@@ -10,6 +10,9 @@
 #include <string_view>
 
 namespace AST {
+// Forward declaration for `Block` (used by `FunctionDeclaration`).
+class Block;
+
 /**
  * Base class for declarations in the AST.
  *
@@ -30,20 +33,19 @@ class VariableDeclaration : public Declaration {
      * @param varType The type of the variable.
      */
     explicit VariableDeclaration(std::string_view identifier,
-                                 std::shared_ptr<Type> varType);
+                                 std::unique_ptr<Type> varType);
     /**
      * Constructor for the `VariableDeclaration` class with an optional
      * initializer and without an optional storage class.
      *
      * @param identifier The identifier of the variable.
      * @param optInitializer The optional initializer expression for the
-     * variable.
+     * variable (can be `nullptr`).
      * @param varType The type of the variable.
      */
-    explicit VariableDeclaration(
-        std::string_view identifier,
-        std::optional<std::shared_ptr<Expression>> optInitializer,
-        std::shared_ptr<Type> varType);
+    explicit VariableDeclaration(std::string_view identifier,
+                                 std::unique_ptr<Expression> optInitializer,
+                                 std::unique_ptr<Type> varType);
 
     /**
      * Constructor for the `VariableDeclaration` class without an optional
@@ -51,11 +53,12 @@ class VariableDeclaration : public Declaration {
      *
      * @param identifier The identifier of the variable.
      * @param varType The type of the variable.
-     * @param optStorageClass The optional storage class of the variable.
+     * @param optStorageClass The optional storage class of the variable (can be
+     * `nullptr`).
      */
-    explicit VariableDeclaration(
-        std::string_view identifier, std::shared_ptr<Type> varType,
-        std::optional<std::shared_ptr<StorageClass>> optStorageClass);
+    explicit VariableDeclaration(std::string_view identifier,
+                                 std::unique_ptr<Type> varType,
+                                 std::unique_ptr<StorageClass> optStorageClass);
 
     /**
      * Constructor for the `VariableDeclaration` class with an optional
@@ -63,30 +66,27 @@ class VariableDeclaration : public Declaration {
      *
      * @param identifier The identifier of the variable.
      * @param optInitializer The optional initializer expression for the
-     * variable.
+     * variable (can be `nullptr`).
      * @param varType The type of the variable.
-     * @param optStorageClass The optional storage class of the variable.
+     * @param optStorageClass The optional storage class of the variable (can be
+     * `nullptr`).
      */
-    explicit VariableDeclaration(
-        std::string_view identifier,
-        std::optional<std::shared_ptr<Expression>> optInitializer,
-        std::shared_ptr<Type> varType,
-        std::optional<std::shared_ptr<StorageClass>> optStorageClass);
+    explicit VariableDeclaration(std::string_view identifier,
+                                 std::unique_ptr<Expression> optInitializer,
+                                 std::unique_ptr<Type> varType,
+                                 std::unique_ptr<StorageClass> optStorageClass);
 
     void accept(Visitor &visitor) override;
 
     [[nodiscard]] const std::string &getIdentifier() const;
 
-    [[nodiscard]] std::optional<std::shared_ptr<Expression>>
-    getOptInitializer() const;
+    [[nodiscard]] Expression *getOptInitializer() const;
 
-    void setOptInitializer(
-        std::optional<std::shared_ptr<Expression>> newOptInitializer);
+    void setOptInitializer(std::unique_ptr<Expression> newOptInitializer);
 
-    [[nodiscard]] std::shared_ptr<Type> getVarType() const;
+    [[nodiscard]] Type *getVarType() const;
 
-    [[nodiscard]] std::optional<std::shared_ptr<StorageClass>>
-    getOptStorageClass() const;
+    [[nodiscard]] StorageClass *getOptStorageClass() const;
 
   private:
     /**
@@ -95,19 +95,19 @@ class VariableDeclaration : public Declaration {
     std::string identifier;
 
     /**
-     * The optional initializer expression of the variable.
+     * The optional initializer expression of the variable (can be `nullptr`).
      */
-    std::optional<std::shared_ptr<Expression>> optInitializer;
+    std::unique_ptr<Expression> optInitializer;
 
     /**
      * The type of the variable.
      */
-    std::shared_ptr<Type> varType;
+    std::unique_ptr<Type> varType;
 
     /**
-     * The optional storage class of the variable.
+     * The optional storage class of the variable (can be `nullptr`).
      */
-    std::optional<std::shared_ptr<StorageClass>> optStorageClass;
+    std::unique_ptr<StorageClass> optStorageClass;
 };
 
 class FunctionDeclaration : public Declaration {
@@ -122,8 +122,8 @@ class FunctionDeclaration : public Declaration {
      */
     explicit FunctionDeclaration(
         std::string_view identifier,
-        std::shared_ptr<std::vector<std::string>> parameters,
-        std::shared_ptr<Type> funType);
+        std::unique_ptr<std::vector<std::string>> parameters,
+        std::unique_ptr<Type> funType);
 
     /**
      * Constructor for the `FunctionDeclaration` class with an optional body
@@ -131,14 +131,13 @@ class FunctionDeclaration : public Declaration {
      *
      * @param identifier The identifier of the function.
      * @param parameters The parameter identifiers of the function.
-     * @param optBody The optional body of the function.
+     * @param optBody The optional body of the function (can be `nullptr`).
      * @param funType The function type of the function.
      */
     explicit FunctionDeclaration(
         std::string_view identifier,
-        std::shared_ptr<std::vector<std::string>> parameters,
-        std::optional<std::shared_ptr<Block>> optBody,
-        std::shared_ptr<Type> funType);
+        std::unique_ptr<std::vector<std::string>> parameters,
+        std::unique_ptr<Block> optBody, std::unique_ptr<Type> funType);
 
     /**
      * Constructor for the `FunctionDeclaration` class without an optional body
@@ -147,13 +146,14 @@ class FunctionDeclaration : public Declaration {
      * @param identifier The identifier of the function.
      * @param parameters The parameter identifiers of the function.
      * @param funType The function type of the function.
-     * @param optStorageClass The optional storage class of the function.
+     * @param optStorageClass The optional storage class of the function (can be
+     * nullptr).
      */
     explicit FunctionDeclaration(
         std::string_view identifier,
-        std::shared_ptr<std::vector<std::string>> parameters,
-        std::shared_ptr<Type> funType,
-        std::optional<std::shared_ptr<StorageClass>> optStorageClass);
+        std::unique_ptr<std::vector<std::string>> parameters,
+        std::unique_ptr<Type> funType,
+        std::unique_ptr<StorageClass> optStorageClass);
 
     /**
      * Constructor for the `FunctionDeclaration` class with an optional body
@@ -161,39 +161,45 @@ class FunctionDeclaration : public Declaration {
      *
      * @param identifier The identifier of the function.
      * @param parameters The parameter identifiers of the function.
-     * @param optBody The optional body of the function.
+     * @param optBody The optional body of the function (can be `nullptr`).
      * @param funType The function type of the function.
-     * @param optStorageClass The optional storage class of the function.
+     * @param optStorageClass The optional storage class of the function (can be
+     * `nullptr`).
      */
     explicit FunctionDeclaration(
         std::string_view identifier,
-        std::shared_ptr<std::vector<std::string>> parameters,
-        std::optional<std::shared_ptr<Block>> optBody,
-        std::shared_ptr<Type> funType,
-        std::optional<std::shared_ptr<StorageClass>> optStorageClass);
+        std::unique_ptr<std::vector<std::string>> parameters,
+        std::unique_ptr<Block> optBody, std::unique_ptr<Type> funType,
+        std::unique_ptr<StorageClass> optStorageClass);
+
+    /**
+     * Destructor for the `FunctionDeclaration` class.
+     *
+     * Declared here, defined in `declaration.cpp` to allow incomplete type
+     * `Block` in header.
+     */
+    ~FunctionDeclaration();
 
     void accept(Visitor &visitor) override;
 
     [[nodiscard]] const std::string &getIdentifier() const;
 
-    [[nodiscard]] const std::shared_ptr<std::vector<std::string>> &
+    [[nodiscard]] const std::vector<std::string> &
     getParameterIdentifiers() const;
 
-    [[nodiscard]] std::shared_ptr<Type> getFunType() const;
+    [[nodiscard]] Type *getFunType() const;
 
-    [[nodiscard]] std::optional<std::shared_ptr<Block>> getOptBody() const;
+    [[nodiscard]] Block *getOptBody() const;
 
-    [[nodiscard]] std::optional<std::shared_ptr<StorageClass>>
-    getOptStorageClass() const;
+    [[nodiscard]] StorageClass *getOptStorageClass() const;
 
-    void setParameters(std::shared_ptr<std::vector<std::string>> parameters);
+    void setParameters(std::unique_ptr<std::vector<std::string>> parameters);
 
-    void setOptBody(std::optional<std::shared_ptr<Block>> optBody);
+    void setOptBody(std::unique_ptr<Block> optBody);
 
-    void setFunType(std::shared_ptr<Type> funType);
+    void setFunType(std::unique_ptr<Type> funType);
 
-    void setOptStorageClass(
-        std::optional<std::shared_ptr<StorageClass>> optStorageClass);
+    void setOptStorageClass(std::unique_ptr<StorageClass> optStorageClass);
 
   private:
     /**
@@ -204,22 +210,22 @@ class FunctionDeclaration : public Declaration {
     /**
      * The parameter identifiers of the function.
      */
-    std::shared_ptr<std::vector<std::string>> parameters;
+    std::unique_ptr<std::vector<std::string>> parameters;
 
     /**
-     * The optional body of the function.
+     * The optional body of the function (can be `nullptr`).
      */
-    std::optional<std::shared_ptr<Block>> optBody;
+    std::unique_ptr<Block> optBody;
 
     /**
      * The function type of the function.
      */
-    std::shared_ptr<Type> funType;
+    std::unique_ptr<Type> funType;
 
     /**
-     * The optional storage class of the function.
+     * The optional storage class of the function (can be `nullptr`).
      */
-    std::optional<std::shared_ptr<StorageClass>> optStorageClass;
+    std::unique_ptr<StorageClass> optStorageClass;
 };
 } // Namespace AST
 

--- a/src/frontend/declaration.h
+++ b/src/frontend/declaration.h
@@ -80,6 +80,8 @@ class VariableDeclaration : public Declaration {
 
     [[nodiscard]] const std::string &getIdentifier() const;
 
+    void setIdentifier(std::string_view identifier);
+
     [[nodiscard]] Expression *getOptInitializer() const;
 
     void setOptInitializer(std::unique_ptr<Expression> newOptInitializer);

--- a/src/frontend/expression.cpp
+++ b/src/frontend/expression.cpp
@@ -100,9 +100,7 @@ UnaryExpression::UnaryExpression(std::string_view opInStr,
     if (!expr) {
         throw std::logic_error("Null expression in unary expression");
     }
-    // Release the `unique_ptr` and re-wrap as `Factor` `unique_ptr`.
-    // This relies on `expr` actually being a `Factor` subtype.
-    this->expr.reset(static_cast<Factor *>(expr.release()));
+    this->expr = std::move(expr);
 }
 
 UnaryExpression::UnaryExpression(std::string_view opInStr,
@@ -125,17 +123,15 @@ UnaryExpression::UnaryExpression(std::string_view opInStr,
     if (!expr) {
         throw std::logic_error("Null expression in unary expression");
     }
-    // Release the `unique_ptr` and re-wrap as `Factor` `unique_ptr`.
-    // This relies on `expr` actually being a `Factor` subtype.
-    this->expr.reset(static_cast<Factor *>(expr.release()));
+    this->expr = std::move(expr);
 }
 
 UnaryExpression::UnaryExpression(std::unique_ptr<UnaryOperator> op,
-                                 std::unique_ptr<Factor> expr)
+                                 std::unique_ptr<Expression> expr)
     : op(std::move(op)), expr(std::move(expr)) {}
 
 UnaryExpression::UnaryExpression(std::unique_ptr<UnaryOperator> op,
-                                 std::unique_ptr<Factor> expr,
+                                 std::unique_ptr<Expression> expr,
                                  std::unique_ptr<Type> expType)
     : op(std::move(op)), expr(std::move(expr)), expType(std::move(expType)) {}
 
@@ -143,7 +139,7 @@ void UnaryExpression::accept(Visitor &visitor) { visitor.visit(*this); }
 
 UnaryOperator *UnaryExpression::getOperator() const { return op.get(); }
 
-Factor *UnaryExpression::getExpression() const { return expr.get(); }
+Expression *UnaryExpression::getExpression() const { return expr.get(); }
 
 Type *UnaryExpression::getExpType() const { return expType.get(); }
 

--- a/src/frontend/expression.cpp
+++ b/src/frontend/expression.cpp
@@ -50,6 +50,10 @@ const std::string &VariableExpression::getIdentifier() const {
     return identifier;
 }
 
+void VariableExpression::setIdentifier(std::string_view newIdentifier) {
+    identifier = newIdentifier;
+}
+
 Type *VariableExpression::getExpType() const { return expType.get(); }
 
 void VariableExpression::setExpType(std::unique_ptr<Type> newExpType) {
@@ -382,6 +386,10 @@ void FunctionCallExpression::accept(Visitor &visitor) { visitor.visit(*this); }
 
 const std::string &FunctionCallExpression::getIdentifier() const {
     return identifier;
+}
+
+void FunctionCallExpression::setIdentifier(std::string_view newIdentifier) {
+    identifier = newIdentifier;
 }
 
 const std::vector<std::unique_ptr<Expression>> &

--- a/src/frontend/expression.h
+++ b/src/frontend/expression.h
@@ -124,6 +124,8 @@ class VariableExpression : public Factor {
 
     [[nodiscard]] const std::string &getIdentifier() const;
 
+    void setIdentifier(std::string_view identifier);
+
     [[nodiscard]] Type *getExpType() const override;
 
     void setExpType(std::unique_ptr<Type> expType) override;
@@ -530,6 +532,8 @@ class FunctionCallExpression : public Expression {
     void accept(Visitor &visitor) override;
 
     [[nodiscard]] const std::string &getIdentifier() const;
+
+    void setIdentifier(std::string_view identifier);
 
     [[nodiscard]] const std::vector<std::unique_ptr<Expression>> &
     getArguments() const;

--- a/src/frontend/expression.h
+++ b/src/frontend/expression.h
@@ -33,16 +33,16 @@ class Expression : public AST {
     /**
      * Pure virtual getter for the expression type.
      *
-     * @return The type of the expression.
+     * @return The type of the expression (non-owning pointer).
      */
-    virtual std::shared_ptr<Type> getExpType() const = 0;
+    virtual Type *getExpType() const = 0;
 
     /**
      * Pure virtual setter for the expression type.
      *
      * @param expType The new type of the expression.
      */
-    virtual void setExpType(std::shared_ptr<Type> expType) = 0;
+    virtual void setExpType(std::unique_ptr<Type> expType) = 0;
 };
 
 /**
@@ -64,7 +64,7 @@ class ConstantExpression : public Factor {
      *
      * @param constant The constant value of the expression.
      */
-    explicit ConstantExpression(std::shared_ptr<Constant> constant);
+    explicit ConstantExpression(std::unique_ptr<Constant> constant);
 
     /**
      * Constructor for the constant expression class with expression type
@@ -73,16 +73,16 @@ class ConstantExpression : public Factor {
      * @param constant The constant value of the expression.
      * @param expType The type of the expression.
      */
-    explicit ConstantExpression(std::shared_ptr<Constant> constant,
-                                std::shared_ptr<Type> expType);
+    explicit ConstantExpression(std::unique_ptr<Constant> constant,
+                                std::unique_ptr<Type> expType);
 
     void accept(Visitor &visitor) override;
 
-    [[nodiscard]] std::shared_ptr<Constant> getConstant() const;
+    [[nodiscard]] Constant *getConstant() const;
 
-    [[nodiscard]] std::shared_ptr<Type> getExpType() const override;
+    [[nodiscard]] Type *getExpType() const override;
 
-    void setExpType(std::shared_ptr<Type> expType) override;
+    void setExpType(std::unique_ptr<Type> expType) override;
 
     [[nodiscard]] int getConstantInInt() const;
 
@@ -92,12 +92,12 @@ class ConstantExpression : public Factor {
     /**
      * The constant value of the expression.
      */
-    std::shared_ptr<Constant> constant;
+    std::unique_ptr<Constant> constant;
 
     /**
      * The type of the expression.
      */
-    std::shared_ptr<Type> expType;
+    std::unique_ptr<Type> expType;
 };
 
 class VariableExpression : public Factor {
@@ -118,15 +118,15 @@ class VariableExpression : public Factor {
      * @param expType The type of the expression.
      */
     explicit VariableExpression(std::string_view identifier,
-                                std::shared_ptr<Type> expType);
+                                std::unique_ptr<Type> expType);
 
     void accept(Visitor &visitor) override;
 
     [[nodiscard]] const std::string &getIdentifier() const;
 
-    [[nodiscard]] std::shared_ptr<Type> getExpType() const override;
+    [[nodiscard]] Type *getExpType() const override;
 
-    void setExpType(std::shared_ptr<Type> expType) override;
+    void setExpType(std::unique_ptr<Type> expType) override;
 
   private:
     /**
@@ -137,7 +137,7 @@ class VariableExpression : public Factor {
     /**
      * The type of the expression.
      */
-    std::shared_ptr<Type> expType;
+    std::unique_ptr<Type> expType;
 };
 
 /**
@@ -151,8 +151,8 @@ class CastExpression : public Factor {
      *
      * @param targetType The target type of the cast expression.
      */
-    explicit CastExpression(std::shared_ptr<Type> targetType,
-                            std::shared_ptr<Expression> expr);
+    explicit CastExpression(std::unique_ptr<Type> targetType,
+                            std::unique_ptr<Expression> expr);
 
     /**
      * Constructor for the cast expression class with expression type
@@ -162,35 +162,35 @@ class CastExpression : public Factor {
      * @param expr The expression being casted.
      * @param expType The type of the expression.
      */
-    explicit CastExpression(std::shared_ptr<Type> targetType,
-                            std::shared_ptr<Expression> expr,
-                            std::shared_ptr<Type> expType);
+    explicit CastExpression(std::unique_ptr<Type> targetType,
+                            std::unique_ptr<Expression> expr,
+                            std::unique_ptr<Type> expType);
 
     void accept(Visitor &visitor) override;
 
-    [[nodiscard]] std::shared_ptr<Type> getTargetType() const;
+    [[nodiscard]] Type *getTargetType() const;
 
-    [[nodiscard]] std::shared_ptr<Expression> getExpression() const;
+    [[nodiscard]] Expression *getExpression() const;
 
-    [[nodiscard]] std::shared_ptr<Type> getExpType() const override;
+    [[nodiscard]] Type *getExpType() const override;
 
-    void setExpType(std::shared_ptr<Type> expType) override;
+    void setExpType(std::unique_ptr<Type> expType) override;
 
   private:
     /**
      * The target type of the cast expression.
      */
-    std::shared_ptr<Type> targetType;
+    std::unique_ptr<Type> targetType;
 
     /**
      * The expression being casted.
      */
-    std::shared_ptr<Expression> expr;
+    std::unique_ptr<Expression> expr;
 
     /**
      * The type of the expression.
      */
-    std::shared_ptr<Type> expType;
+    std::unique_ptr<Type> expType;
 };
 
 /**
@@ -206,7 +206,7 @@ class UnaryExpression : public Factor {
      * @param expr The expression being operated on.
      */
     explicit UnaryExpression(std::string_view opInStr,
-                             std::shared_ptr<Expression> expr);
+                             std::unique_ptr<Expression> expr);
 
     /**
      * Constructor for the unary expression class with operator as a string and
@@ -217,8 +217,8 @@ class UnaryExpression : public Factor {
      * @param expType The type of the expression.
      */
     explicit UnaryExpression(std::string_view opInStr,
-                             std::shared_ptr<Expression> expr,
-                             std::shared_ptr<Type> expType);
+                             std::unique_ptr<Expression> expr,
+                             std::unique_ptr<Type> expType);
 
     /**
      * Constructor for the unary expression class with operator as an object and
@@ -227,8 +227,8 @@ class UnaryExpression : public Factor {
      * @param op The unary operator.
      * @param expr The expression being operated on.
      */
-    explicit UnaryExpression(std::shared_ptr<UnaryOperator> op,
-                             std::shared_ptr<Factor> expr);
+    explicit UnaryExpression(std::unique_ptr<UnaryOperator> op,
+                             std::unique_ptr<Factor> expr);
 
     /**
      * Constructor for the unary expression class with operator as an object and
@@ -238,35 +238,35 @@ class UnaryExpression : public Factor {
      * @param expr The expression being operated on.
      * @param expType The type of the expression.
      */
-    explicit UnaryExpression(std::shared_ptr<UnaryOperator> op,
-                             std::shared_ptr<Factor> expr,
-                             std::shared_ptr<Type> expType);
+    explicit UnaryExpression(std::unique_ptr<UnaryOperator> op,
+                             std::unique_ptr<Factor> expr,
+                             std::unique_ptr<Type> expType);
 
     void accept(Visitor &visitor) override;
 
-    [[nodiscard]] std::shared_ptr<UnaryOperator> getOperator() const;
+    [[nodiscard]] UnaryOperator *getOperator() const;
 
-    [[nodiscard]] std::shared_ptr<Factor> getExpression() const;
+    [[nodiscard]] Factor *getExpression() const;
 
-    [[nodiscard]] std::shared_ptr<Type> getExpType() const override;
+    [[nodiscard]] Type *getExpType() const override;
 
-    void setExpType(std::shared_ptr<Type> expType) override;
+    void setExpType(std::unique_ptr<Type> expType) override;
 
   private:
     /**
      * The unary operator of the expression.
      */
-    std::shared_ptr<UnaryOperator> op;
+    std::unique_ptr<UnaryOperator> op;
 
     /**
      * The expression being operated on.
      */
-    std::shared_ptr<Factor> expr;
+    std::unique_ptr<Factor> expr;
 
     /**
      * The type of the expression.
      */
-    std::shared_ptr<Type> expType;
+    std::unique_ptr<Type> expType;
 };
 
 /**
@@ -282,9 +282,9 @@ class BinaryExpression : public Expression {
      * @param opInStr The binary operator as a string.
      * @param right The right operand of the binary expression.
      */
-    explicit BinaryExpression(std::shared_ptr<Expression> left,
+    explicit BinaryExpression(std::unique_ptr<Expression> left,
                               std::string_view opInStr,
-                              std::shared_ptr<Expression> right);
+                              std::unique_ptr<Expression> right);
 
     /**
      * Constructor for the binary expression class with operator as a string and
@@ -295,10 +295,10 @@ class BinaryExpression : public Expression {
      * @param right The right operand of the binary expression.
      * @param expType The type of the expression.
      */
-    explicit BinaryExpression(std::shared_ptr<Expression> left,
+    explicit BinaryExpression(std::unique_ptr<Expression> left,
                               std::string_view opInStr,
-                              std::shared_ptr<Expression> right,
-                              std::shared_ptr<Type> expType);
+                              std::unique_ptr<Expression> right,
+                              std::unique_ptr<Type> expType);
     /**
      * Constructor for the binary expression class with operator as an object
      * and without expression type information.
@@ -307,9 +307,9 @@ class BinaryExpression : public Expression {
      * @param op The binary operator.
      * @param right The right operand of the binary expression.
      */
-    explicit BinaryExpression(std::shared_ptr<Expression> left,
-                              std::shared_ptr<BinaryOperator> op,
-                              std::shared_ptr<Expression> right);
+    explicit BinaryExpression(std::unique_ptr<Expression> left,
+                              std::unique_ptr<BinaryOperator> op,
+                              std::unique_ptr<Expression> right);
 
     /**
      * Constructor for the binary expression class with operator as an object
@@ -320,49 +320,49 @@ class BinaryExpression : public Expression {
      * @param right The right operand of the binary expression.
      * @param expType The type of the expression.
      */
-    explicit BinaryExpression(std::shared_ptr<Expression> left,
-                              std::shared_ptr<BinaryOperator> op,
-                              std::shared_ptr<Expression> right,
-                              std::shared_ptr<Type> expType);
+    explicit BinaryExpression(std::unique_ptr<Expression> left,
+                              std::unique_ptr<BinaryOperator> op,
+                              std::unique_ptr<Expression> right,
+                              std::unique_ptr<Type> expType);
 
     void accept(Visitor &visitor) override;
 
-    [[nodiscard]] std::shared_ptr<Expression> getLeft() const;
+    [[nodiscard]] Expression *getLeft() const;
 
-    void setLeft(std::shared_ptr<Expression> left);
+    void setLeft(std::unique_ptr<Expression> left);
 
-    [[nodiscard]] std::shared_ptr<BinaryOperator> getOperator() const;
+    [[nodiscard]] BinaryOperator *getOperator() const;
 
-    void setOperator(std::shared_ptr<BinaryOperator> op);
+    void setOperator(std::unique_ptr<BinaryOperator> op);
 
-    [[nodiscard]] std::shared_ptr<Expression> getRight() const;
+    [[nodiscard]] Expression *getRight() const;
 
-    void setRight(std::shared_ptr<Expression> right);
+    void setRight(std::unique_ptr<Expression> right);
 
-    [[nodiscard]] std::shared_ptr<Type> getExpType() const override;
+    [[nodiscard]] Type *getExpType() const override;
 
-    void setExpType(std::shared_ptr<Type> expType) override;
+    void setExpType(std::unique_ptr<Type> expType) override;
 
   private:
     /**
      * The left operand of the binary expression.
      */
-    std::shared_ptr<Expression> left;
+    std::unique_ptr<Expression> left;
 
     /**
      * The binary operator of the expression.
      */
-    std::shared_ptr<BinaryOperator> op;
+    std::unique_ptr<BinaryOperator> op;
 
     /**
      * The right operand of the binary expression.
      */
-    std::shared_ptr<Expression> right;
+    std::unique_ptr<Expression> right;
 
     /**
      * The type of the expression.
      */
-    std::shared_ptr<Type> expType;
+    std::unique_ptr<Type> expType;
 };
 
 /**
@@ -377,8 +377,8 @@ class AssignmentExpression : public Expression {
      * @param left The left operand of the assignment expression.
      * @param right The right operand of the assignment expression.
      */
-    explicit AssignmentExpression(std::shared_ptr<Expression> left,
-                                  std::shared_ptr<Expression> right);
+    explicit AssignmentExpression(std::unique_ptr<Expression> left,
+                                  std::unique_ptr<Expression> right);
 
     /**
      * Constructor for the assignment expression class with expression type
@@ -388,39 +388,39 @@ class AssignmentExpression : public Expression {
      * @param right The right operand of the assignment expression.
      * @param expType The type of the expression.
      */
-    explicit AssignmentExpression(std::shared_ptr<Expression> left,
-                                  std::shared_ptr<Expression> right,
-                                  std::shared_ptr<Type> expType);
+    explicit AssignmentExpression(std::unique_ptr<Expression> left,
+                                  std::unique_ptr<Expression> right,
+                                  std::unique_ptr<Type> expType);
 
     void accept(Visitor &visitor) override;
 
-    [[nodiscard]] std::shared_ptr<Expression> getLeft() const;
+    [[nodiscard]] Expression *getLeft() const;
 
-    [[nodiscard]] std::shared_ptr<Expression> getRight() const;
+    [[nodiscard]] Expression *getRight() const;
 
-    void setLeft(std::shared_ptr<Expression> left);
+    void setLeft(std::unique_ptr<Expression> left);
 
-    void setRight(std::shared_ptr<Expression> right);
+    void setRight(std::unique_ptr<Expression> right);
 
-    [[nodiscard]] std::shared_ptr<Type> getExpType() const override;
+    [[nodiscard]] Type *getExpType() const override;
 
-    void setExpType(std::shared_ptr<Type> expType) override;
+    void setExpType(std::unique_ptr<Type> expType) override;
 
   private:
     /**
      * The left operand of the assignment expression.
      */
-    std::shared_ptr<Expression> left;
+    std::unique_ptr<Expression> left;
 
     /**
      * The right operand of the assignment expression.
      */
-    std::shared_ptr<Expression> right;
+    std::unique_ptr<Expression> right;
 
     /**
      * The type of the expression.
      */
-    std::shared_ptr<Type> expType;
+    std::unique_ptr<Type> expType;
 };
 
 /**
@@ -438,9 +438,9 @@ class ConditionalExpression : public Expression {
      * @param elseExpression The 'else' expression of the conditional
      * expression.
      */
-    explicit ConditionalExpression(std::shared_ptr<Expression> condition,
-                                   std::shared_ptr<Expression> thenExpression,
-                                   std::shared_ptr<Expression> elseExpression);
+    explicit ConditionalExpression(std::unique_ptr<Expression> condition,
+                                   std::unique_ptr<Expression> thenExpression,
+                                   std::unique_ptr<Expression> elseExpression);
 
     /**
      * Constructor for the conditional expression class with expression type
@@ -453,49 +453,49 @@ class ConditionalExpression : public Expression {
      * expression.
      * @param expType The type of the expression.
      */
-    explicit ConditionalExpression(std::shared_ptr<Expression> condition,
-                                   std::shared_ptr<Expression> thenExpression,
-                                   std::shared_ptr<Expression> elseExpression,
-                                   std::shared_ptr<Type> expType);
+    explicit ConditionalExpression(std::unique_ptr<Expression> condition,
+                                   std::unique_ptr<Expression> thenExpression,
+                                   std::unique_ptr<Expression> elseExpression,
+                                   std::unique_ptr<Type> expType);
 
     void accept(Visitor &visitor) override;
 
-    [[nodiscard]] std::shared_ptr<Expression> getCondition() const;
+    [[nodiscard]] Expression *getCondition() const;
 
-    void setCondition(std::shared_ptr<Expression> condition);
+    void setCondition(std::unique_ptr<Expression> condition);
 
-    [[nodiscard]] std::shared_ptr<Expression> getThenExpression() const;
+    [[nodiscard]] Expression *getThenExpression() const;
 
-    void setThenExpression(std::shared_ptr<Expression> thenExpression);
+    void setThenExpression(std::unique_ptr<Expression> thenExpression);
 
-    [[nodiscard]] std::shared_ptr<Expression> getElseExpression() const;
+    [[nodiscard]] Expression *getElseExpression() const;
 
-    void setElseExpression(std::shared_ptr<Expression> elseExpression);
+    void setElseExpression(std::unique_ptr<Expression> elseExpression);
 
-    [[nodiscard]] std::shared_ptr<Type> getExpType() const override;
+    [[nodiscard]] Type *getExpType() const override;
 
-    void setExpType(std::shared_ptr<Type> expType) override;
+    void setExpType(std::unique_ptr<Type> expType) override;
 
   private:
     /**
      * The condition expression of the conditional expression.
      */
-    std::shared_ptr<Expression> condition;
+    std::unique_ptr<Expression> condition;
 
     /**
      * The 'then' expression of the conditional expression.
      */
-    std::shared_ptr<Expression> thenExpression;
+    std::unique_ptr<Expression> thenExpression;
 
     /**
      * The 'else' expression of the conditional expression.
      */
-    std::shared_ptr<Expression> elseExpression;
+    std::unique_ptr<Expression> elseExpression;
 
     /**
      * The type of the expression.
      */
-    std::shared_ptr<Type> expType;
+    std::unique_ptr<Type> expType;
 };
 
 /**
@@ -512,7 +512,7 @@ class FunctionCallExpression : public Expression {
      */
     explicit FunctionCallExpression(
         std::string_view identifier,
-        std::shared_ptr<std::vector<std::shared_ptr<Expression>>> arguments);
+        std::unique_ptr<std::vector<std::unique_ptr<Expression>>> arguments);
 
     /**
      * Constructor for the function call expression class with expression type
@@ -524,23 +524,22 @@ class FunctionCallExpression : public Expression {
      */
     explicit FunctionCallExpression(
         std::string_view identifier,
-        std::shared_ptr<std::vector<std::shared_ptr<Expression>>> arguments,
-        std::shared_ptr<Type> expType);
+        std::unique_ptr<std::vector<std::unique_ptr<Expression>>> arguments,
+        std::unique_ptr<Type> expType);
 
     void accept(Visitor &visitor) override;
 
     [[nodiscard]] const std::string &getIdentifier() const;
 
-    [[nodiscard]] const std::shared_ptr<
-        std::vector<std::shared_ptr<Expression>>> &
+    [[nodiscard]] const std::vector<std::unique_ptr<Expression>> &
     getArguments() const;
 
     void setArguments(
-        std::shared_ptr<std::vector<std::shared_ptr<Expression>>> arguments);
+        std::unique_ptr<std::vector<std::unique_ptr<Expression>>> arguments);
 
-    [[nodiscard]] std::shared_ptr<Type> getExpType() const override;
+    [[nodiscard]] Type *getExpType() const override;
 
-    void setExpType(std::shared_ptr<Type> expType) override;
+    void setExpType(std::unique_ptr<Type> expType) override;
 
   private:
     /**
@@ -550,11 +549,11 @@ class FunctionCallExpression : public Expression {
     /**
      * The arguments of the function call.
      */
-    std::shared_ptr<std::vector<std::shared_ptr<Expression>>> arguments;
+    std::unique_ptr<std::vector<std::unique_ptr<Expression>>> arguments;
     /**
      * The type of the expression.
      */
-    std::shared_ptr<Type> expType;
+    std::unique_ptr<Type> expType;
 };
 } // Namespace AST
 

--- a/src/frontend/expression.h
+++ b/src/frontend/expression.h
@@ -230,7 +230,7 @@ class UnaryExpression : public Factor {
      * @param expr The expression being operated on.
      */
     explicit UnaryExpression(std::unique_ptr<UnaryOperator> op,
-                             std::unique_ptr<Factor> expr);
+                             std::unique_ptr<Expression> expr);
 
     /**
      * Constructor for the unary expression class with operator as an object and
@@ -241,14 +241,14 @@ class UnaryExpression : public Factor {
      * @param expType The type of the expression.
      */
     explicit UnaryExpression(std::unique_ptr<UnaryOperator> op,
-                             std::unique_ptr<Factor> expr,
+                             std::unique_ptr<Expression> expr,
                              std::unique_ptr<Type> expType);
 
     void accept(Visitor &visitor) override;
 
     [[nodiscard]] UnaryOperator *getOperator() const;
 
-    [[nodiscard]] Factor *getExpression() const;
+    [[nodiscard]] Expression *getExpression() const;
 
     [[nodiscard]] Type *getExpType() const override;
 
@@ -263,7 +263,7 @@ class UnaryExpression : public Factor {
     /**
      * The expression being operated on.
      */
-    std::unique_ptr<Factor> expr;
+    std::unique_ptr<Expression> expr;
 
     /**
      * The type of the expression.

--- a/src/frontend/forInit.cpp
+++ b/src/frontend/forInit.cpp
@@ -1,20 +1,18 @@
 #include "forInit.h"
 
 namespace AST {
-InitDecl::InitDecl(std::shared_ptr<VariableDeclaration> decl) : decl(decl) {}
+InitDecl::InitDecl(std::unique_ptr<VariableDeclaration> decl)
+    : decl(std::move(decl)) {}
 
 void InitDecl::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<VariableDeclaration> InitDecl::getVariableDeclaration() const {
-    return decl;
+VariableDeclaration *InitDecl::getVariableDeclaration() const {
+    return decl.get();
 }
 
-InitExpr::InitExpr(std::optional<std::shared_ptr<Expression>> expr)
-    : expr(expr) {}
+InitExpr::InitExpr(std::unique_ptr<Expression> expr) : expr(std::move(expr)) {}
 
 void InitExpr::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::optional<std::shared_ptr<Expression>> InitExpr::getExpression() const {
-    return expr;
-}
+Expression *InitExpr::getExpression() const { return expr.get(); }
 } // Namespace AST

--- a/src/frontend/forInit.h
+++ b/src/frontend/forInit.h
@@ -27,18 +27,17 @@ class InitDecl : public ForInit {
      *
      * @param decl The variable declaration used for initialization.
      */
-    explicit InitDecl(std::shared_ptr<VariableDeclaration> decl);
+    explicit InitDecl(std::unique_ptr<VariableDeclaration> decl);
 
     void accept(Visitor &visitor) override;
 
-    [[nodiscard]] std::shared_ptr<VariableDeclaration>
-    getVariableDeclaration() const;
+    [[nodiscard]] VariableDeclaration *getVariableDeclaration() const;
 
   private:
     /**
      * The variable declaration used for initialization.
      */
-    std::shared_ptr<VariableDeclaration> decl;
+    std::unique_ptr<VariableDeclaration> decl;
 };
 
 /**
@@ -54,20 +53,20 @@ class InitExpr : public ForInit {
     /**
      * Constructor for the init-expr class with an expression.
      *
-     * @param expr The optional expression used for initialization.
+     * @param expr The optional expression used for initialization (can be
+     * `nullptr`).
      */
-    explicit InitExpr(std::optional<std::shared_ptr<Expression>> expr);
+    explicit InitExpr(std::unique_ptr<Expression> expr);
 
     void accept(Visitor &visitor) override;
 
-    [[nodiscard]] std::optional<std::shared_ptr<Expression>>
-    getExpression() const;
+    [[nodiscard]] Expression *getExpression() const;
 
   private:
     /**
-     * The optional expression used for initialization.
+     * The optional expression used for initialization (can be `nullptr`).
      */
-    std::optional<std::shared_ptr<Expression>> expr;
+    std::unique_ptr<Expression> expr;
 };
 } // Namespace AST
 

--- a/src/frontend/frontendSymbolTable.h
+++ b/src/frontend/frontendSymbolTable.h
@@ -13,12 +13,12 @@ class IdentifierAttribute;
  * Type alias for the frontend symbol table.
  *
  * The key is the identifier (variable or function name), and the value is a
- * pair consisting of (a shared pointer to) the type and (a shared pointer to)
+ * pair consisting of (a unique pointer to) the type and (a unique pointer to)
  * the identifier attribute.
  */
 using FrontendSymbolTable = std::unordered_map<
     std::string,
-    std::pair<std::shared_ptr<Type>, std::shared_ptr<IdentifierAttribute>>>;
+    std::pair<std::unique_ptr<Type>, std::unique_ptr<IdentifierAttribute>>>;
 } // namespace AST
 
 #endif // FRONTEND_SYMBOL_TABLE_H

--- a/src/frontend/function.cpp
+++ b/src/frontend/function.cpp
@@ -2,14 +2,16 @@
 #include "visitor.h"
 
 namespace AST {
-Function::Function(std::string_view identifier, std::shared_ptr<Block> body)
-    : identifier(identifier), body(body) {}
+Function::Function(std::string_view identifier, std::unique_ptr<Block> body)
+    : identifier(identifier), body(std::move(body)) {}
 
 void Function::accept(Visitor &visitor) { visitor.visit(*this); }
 
 const std::string &Function::getIdentifier() const { return identifier; }
 
-std::shared_ptr<Block> Function::getBody() const { return body; }
+Block *Function::getBody() const { return body.get(); }
 
-void Function::setBody(std::shared_ptr<Block> newBody) { this->body = newBody; }
+void Function::setBody(std::unique_ptr<Block> newBody) {
+    body = std::move(newBody);
+}
 } // Namespace AST

--- a/src/frontend/function.h
+++ b/src/frontend/function.h
@@ -21,15 +21,15 @@ class Function : public AST {
      * @param identifier The identifier of the function.
      * @param body The body block of the function.
      */
-    explicit Function(std::string_view identifier, std::shared_ptr<Block> body);
+    explicit Function(std::string_view identifier, std::unique_ptr<Block> body);
 
     void accept(Visitor &visitor) override;
 
     [[nodiscard]] const std::string &getIdentifier() const;
 
-    [[nodiscard]] std::shared_ptr<Block> getBody() const;
+    [[nodiscard]] Block *getBody() const;
 
-    void setBody(std::shared_ptr<Block> body);
+    void setBody(std::unique_ptr<Block> body);
 
   private:
     /**
@@ -40,7 +40,7 @@ class Function : public AST {
     /**
      * The body block of the function.
      */
-    std::shared_ptr<Block> body;
+    std::unique_ptr<Block> body;
 };
 } // Namespace AST
 

--- a/src/frontend/parser.h
+++ b/src/frontend/parser.h
@@ -28,9 +28,9 @@ class Parser {
     /**
      * Parse the tokens and return the root of the AST (`Program` node).
      *
-     * @return The root of the AST (as a shared pointer to a `Program` node).
+     * @return The root of the AST (as a unique pointer to a `Program` node).
      */
-    std::shared_ptr<Program> parse();
+    std::unique_ptr<Program> parse();
 
   private:
     /**
@@ -85,7 +85,7 @@ class Parser {
      *
      * @return The declaration node.
      */
-    std::shared_ptr<Declaration> parseDeclaration();
+    std::unique_ptr<Declaration> parseDeclaration();
 
     /**
      * Parse type specifiers in function parameters.
@@ -99,42 +99,42 @@ class Parser {
      *
      * @return The block item node.
      */
-    std::shared_ptr<BlockItem> parseBlockItem();
+    std::unique_ptr<BlockItem> parseBlockItem();
 
     /**
      * Parse a block.
      *
      * @return The block node.
      */
-    std::shared_ptr<Block> parseBlock();
+    std::unique_ptr<Block> parseBlock();
 
     /**
      * Parse a function definition.
      *
      * @return The function definition node.
      */
-    std::shared_ptr<ForInit> parseForInit();
+    std::unique_ptr<ForInit> parseForInit();
 
     /**
      * Parse a statement.
      *
      * @return The statement node.
      */
-    std::shared_ptr<Statement> parseStatement();
+    std::unique_ptr<Statement> parseStatement();
 
     /**
      * Parse a factor.
      *
      * @return The expression node representing the factor.
      */
-    std::shared_ptr<Expression> parseFactor();
+    std::unique_ptr<Expression> parseFactor();
 
     /**
      * Parse a constant.
      *
      * @return The constant node.
      */
-    std::shared_ptr<Constant> parseConstant();
+    std::unique_ptr<Constant> parseConstant();
 
     /**
      * Parse an expression with the given minimum precedence.
@@ -142,7 +142,7 @@ class Parser {
      * @param minPrecedence The minimum precedence for parsing the expression.
      * @return The expression node.
      */
-    std::shared_ptr<Expression> parseExpression(int minPrecedence = 0);
+    std::unique_ptr<Expression> parseExpression(int minPrecedence = 0);
 
     /**
      * Parse the middle part of a conditional expression (between '?' and ':').
@@ -150,16 +150,16 @@ class Parser {
      * @return The expression node representing the
      * conditional middle.
      */
-    std::shared_ptr<Expression> parseConditionalMiddle();
+    std::unique_ptr<Expression> parseConditionalMiddle();
 
     /**
      * Parse a type and storage class from a list of specifiers.
      *
      * @param specifierList A vector of specifier strings.
-     * @return A pair consisting of (a shared pointer to) the type and a (shared
+     * @return A pair consisting of (a unique pointer to) the type and a (unique
      * pointer) to the storage class.
      */
-    std::pair<std::shared_ptr<Type>, std::shared_ptr<StorageClass>>
+    std::pair<std::unique_ptr<Type>, std::unique_ptr<StorageClass>>
     parseTypeAndStorageClass(const std::vector<std::string> &specifierList);
 
     /**
@@ -168,7 +168,7 @@ class Parser {
      * @param specifierList A vector of specifier strings.
      * @return The type.
      */
-    std::shared_ptr<Type>
+    std::unique_ptr<Type>
     parseType(const std::vector<std::string> &specifierList);
 
     /**
@@ -177,7 +177,7 @@ class Parser {
      * @param specifier A specifier string.
      * @return The storage class.
      */
-    std::shared_ptr<StorageClass>
+    std::unique_ptr<StorageClass>
     parseStorageClass(const std::string &specifier);
 
     /**

--- a/src/frontend/program.cpp
+++ b/src/frontend/program.cpp
@@ -3,19 +3,19 @@
 
 namespace AST {
 Program::Program(
-    std::shared_ptr<std::vector<std::shared_ptr<Declaration>>> declarations)
-    : declarations(declarations) {}
+    std::unique_ptr<std::vector<std::unique_ptr<Declaration>>> declarations)
+    : declarations(std::move(declarations)) {}
 
 void Program::accept(Visitor &visitor) { visitor.visit(*this); }
 
-const std::shared_ptr<std::vector<std::shared_ptr<Declaration>>> &
+const std::vector<std::unique_ptr<Declaration>> &
 Program::getDeclarations() const {
-    return declarations;
+    return *declarations;
 }
 
 void Program::setDeclarations(
-    std::shared_ptr<std::vector<std::shared_ptr<Declaration>>>
+    std::unique_ptr<std::vector<std::unique_ptr<Declaration>>>
         newDeclarations) {
-    this->declarations = newDeclarations;
+    this->declarations = std::move(newDeclarations);
 }
 } // Namespace AST

--- a/src/frontend/program.h
+++ b/src/frontend/program.h
@@ -15,28 +15,27 @@ namespace AST {
 class Program : public AST {
   public:
     /**
-     * Constructor for the Program class.
+     * Constructor for the `Program` class.
      *
      * @param declaration The list of declarations in the program.
      */
-    explicit Program(std::shared_ptr<std::vector<std::shared_ptr<Declaration>>>
+    explicit Program(std::unique_ptr<std::vector<std::unique_ptr<Declaration>>>
                          declarations);
 
     void accept(Visitor &visitor) override;
 
-    [[nodiscard]] const std::shared_ptr<
-        std::vector<std::shared_ptr<Declaration>>> &
+    [[nodiscard]] const std::vector<std::unique_ptr<Declaration>> &
     getDeclarations() const;
 
     void
-    setDeclarations(std::shared_ptr<std::vector<std::shared_ptr<Declaration>>>
+    setDeclarations(std::unique_ptr<std::vector<std::unique_ptr<Declaration>>>
                         declarations);
 
   private:
     /**
      * The list of declarations that make up the program.
      */
-    std::shared_ptr<std::vector<std::shared_ptr<Declaration>>> declarations;
+    std::unique_ptr<std::vector<std::unique_ptr<Declaration>>> declarations;
 };
 } // Namespace AST
 

--- a/src/frontend/semanticAnalysisPasses.cpp
+++ b/src/frontend/semanticAnalysisPasses.cpp
@@ -126,24 +126,6 @@ cloneBinaryOperator(const AST::BinaryOperator *op) {
 }
 
 /**
- * Convert an expression to a factor.
- *
- * @param expr The expression to convert.
- * @return The converted factor.
- */
-std::unique_ptr<AST::Factor> toFactor(std::unique_ptr<AST::Expression> expr) {
-    if (!expr) {
-        return nullptr;
-    }
-    auto *raw = dynamic_cast<AST::Factor *>(expr.get());
-    if (!raw) {
-        throw std::logic_error("Expression is not a factor");
-    }
-    auto *released = expr.release();
-    return std::unique_ptr<AST::Factor>(static_cast<AST::Factor *>(released));
-}
-
-/**
  * Clone an expression.
  *
  * @param expression The expression to clone.
@@ -187,8 +169,7 @@ cloneExpression(const AST::Expression *expression) {
     }
     if (auto unaryExpression =
             dynamic_cast<const AST::UnaryExpression *>(expression)) {
-        auto operand =
-            toFactor(cloneExpression(unaryExpression->getExpression()));
+        auto operand = cloneExpression(unaryExpression->getExpression());
         auto cloned = std::make_unique<AST::UnaryExpression>(
             cloneUnaryOperator(unaryExpression->getOperator()),
             std::move(operand), cloneType(unaryExpression->getExpType()));

--- a/src/frontend/semanticAnalysisPasses.cpp
+++ b/src/frontend/semanticAnalysisPasses.cpp
@@ -1,13 +1,266 @@
 #include "semanticAnalysisPasses.h"
+#include "forInit.h"
 #include "frontendSymbolTable.h"
 #include <memory>
 #include <sstream>
+
+namespace {
+/**
+ * Clone a type.
+ *
+ * @param type The type to clone.
+ * @return The cloned type.
+ */
+std::unique_ptr<AST::Type> cloneType(const AST::Type *type) {
+    if (!type) {
+        return nullptr;
+    }
+    if (dynamic_cast<const AST::IntType *>(type)) {
+        return std::make_unique<AST::IntType>();
+    }
+    if (dynamic_cast<const AST::LongType *>(type)) {
+        return std::make_unique<AST::LongType>();
+    }
+    if (auto functionType = dynamic_cast<const AST::FunctionType *>(type)) {
+        auto parameterTypes =
+            std::make_unique<std::vector<std::unique_ptr<AST::Type>>>();
+        parameterTypes->reserve(functionType->getParameterTypes().size());
+        for (const auto &parameter : functionType->getParameterTypes()) {
+            parameterTypes->emplace_back(cloneType(parameter.get()));
+        }
+        return std::make_unique<AST::FunctionType>(
+            std::move(parameterTypes),
+            cloneType(&functionType->getReturnType()));
+    }
+    throw std::logic_error("Unsupported type in cloneType");
+}
+
+/**
+ * Clone a constant.
+ *
+ * @param constant The constant to clone.
+ * @return The cloned constant.
+ */
+std::unique_ptr<AST::Constant> cloneConstant(const AST::Constant *constant) {
+    if (auto intConst = dynamic_cast<const AST::ConstantInt *>(constant)) {
+        return std::make_unique<AST::ConstantInt>(intConst->getValue());
+    }
+    if (auto longConst = dynamic_cast<const AST::ConstantLong *>(constant)) {
+        return std::make_unique<AST::ConstantLong>(longConst->getValue());
+    }
+    throw std::logic_error("Unsupported constant type in cloneConstant");
+}
+
+/**
+ * Clone a unary operator.
+ *
+ * @param op The unary operator to clone.
+ * @return The cloned unary operator.
+ */
+std::unique_ptr<AST::UnaryOperator>
+cloneUnaryOperator(const AST::UnaryOperator *op) {
+    if (dynamic_cast<const AST::ComplementOperator *>(op)) {
+        return std::make_unique<AST::ComplementOperator>();
+    }
+    if (dynamic_cast<const AST::NegateOperator *>(op)) {
+        return std::make_unique<AST::NegateOperator>();
+    }
+    if (dynamic_cast<const AST::NotOperator *>(op)) {
+        return std::make_unique<AST::NotOperator>();
+    }
+    throw std::logic_error("Unsupported unary operator in cloneUnaryOperator");
+}
+
+/**
+ * Clone a binary operator.
+ *
+ * @param op The binary operator to clone.
+ * @return The cloned binary operator.
+ */
+std::unique_ptr<AST::BinaryOperator>
+cloneBinaryOperator(const AST::BinaryOperator *op) {
+    if (dynamic_cast<const AST::AddOperator *>(op)) {
+        return std::make_unique<AST::AddOperator>();
+    }
+    if (dynamic_cast<const AST::SubtractOperator *>(op)) {
+        return std::make_unique<AST::SubtractOperator>();
+    }
+    if (dynamic_cast<const AST::MultiplyOperator *>(op)) {
+        return std::make_unique<AST::MultiplyOperator>();
+    }
+    if (dynamic_cast<const AST::DivideOperator *>(op)) {
+        return std::make_unique<AST::DivideOperator>();
+    }
+    if (dynamic_cast<const AST::RemainderOperator *>(op)) {
+        return std::make_unique<AST::RemainderOperator>();
+    }
+    if (dynamic_cast<const AST::AndOperator *>(op)) {
+        return std::make_unique<AST::AndOperator>();
+    }
+    if (dynamic_cast<const AST::OrOperator *>(op)) {
+        return std::make_unique<AST::OrOperator>();
+    }
+    if (dynamic_cast<const AST::EqualOperator *>(op)) {
+        return std::make_unique<AST::EqualOperator>();
+    }
+    if (dynamic_cast<const AST::NotEqualOperator *>(op)) {
+        return std::make_unique<AST::NotEqualOperator>();
+    }
+    if (dynamic_cast<const AST::LessThanOperator *>(op)) {
+        return std::make_unique<AST::LessThanOperator>();
+    }
+    if (dynamic_cast<const AST::LessThanOrEqualOperator *>(op)) {
+        return std::make_unique<AST::LessThanOrEqualOperator>();
+    }
+    if (dynamic_cast<const AST::GreaterThanOperator *>(op)) {
+        return std::make_unique<AST::GreaterThanOperator>();
+    }
+    if (dynamic_cast<const AST::GreaterThanOrEqualOperator *>(op)) {
+        return std::make_unique<AST::GreaterThanOrEqualOperator>();
+    }
+    if (dynamic_cast<const AST::AssignmentOperator *>(op)) {
+        return std::make_unique<AST::AssignmentOperator>();
+    }
+    throw std::logic_error(
+        "Unsupported binary operator in cloneBinaryOperator");
+}
+
+/**
+ * Convert an expression to a factor.
+ *
+ * @param expr The expression to convert.
+ * @return The converted factor.
+ */
+std::unique_ptr<AST::Factor> toFactor(std::unique_ptr<AST::Expression> expr) {
+    if (!expr) {
+        return nullptr;
+    }
+    auto *raw = dynamic_cast<AST::Factor *>(expr.get());
+    if (!raw) {
+        throw std::logic_error("Expression is not a factor");
+    }
+    auto *released = expr.release();
+    return std::unique_ptr<AST::Factor>(static_cast<AST::Factor *>(released));
+}
+
+/**
+ * Clone an expression.
+ *
+ * @param expression The expression to clone.
+ * @return The cloned expression.
+ */
+std::unique_ptr<AST::Expression>
+cloneExpression(const AST::Expression *expression) {
+    if (!expression) {
+        return nullptr;
+    }
+    if (auto assignmentExpression =
+            dynamic_cast<const AST::AssignmentExpression *>(expression)) {
+        auto left = cloneExpression(assignmentExpression->getLeft());
+        auto right = cloneExpression(assignmentExpression->getRight());
+        auto cloned = std::make_unique<AST::AssignmentExpression>(
+            std::move(left), std::move(right));
+        cloned->setExpType(cloneType(assignmentExpression->getExpType()));
+        return cloned;
+    }
+    if (auto variableExpression =
+            dynamic_cast<const AST::VariableExpression *>(expression)) {
+        auto cloned = std::make_unique<AST::VariableExpression>(
+            variableExpression->getIdentifier(),
+            cloneType(variableExpression->getExpType()));
+        return cloned;
+    }
+    if (auto constantExpression =
+            dynamic_cast<const AST::ConstantExpression *>(expression)) {
+        auto cloned = std::make_unique<AST::ConstantExpression>(
+            cloneConstant(constantExpression->getConstant()),
+            cloneType(constantExpression->getExpType()));
+        return cloned;
+    }
+    if (auto castExpression =
+            dynamic_cast<const AST::CastExpression *>(expression)) {
+        auto cloned = std::make_unique<AST::CastExpression>(
+            cloneType(castExpression->getTargetType()),
+            cloneExpression(castExpression->getExpression()),
+            cloneType(castExpression->getExpType()));
+        return cloned;
+    }
+    if (auto unaryExpression =
+            dynamic_cast<const AST::UnaryExpression *>(expression)) {
+        auto operand =
+            toFactor(cloneExpression(unaryExpression->getExpression()));
+        auto cloned = std::make_unique<AST::UnaryExpression>(
+            cloneUnaryOperator(unaryExpression->getOperator()),
+            std::move(operand), cloneType(unaryExpression->getExpType()));
+        return cloned;
+    }
+    if (auto binaryExpression =
+            dynamic_cast<const AST::BinaryExpression *>(expression)) {
+        auto left = cloneExpression(binaryExpression->getLeft());
+        auto right = cloneExpression(binaryExpression->getRight());
+        auto cloned = std::make_unique<AST::BinaryExpression>(
+            std::move(left),
+            cloneBinaryOperator(binaryExpression->getOperator()),
+            std::move(right), cloneType(binaryExpression->getExpType()));
+        return cloned;
+    }
+    if (auto conditionalExpression =
+            dynamic_cast<const AST::ConditionalExpression *>(expression)) {
+        auto cloned = std::make_unique<AST::ConditionalExpression>(
+            cloneExpression(conditionalExpression->getCondition()),
+            cloneExpression(conditionalExpression->getThenExpression()),
+            cloneExpression(conditionalExpression->getElseExpression()),
+            cloneType(conditionalExpression->getExpType()));
+        return cloned;
+    }
+    if (auto functionCallExpression =
+            dynamic_cast<const AST::FunctionCallExpression *>(expression)) {
+        auto arguments =
+            std::make_unique<std::vector<std::unique_ptr<AST::Expression>>>();
+        arguments->reserve(functionCallExpression->getArguments().size());
+        for (const auto &argument : functionCallExpression->getArguments()) {
+            arguments->emplace_back(cloneExpression(argument.get()));
+        }
+        auto cloned = std::make_unique<AST::FunctionCallExpression>(
+            functionCallExpression->getIdentifier(), std::move(arguments),
+            cloneType(functionCallExpression->getExpType()));
+        return cloned;
+    }
+    throw std::logic_error("Unsupported expression type in cloneExpression");
+}
+
+/**
+ * Clone an initial value.
+ *
+ * @param initialValue The initial value to clone.
+ * @return The cloned initial value.
+ */
+std::unique_ptr<AST::InitialValue>
+cloneInitialValue(const AST::InitialValue *initialValue) {
+    if (dynamic_cast<const AST::NoInitializer *>(initialValue)) {
+        return std::make_unique<AST::NoInitializer>();
+    }
+    if (dynamic_cast<const AST::Tentative *>(initialValue)) {
+        return std::make_unique<AST::Tentative>();
+    }
+    if (auto initial = dynamic_cast<const AST::Initial *>(initialValue)) {
+        auto value = initial->getStaticInit()->getValue();
+        if (std::holds_alternative<int>(value)) {
+            return std::make_unique<AST::Initial>(std::get<int>(value));
+        }
+        if (std::holds_alternative<long>(value)) {
+            return std::make_unique<AST::Initial>(std::get<long>(value));
+        }
+    }
+    throw std::logic_error("Unsupported initial value in cloneInitialValue");
+}
+} // namespace
 
 namespace AST {
 /*
  * Start: Functions for the identifier-resolution pass.
  */
-int IdentifierResolutionPass::resolveProgram(std::shared_ptr<Program> program) {
+int IdentifierResolutionPass::resolveProgram(Program &program) {
     // Initialize an empty identifier map (that will be passed to the helpers).
     // Instead of maintaining a "global" identifier map, we pass the identifier
     // map to the helper functions to, together with `copyIdentifierMap`, ensure
@@ -16,29 +269,21 @@ int IdentifierResolutionPass::resolveProgram(std::shared_ptr<Program> program) {
 
     // At the top level, resolve the list of declarations in the
     // program.
-    auto resolvedDeclarations =
-        std::make_shared<std::vector<std::shared_ptr<Declaration>>>();
-    for (auto &declaration : *program->getDeclarations()) {
-        if (auto functionDeclaration =
-                std::dynamic_pointer_cast<FunctionDeclaration>(declaration)) {
-            auto resolvedFunctionDeclaration =
-                resolveFunctionDeclaration(functionDeclaration, identifierMap);
-            resolvedDeclarations->emplace_back(resolvedFunctionDeclaration);
+    for (auto &declaration : program.getDeclarations()) {
+        if (auto *functionDeclaration =
+                dynamic_cast<FunctionDeclaration *>(declaration.get())) {
+            resolveFunctionDeclaration(functionDeclaration, identifierMap);
         }
-        else if (auto variableDeclaration =
-                     std::dynamic_pointer_cast<VariableDeclaration>(
-                         declaration)) {
-            auto resolvedVariableDeclaration =
-                resolveFileScopeVariableDeclaration(variableDeclaration,
-                                                    identifierMap);
-            resolvedDeclarations->emplace_back(resolvedVariableDeclaration);
+        else if (auto *variableDeclaration =
+                     dynamic_cast<VariableDeclaration *>(declaration.get())) {
+            resolveFileScopeVariableDeclaration(variableDeclaration,
+                                                identifierMap);
         }
         else {
             throw std::logic_error(
                 "Unsupported declaration type for identifier resolution");
         }
     }
-    program->setDeclarations(resolvedDeclarations);
 
     return this->variableResolutionCounter;
 }
@@ -62,34 +307,28 @@ std::string IdentifierResolutionPass::generateUniqueVariableName(
     return identifier + "." + std::to_string(this->variableResolutionCounter++);
 }
 
-std::shared_ptr<Declaration>
-IdentifierResolutionPass::resolveFileScopeVariableDeclaration(
-    std::shared_ptr<Declaration> declaration,
+void IdentifierResolutionPass::resolveFileScopeVariableDeclaration(
+    VariableDeclaration *declaration,
     std::unordered_map<std::string, MapEntry> &identifierMap) {
-    if (auto variableDeclaration =
-            std::dynamic_pointer_cast<VariableDeclaration>(declaration)) {
-        identifierMap[variableDeclaration->getIdentifier()] =
-            MapEntry(variableDeclaration->getIdentifier(), true, true);
-        return declaration;
-    }
-    else {
+    if (!declaration) {
         throw std::logic_error(
             "Unsupported declaration type for file-scope variable resolution");
     }
+    identifierMap[declaration->getIdentifier()] =
+        MapEntry(declaration->getIdentifier(), true, true);
 }
 
-std::shared_ptr<VariableDeclaration>
-IdentifierResolutionPass::resolveLocalVariableDeclaration(
-    std::shared_ptr<VariableDeclaration> declaration,
+void IdentifierResolutionPass::resolveLocalVariableDeclaration(
+    VariableDeclaration *declaration,
     std::unordered_map<std::string, MapEntry> &identifierMap) {
     if (identifierMap.find(declaration->getIdentifier()) !=
         identifierMap.end()) {
         auto previousEntry = identifierMap[declaration->getIdentifier()];
         if (previousEntry.fromCurrentScopeOrNot()) {
             if (!(previousEntry.hasLinkageOrNot() &&
-                  declaration->getOptStorageClass().has_value() &&
-                  std::dynamic_pointer_cast<ExternStorageClass>(
-                      declaration->getOptStorageClass().value()))) {
+                  declaration->getOptStorageClass() &&
+                  dynamic_cast<ExternStorageClass *>(
+                      declaration->getOptStorageClass()))) {
                 std::stringstream msg;
                 msg << "Conflicting local variable declaration: "
                     << declaration->getIdentifier();
@@ -97,12 +336,10 @@ IdentifierResolutionPass::resolveLocalVariableDeclaration(
             }
         }
     }
-    if (declaration->getOptStorageClass().has_value() &&
-        std::dynamic_pointer_cast<ExternStorageClass>(
-            declaration->getOptStorageClass().value())) {
+    if (declaration->getOptStorageClass() &&
+        dynamic_cast<ExternStorageClass *>(declaration->getOptStorageClass())) {
         identifierMap[declaration->getIdentifier()] =
             MapEntry(declaration->getIdentifier(), true, true);
-        return declaration;
     }
     else {
         auto declarationIdentifier = declaration->getIdentifier();
@@ -111,132 +348,78 @@ IdentifierResolutionPass::resolveLocalVariableDeclaration(
         identifierMap[declarationIdentifier] =
             MapEntry(uniqueVariableName, true, false);
         auto optInitializer = declaration->getOptInitializer();
-        if (optInitializer.has_value()) {
-            auto tmpInitializer =
-                resolveExpression(optInitializer.value(), identifierMap);
-            optInitializer = std::make_optional(tmpInitializer);
+        if (optInitializer) {
+            resolveExpression(optInitializer, identifierMap);
         }
-        return std::make_shared<VariableDeclaration>(
-            identifierMap[declarationIdentifier].getNewName(), optInitializer,
-            declaration->getVarType(), declaration->getOptStorageClass());
+        declaration->setIdentifier(
+            identifierMap[declarationIdentifier].getNewName());
     }
 }
 
-std::shared_ptr<Statement> IdentifierResolutionPass::resolveStatement(
-    std::shared_ptr<Statement> statement,
+void IdentifierResolutionPass::resolveStatement(
+    Statement *statement,
     std::unordered_map<std::string, MapEntry> &identifierMap) {
-    if (auto returnStatement =
-            std::dynamic_pointer_cast<ReturnStatement>(statement)) {
+    if (auto returnStatement = dynamic_cast<ReturnStatement *>(statement)) {
         // If the statement is a return statement, resolve the expression in the
         // return statement.
-        auto resolvedExpression =
-            resolveExpression(returnStatement->getExpression(), identifierMap);
-        // Return a new return statement with the resolved expression.
-        return std::make_shared<ReturnStatement>(resolvedExpression);
+        resolveExpression(returnStatement->getExpression(), identifierMap);
     }
     else if (auto expressionStatement =
-                 std::dynamic_pointer_cast<ExpressionStatement>(statement)) {
+                 dynamic_cast<ExpressionStatement *>(statement)) {
         // If the statement is an expression statement, resolve the expression
         // in the expression statement.
-        auto resolvedExpression = resolveExpression(
-            expressionStatement->getExpression(), identifierMap);
-        // Return a new expression statement with the resolved expression.
-        return std::make_shared<ExpressionStatement>(resolvedExpression);
+        resolveExpression(expressionStatement->getExpression(), identifierMap);
     }
     else if (auto compoundStatement =
-                 std::dynamic_pointer_cast<CompoundStatement>(statement)) {
+                 dynamic_cast<CompoundStatement *>(statement)) {
         // Copy the identifier map (with modifications) and resolve the block in
         // the compound statement.
         auto copiedIdentifierMap = copyIdentifierMap(identifierMap);
-        auto resolvedBlock =
-            resolveBlock(compoundStatement->getBlock(), copiedIdentifierMap);
-        return std::make_shared<CompoundStatement>(resolvedBlock);
+        resolveBlock(compoundStatement->getBlock(), copiedIdentifierMap);
     }
-    else if (auto breakStatement =
-                 std::dynamic_pointer_cast<BreakStatement>(statement)) {
-        // If the statement is a break statement, return the break statement.
-        return breakStatement;
-    }
-    else if (auto continueStatement =
-                 std::dynamic_pointer_cast<ContinueStatement>(statement)) {
-        // If the statement is a continue statement, return the continue
-        // statement.
-        return continueStatement;
-    }
-    else if (auto whileStatement =
-                 std::dynamic_pointer_cast<WhileStatement>(statement)) {
+    else if (auto whileStatement = dynamic_cast<WhileStatement *>(statement)) {
         // If the statement is a while-statement, resolve the condition
         // expression and the body statement in the while-statement.
-        auto resolvedCondition =
-            resolveExpression(whileStatement->getCondition(), identifierMap);
-        auto resolvedBody =
-            resolveStatement(whileStatement->getBody(), identifierMap);
-        return std::make_shared<WhileStatement>(resolvedCondition,
-                                                resolvedBody);
+        resolveExpression(whileStatement->getCondition(), identifierMap);
+        resolveStatement(whileStatement->getBody(), identifierMap);
     }
     else if (auto doWhileStatement =
-                 std::dynamic_pointer_cast<DoWhileStatement>(statement)) {
+                 dynamic_cast<DoWhileStatement *>(statement)) {
         // If the statement is a do-while-statement, resolve the condition
         // expression and the body statement in the do-while-statement.
-        auto resolvedCondition =
-            resolveExpression(doWhileStatement->getCondition(), identifierMap);
-        auto resolvedBody =
-            resolveStatement(doWhileStatement->getBody(), identifierMap);
-        return std::make_shared<DoWhileStatement>(resolvedCondition,
-                                                  resolvedBody);
+        resolveExpression(doWhileStatement->getCondition(), identifierMap);
+        resolveStatement(doWhileStatement->getBody(), identifierMap);
     }
-    else if (auto forStatement =
-                 std::dynamic_pointer_cast<ForStatement>(statement)) {
+    else if (auto forStatement = dynamic_cast<ForStatement *>(statement)) {
         // Copy the identifier map (with modifications) and resolve the
         // for-init, (optional) condition, (optional) post, and body in the
         // for-statement.
         auto copiedIdentifierMap = copyIdentifierMap(identifierMap);
-        auto resolvedForInit =
-            resolveForInit(forStatement->getForInit(), copiedIdentifierMap);
-        auto resolvedOptCondition =
-            std::optional<std::shared_ptr<Expression>>();
-        if (forStatement->getOptCondition().has_value()) {
-            auto resolvedCondition = resolveExpression(
-                forStatement->getOptCondition().value(), copiedIdentifierMap);
-            resolvedOptCondition = std::make_optional(resolvedCondition);
+        resolveForInit(forStatement->getForInit(), copiedIdentifierMap);
+        if (forStatement->getOptCondition()) {
+            resolveExpression(forStatement->getOptCondition(),
+                              copiedIdentifierMap);
         }
-        auto resolvedOptPost = std::optional<std::shared_ptr<Expression>>();
-        if (forStatement->getOptPost().has_value()) {
-            auto resolvedPost = resolveExpression(
-                forStatement->getOptPost().value(), copiedIdentifierMap);
-            resolvedOptPost = std::make_optional(resolvedPost);
+        if (forStatement->getOptPost()) {
+            resolveExpression(forStatement->getOptPost(), copiedIdentifierMap);
         }
-        auto resolvedBody =
-            resolveStatement(forStatement->getBody(), copiedIdentifierMap);
-        return std::make_shared<ForStatement>(resolvedForInit,
-                                              resolvedOptCondition,
-                                              resolvedOptPost, resolvedBody);
+        resolveStatement(forStatement->getBody(), copiedIdentifierMap);
     }
-    else if (auto ifStatement =
-                 std::dynamic_pointer_cast<IfStatement>(statement)) {
+    else if (auto ifStatement = dynamic_cast<IfStatement *>(statement)) {
         // If the statement is an if-statement, resolve the condition
         // expression, then-statement, and (optional) else-statement in the
         // if-statement.
-        auto resolvedCondition =
-            resolveExpression(ifStatement->getCondition(), identifierMap);
-        auto resolvedThenStatement =
-            resolveStatement(ifStatement->getThenStatement(), identifierMap);
-        if (ifStatement->getElseOptStatement().has_value()) {
-            auto resolvedElseStatement = resolveStatement(
-                ifStatement->getElseOptStatement().value(), identifierMap);
-            return std::make_shared<IfStatement>(resolvedCondition,
-                                                 resolvedThenStatement,
-                                                 resolvedElseStatement);
-        }
-        else {
-            return std::make_shared<IfStatement>(resolvedCondition,
-                                                 resolvedThenStatement);
+        resolveExpression(ifStatement->getCondition(), identifierMap);
+        resolveStatement(ifStatement->getThenStatement(), identifierMap);
+        if (ifStatement->getElseOptStatement()) {
+            resolveStatement(ifStatement->getElseOptStatement(), identifierMap);
         }
     }
-    else if (auto nullStatement =
-                 std::dynamic_pointer_cast<NullStatement>(statement)) {
-        // If the statement is a null statement, return the null statement.
-        return nullStatement;
+    else if (dynamic_cast<BreakStatement *>(statement)) {
+    }
+    else if (dynamic_cast<ContinueStatement *>(statement)) {
+    }
+    else if (dynamic_cast<NullStatement *>(statement)) {
     }
     else {
         throw std::logic_error(
@@ -244,24 +427,20 @@ std::shared_ptr<Statement> IdentifierResolutionPass::resolveStatement(
     }
 }
 
-std::shared_ptr<Expression> IdentifierResolutionPass::resolveExpression(
-    std::shared_ptr<Expression> expression,
+void IdentifierResolutionPass::resolveExpression(
+    Expression *expression,
     std::unordered_map<std::string, MapEntry> &identifierMap) {
     if (auto assignmentExpression =
-            std::dynamic_pointer_cast<AssignmentExpression>(expression)) {
-        if (!(std::dynamic_pointer_cast<VariableExpression>(
+            dynamic_cast<AssignmentExpression *>(expression)) {
+        if (!(dynamic_cast<VariableExpression *>(
                 assignmentExpression->getLeft()))) {
             throw std::logic_error("Invalid lvalue in assignment expression");
         }
-        auto resolvedLeft =
-            resolveExpression(assignmentExpression->getLeft(), identifierMap);
-        auto resolvedRight =
-            resolveExpression(assignmentExpression->getRight(), identifierMap);
-        return std::make_shared<AssignmentExpression>(resolvedLeft,
-                                                      resolvedRight);
+        resolveExpression(assignmentExpression->getLeft(), identifierMap);
+        resolveExpression(assignmentExpression->getRight(), identifierMap);
     }
     else if (auto variableExpression =
-                 std::dynamic_pointer_cast<VariableExpression>(expression)) {
+                 dynamic_cast<VariableExpression *>(expression)) {
         // If the expression is a variable expression, check if the variable is
         // already in the identifier map. If it is not, throw an error.
         // Otherwise, return a new variable expression with the resolved
@@ -272,58 +451,35 @@ std::shared_ptr<Expression> IdentifierResolutionPass::resolveExpression(
             msg << "Undeclared variable: " << identifier;
             throw std::logic_error(msg.str());
         }
-        return std::make_shared<VariableExpression>(
+        variableExpression->setIdentifier(
             identifierMap[identifier].getNewName());
     }
-    else if (auto constantExpression =
-                 std::dynamic_pointer_cast<ConstantExpression>(expression)) {
-        // If the expression is a constant expression, return the constant
-        // expression.
-        return constantExpression;
-    }
     else if (auto unaryExpression =
-                 std::dynamic_pointer_cast<UnaryExpression>(expression)) {
+                 dynamic_cast<UnaryExpression *>(expression)) {
         // If the expression is a unary expression, resolve the expression in
         // the unary expression.
-        auto resolvedExpression =
-            resolveExpression(unaryExpression->getExpression(), identifierMap);
-        // Return a new unary expression with the resolved expression.
-        return std::make_shared<UnaryExpression>(
-            unaryExpression->getOperator(),
-            std::static_pointer_cast<Factor>(resolvedExpression));
+        resolveExpression(unaryExpression->getExpression(), identifierMap);
     }
     else if (auto binaryExpression =
-                 std::dynamic_pointer_cast<BinaryExpression>(expression)) {
+                 dynamic_cast<BinaryExpression *>(expression)) {
         // If the expression is a binary expression, resolve the left and right
         // expressions in the binary expression.
-        auto resolvedLeft =
-            resolveExpression(binaryExpression->getLeft(), identifierMap);
-        auto resolvedRight =
-            resolveExpression(binaryExpression->getRight(), identifierMap);
-        // Return a new binary expression with the resolved left and right
-        // expressions.
-        return std::make_shared<BinaryExpression>(
-            resolvedLeft, binaryExpression->getOperator(), resolvedRight);
+        resolveExpression(binaryExpression->getLeft(), identifierMap);
+        resolveExpression(binaryExpression->getRight(), identifierMap);
     }
     else if (auto conditionalExpression =
-                 std::dynamic_pointer_cast<ConditionalExpression>(expression)) {
+                 dynamic_cast<ConditionalExpression *>(expression)) {
         // If the expression is a conditional expression, resolve the condition
         // expression, then-expression, and else-expression in the conditional
         // expression.
-        auto resolvedCondition = resolveExpression(
-            conditionalExpression->getCondition(), identifierMap);
-        auto resolvedThenExpression = resolveExpression(
-            conditionalExpression->getThenExpression(), identifierMap);
-        auto resolvedElseExpression = resolveExpression(
-            conditionalExpression->getElseExpression(), identifierMap);
-        // Return a new conditional expression with the resolved condition
-        // expression, then-expression, and else-expression.
-        return std::make_shared<ConditionalExpression>(
-            resolvedCondition, resolvedThenExpression, resolvedElseExpression);
+        resolveExpression(conditionalExpression->getCondition(), identifierMap);
+        resolveExpression(conditionalExpression->getThenExpression(),
+                          identifierMap);
+        resolveExpression(conditionalExpression->getElseExpression(),
+                          identifierMap);
     }
     else if (auto functionCallExpression =
-                 std::dynamic_pointer_cast<FunctionCallExpression>(
-                     expression)) {
+                 dynamic_cast<FunctionCallExpression *>(expression)) {
         // If the expression is a function call expression, check if the
         // function is already in the identifier map. If it is not, throw an
         // error. Otherwise, return a new function call expression with the
@@ -338,21 +494,15 @@ std::shared_ptr<Expression> IdentifierResolutionPass::resolveExpression(
         }
         auto resolvedFunctionName =
             identifierMap[functionCallExpression->getIdentifier()].getNewName();
-        auto resolvedArguments =
-            std::make_shared<std::vector<std::shared_ptr<Expression>>>();
-        for (auto &argument : *functionCallExpression->getArguments()) {
-            resolvedArguments->emplace_back(
-                resolveExpression(argument, identifierMap));
+        functionCallExpression->setIdentifier(resolvedFunctionName);
+        for (auto &argument : functionCallExpression->getArguments()) {
+            resolveExpression(argument.get(), identifierMap);
         }
-        return std::make_shared<FunctionCallExpression>(resolvedFunctionName,
-                                                        resolvedArguments);
     }
-    else if (auto castExpression =
-                 std::dynamic_pointer_cast<CastExpression>(expression)) {
-        auto resolvedExpression =
-            resolveExpression(castExpression->getExpression(), identifierMap);
-        return std::make_shared<CastExpression>(castExpression->getTargetType(),
-                                                resolvedExpression);
+    else if (auto castExpression = dynamic_cast<CastExpression *>(expression)) {
+        resolveExpression(castExpression->getExpression(), identifierMap);
+    }
+    else if (dynamic_cast<ConstantExpression *>(expression)) {
     }
     else {
         throw std::logic_error(
@@ -360,28 +510,21 @@ std::shared_ptr<Expression> IdentifierResolutionPass::resolveExpression(
     }
 }
 
-std::shared_ptr<Block> IdentifierResolutionPass::resolveBlock(
-    std::shared_ptr<Block> block,
-    std::unordered_map<std::string, MapEntry> &identifierMap) {
+void IdentifierResolutionPass::resolveBlock(
+    Block *block, std::unordered_map<std::string, MapEntry> &identifierMap) {
     // Get the block items from the block and resolve the variables in each
     // block item.
-    auto blockItems = block->getBlockItems();
-    for (auto &blockItem : *blockItems) {
-        if (auto dBlockItem =
-                std::dynamic_pointer_cast<DBlockItem>(blockItem)) {
-            if (auto variableDeclaration =
-                    std::dynamic_pointer_cast<VariableDeclaration>(
-                        dBlockItem->getDeclaration())) {
-                auto resolvedDeclaration = resolveLocalVariableDeclaration(
-                    variableDeclaration, identifierMap);
-                dBlockItem->setDeclaration(resolvedDeclaration);
+    for (auto &blockItem : block->getBlockItems()) {
+        if (auto dBlockItem = dynamic_cast<DBlockItem *>(blockItem.get())) {
+            if (auto variableDeclaration = dynamic_cast<VariableDeclaration *>(
+                    dBlockItem->getDeclaration())) {
+                resolveLocalVariableDeclaration(variableDeclaration,
+                                                identifierMap);
             }
             else if (auto functionDeclaration =
-                         std::dynamic_pointer_cast<FunctionDeclaration>(
+                         dynamic_cast<FunctionDeclaration *>(
                              dBlockItem->getDeclaration())) {
-                auto resolvedDeclaration = resolveFunctionDeclaration(
-                    functionDeclaration, identifierMap);
-                dBlockItem->setDeclaration(resolvedDeclaration);
+                resolveFunctionDeclaration(functionDeclaration, identifierMap);
             }
             else {
                 throw std::logic_error(
@@ -389,40 +532,28 @@ std::shared_ptr<Block> IdentifierResolutionPass::resolveBlock(
             }
         }
         else if (auto sBlockItem =
-                     std::dynamic_pointer_cast<SBlockItem>(blockItem)) {
-            auto resolvedStatement =
-                resolveStatement(sBlockItem->getStatement(), identifierMap);
-            sBlockItem->setStatement(resolvedStatement);
+                     dynamic_cast<SBlockItem *>(blockItem.get())) {
+            resolveStatement(sBlockItem->getStatement(), identifierMap);
         }
         else {
             throw std::logic_error(
                 "Unsupported block item typen for identifier resolution");
         }
     }
-
-    // Return a new block with the resolved block items.
-    return std::make_shared<Block>(blockItems);
 }
 
-std::shared_ptr<ForInit> IdentifierResolutionPass::resolveForInit(
-    std::shared_ptr<ForInit> forInit,
+void IdentifierResolutionPass::resolveForInit(
+    ForInit *forInit,
     std::unordered_map<std::string, MapEntry> &identifierMap) {
     // Resolve the for-init based on the type of the for init.
-    if (auto initExpr = std::dynamic_pointer_cast<InitExpr>(forInit)) {
-        auto optExpr = initExpr->getExpression();
-        if (optExpr.has_value()) {
-            auto resolvedExpr =
-                resolveExpression(optExpr.value(), identifierMap);
-            return std::make_shared<InitExpr>(resolvedExpr);
-        }
-        else {
-            return std::make_shared<InitExpr>();
+    if (auto initExpr = dynamic_cast<InitExpr *>(forInit)) {
+        if (auto *expr = initExpr->getExpression()) {
+            resolveExpression(expr, identifierMap);
         }
     }
-    else if (auto initDecl = std::dynamic_pointer_cast<InitDecl>(forInit)) {
-        auto resolvedDecl = resolveLocalVariableDeclaration(
-            initDecl->getVariableDeclaration(), identifierMap);
-        return std::make_shared<InitDecl>(resolvedDecl);
+    else if (auto initDecl = dynamic_cast<InitDecl *>(forInit)) {
+        resolveLocalVariableDeclaration(initDecl->getVariableDeclaration(),
+                                        identifierMap);
     }
     else {
         throw std::logic_error(
@@ -430,9 +561,8 @@ std::shared_ptr<ForInit> IdentifierResolutionPass::resolveForInit(
     }
 }
 
-std::shared_ptr<FunctionDeclaration>
-IdentifierResolutionPass::resolveFunctionDeclaration(
-    std::shared_ptr<FunctionDeclaration> declaration,
+void IdentifierResolutionPass::resolveFunctionDeclaration(
+    FunctionDeclaration *declaration,
     std::unordered_map<std::string, MapEntry> &identifierMap) {
     if (identifierMap.find(declaration->getIdentifier()) !=
         identifierMap.end()) {
@@ -448,8 +578,8 @@ IdentifierResolutionPass::resolveFunctionDeclaration(
     identifierMap[declaration->getIdentifier()] =
         MapEntry(declaration->getIdentifier(), true, true);
     auto innerIdentifierMap = copyIdentifierMap(identifierMap);
-    auto resolvedParameters = std::make_shared<std::vector<std::string>>();
-    for (auto &parameter : *declaration->getParameterIdentifiers()) {
+    auto resolvedParameters = std::make_unique<std::vector<std::string>>();
+    for (const auto &parameter : declaration->getParameterIdentifiers()) {
         // Skip the built-in types `int` and `long` since they are not actual
         // parameters.
         if (parameter == "int" || parameter == "long") {
@@ -458,14 +588,10 @@ IdentifierResolutionPass::resolveFunctionDeclaration(
         resolvedParameters->emplace_back(
             resolveParameter(parameter, innerIdentifierMap));
     }
-    auto resolvedOptBody = std::optional<std::shared_ptr<Block>>();
-    if (declaration->getOptBody().has_value()) {
-        resolvedOptBody = std::make_optional(resolveBlock(
-            declaration->getOptBody().value(), innerIdentifierMap));
+    declaration->setParameters(std::move(resolvedParameters));
+    if (declaration->getOptBody()) {
+        resolveBlock(declaration->getOptBody(), innerIdentifierMap);
     }
-    return std::make_shared<FunctionDeclaration>(
-        declaration->getIdentifier(), resolvedParameters, resolvedOptBody,
-        declaration->getFunType(), declaration->getOptStorageClass());
 }
 
 std::string IdentifierResolutionPass::resolveParameter(
@@ -495,19 +621,18 @@ std::string IdentifierResolutionPass::resolveParameter(
 TypeCheckingPass::TypeCheckingPass(FrontendSymbolTable &frontendSymbolTable)
     : frontendSymbolTable(frontendSymbolTable) {}
 
-void TypeCheckingPass::typeCheckProgram(std::shared_ptr<Program> program) {
+void TypeCheckingPass::typeCheckProgram(Program &program) {
     // Clear the symbol table for this compilation.
     frontendSymbolTable.clear();
 
     // Type-check the program.
-    for (auto &declaration : *program->getDeclarations()) {
-        if (auto functionDeclaration =
-                std::dynamic_pointer_cast<FunctionDeclaration>(declaration)) {
+    for (auto &declaration : program.getDeclarations()) {
+        if (auto *functionDeclaration =
+                dynamic_cast<FunctionDeclaration *>(declaration.get())) {
             typeCheckFunctionDeclaration(functionDeclaration);
         }
-        else if (auto variableDeclaration =
-                     std::dynamic_pointer_cast<VariableDeclaration>(
-                         declaration)) {
+        else if (auto *variableDeclaration =
+                     dynamic_cast<VariableDeclaration *>(declaration.get())) {
             typeCheckFileScopeVariableDeclaration(variableDeclaration);
         }
         else {
@@ -517,9 +642,8 @@ void TypeCheckingPass::typeCheckProgram(std::shared_ptr<Program> program) {
     }
 }
 
-std::shared_ptr<StaticInit> TypeCheckingPass::convertStaticConstantToStaticInit(
-    std::shared_ptr<Type> varType,
-    std::shared_ptr<ConstantExpression> constantExpression) {
+std::unique_ptr<StaticInit> TypeCheckingPass::convertStaticConstantToStaticInit(
+    const Type *varType, const ConstantExpression *constantExpression) {
     // Extract the numeric value from the AST constant.
     auto variantValue = constantExpression->getConstantInIntOrLongVariant();
 
@@ -539,20 +663,19 @@ std::shared_ptr<StaticInit> TypeCheckingPass::convertStaticConstantToStaticInit(
         // This does a 32-bit wrap-around if `numericValue` doesn't fit.
         int wrappedNumericValue =
             static_cast<int>(static_cast<unsigned long>(numericValue));
-        return std::make_shared<IntInit>(wrappedNumericValue);
+        return std::make_unique<IntInit>(wrappedNumericValue);
     }
     // If the declared type is long, store the full 64-bit value.
     else if (*varType == LongType()) {
-        return std::make_shared<LongInit>(numericValue);
+        return std::make_unique<LongInit>(numericValue);
     }
     else {
         throw std::logic_error("Unsupported type in static initializer");
     }
 }
 
-std::shared_ptr<Type>
-TypeCheckingPass::getCommonType(std::shared_ptr<Type> type1,
-                                std::shared_ptr<Type> type2) {
+std::unique_ptr<Type> TypeCheckingPass::getCommonType(const Type *type1,
+                                                      const Type *type2) {
     // If `type1` is `nullptr`, throw an error.
     if (!type1) {
         throw std::logic_error("Null type1 in getCommonType");
@@ -560,75 +683,72 @@ TypeCheckingPass::getCommonType(std::shared_ptr<Type> type1,
     // TODO(zzmic): Check if this is correct.
     // If `type2` is `nullptr`, return `type1`.
     else if (!type2) {
-        return type1;
+        return cloneType(type1);
     }
     // If both types are the same, return `type1` (or `type2`).
     // For now, there are only two primitive types: `int` and `long`.
     else if (*type1 == *type2) {
-        return type1;
+        return cloneType(type1);
     }
     // Otherwise, return the larger type.
     else {
-        return std::make_shared<LongType>();
+        return std::make_unique<LongType>();
     }
 }
 
-std::shared_ptr<Expression>
-TypeCheckingPass::convertTo(std::shared_ptr<Expression> expression,
-                            std::shared_ptr<Type> targetType) {
+std::unique_ptr<Expression>
+TypeCheckingPass::convertTo(const Expression *expression,
+                            const Type *targetType) {
     if (!expression) {
         throw std::logic_error("Null expression in convertTo");
     }
     if (!targetType) {
         throw std::logic_error("Null target type in convertTo");
     }
-    if (expression->getExpType() && targetType &&
-        *expression->getExpType() == *targetType) {
-        return expression;
-    }
     // Otherwise, wrap the expression in a cast expression and annotate the
     // result with the correct type.
-    auto castExpression =
-        std::make_shared<CastExpression>(targetType, expression);
-    castExpression->setExpType(targetType);
+    if (expression->getExpType() && *expression->getExpType() == *targetType) {
+        return cloneExpression(expression);
+    }
+    auto castExpression = std::make_unique<CastExpression>(
+        cloneType(targetType), cloneExpression(expression));
+    castExpression->setExpType(cloneType(targetType));
     return castExpression;
 }
 
 void TypeCheckingPass::typeCheckFunctionDeclaration(
-    std::shared_ptr<FunctionDeclaration> declaration) {
+    FunctionDeclaration *declaration) {
     auto funType = declaration->getFunType();
-    auto funTypePtr = std::dynamic_pointer_cast<FunctionType>(funType);
+    auto funTypePtr = dynamic_cast<FunctionType *>(funType);
     if (!funTypePtr) {
         throw std::logic_error("Function type is not a FunctionType");
     }
-    auto parameterTypes = funTypePtr->getParameterTypes();
-    auto returnType = funTypePtr->getReturnType();
-    auto hasBody = declaration->getOptBody().has_value();
+    auto hasBody = (declaration->getOptBody() != nullptr);
     auto alreadyDefined = false;
     auto global = true;
 
-    if (declaration->getOptStorageClass().has_value() &&
-        std::dynamic_pointer_cast<StaticStorageClass>(
-            declaration->getOptStorageClass().value())) {
+    if (declaration->getOptStorageClass() &&
+        dynamic_cast<StaticStorageClass *>(declaration->getOptStorageClass())) {
         global = false;
     }
     if (frontendSymbolTable.find(declaration->getIdentifier()) !=
         frontendSymbolTable.end()) {
-        auto oldDeclaration = frontendSymbolTable[declaration->getIdentifier()];
-        auto oldType = oldDeclaration.first;
+        auto &oldDeclaration =
+            frontendSymbolTable[declaration->getIdentifier()];
+        auto oldType = oldDeclaration.first.get();
         if (*oldType != *funType) {
             throw std::logic_error("Incompatible function declarations");
         }
-        auto oldFunctionAttribute =
-            std::dynamic_pointer_cast<FunctionAttribute>(oldDeclaration.second);
+        auto *oldFunctionAttribute =
+            dynamic_cast<FunctionAttribute *>(oldDeclaration.second.get());
         alreadyDefined = oldFunctionAttribute->isDefined();
         if (alreadyDefined && hasBody) {
             throw std::logic_error("Function redefinition");
         }
         if (oldFunctionAttribute->isGlobal() &&
-            declaration->getOptStorageClass().has_value() &&
-            std::dynamic_pointer_cast<StaticStorageClass>(
-                declaration->getOptStorageClass().value())) {
+            declaration->getOptStorageClass() &&
+            dynamic_cast<StaticStorageClass *>(
+                declaration->getOptStorageClass())) {
             throw std::logic_error(
                 "Static function declaration follows non-static");
         }
@@ -636,58 +756,57 @@ void TypeCheckingPass::typeCheckFunctionDeclaration(
     }
 
     auto attribute =
-        std::make_shared<FunctionAttribute>(alreadyDefined || hasBody, global);
-    frontendSymbolTable[declaration->getIdentifier()] = {funType, attribute};
+        std::make_unique<FunctionAttribute>(alreadyDefined || hasBody, global);
+    frontendSymbolTable[declaration->getIdentifier()] = {cloneType(funType),
+                                                         std::move(attribute)};
 
     if (hasBody) {
-        auto funcParameterTypes = funTypePtr->getParameterTypes();
-        auto parameterIdentifiers = declaration->getParameterIdentifiers();
+        const auto &funcParameterTypes = funTypePtr->getParameterTypes();
+        auto &parameterIdentifiers = declaration->getParameterIdentifiers();
         // Set parameter types in the symbol table based on the function's
         // parameter types.
-        for (size_t i = 0; i < parameterIdentifiers->size(); ++i) {
+        for (size_t i = 0; i < parameterIdentifiers.size(); ++i) {
             // If the parameter type is available, use it.
-            if (i < funcParameterTypes->size()) {
-                frontendSymbolTable[(*parameterIdentifiers)[i]] = {
-                    (*funcParameterTypes)[i],
-                    std::make_shared<LocalAttribute>()};
+            if (i < funcParameterTypes.size()) {
+                frontendSymbolTable[parameterIdentifiers[i]] = {
+                    cloneType(funcParameterTypes[i].get()),
+                    std::make_unique<LocalAttribute>()};
             }
             else {
-                // Otherwise, fallback to IntType.
-                frontendSymbolTable[(*parameterIdentifiers)[i]] = {
-                    std::make_shared<IntType>(),
-                    std::make_shared<LocalAttribute>()};
+                // Otherwise, fallback to `IntType`.
+                frontendSymbolTable[parameterIdentifiers[i]] = {
+                    std::make_unique<IntType>(),
+                    std::make_unique<LocalAttribute>()};
             }
         }
         // Provide the enclosing function's name for the later type-checking of
         // the return statement.
-        typeCheckBlock(declaration->getOptBody().value(),
-                       declaration->getIdentifier());
+        typeCheckBlock(declaration->getOptBody(), declaration->getIdentifier());
     }
 }
 
 void TypeCheckingPass::typeCheckFileScopeVariableDeclaration(
-    std::shared_ptr<VariableDeclaration> declaration) {
+    VariableDeclaration *declaration) {
     auto varType = declaration->getVarType();
     if (*varType != IntType() && *varType != LongType()) {
         throw std::logic_error(
             "Unsupported variable type for file-scope variables");
     }
 
-    auto initialValue = std::make_shared<InitialValue>();
+    auto initialValue = std::make_unique<InitialValue>();
 
-    if (declaration->getOptInitializer().has_value() &&
-        std::dynamic_pointer_cast<ConstantExpression>(
-            declaration->getOptInitializer().value())) {
-        auto constantExpression = std::dynamic_pointer_cast<ConstantExpression>(
-            declaration->getOptInitializer().value());
+    if (declaration->getOptInitializer() &&
+        dynamic_cast<ConstantExpression *>(declaration->getOptInitializer())) {
+        auto constantExpression = dynamic_cast<ConstantExpression *>(
+            declaration->getOptInitializer());
         auto variantValue = constantExpression->getConstantInIntOrLongVariant();
-        if (std::dynamic_pointer_cast<LongType>(varType)) {
+        if (dynamic_cast<LongType *>(varType)) {
             if (std::holds_alternative<long>(variantValue)) {
                 initialValue =
-                    std::make_shared<Initial>(std::get<long>(variantValue));
+                    std::make_unique<Initial>(std::get<long>(variantValue));
             }
             else if (std::holds_alternative<int>(variantValue)) {
-                initialValue = std::make_shared<Initial>(
+                initialValue = std::make_unique<Initial>(
                     static_cast<long>(std::get<int>(variantValue)));
             }
             else {
@@ -697,12 +816,12 @@ void TypeCheckingPass::typeCheckFileScopeVariableDeclaration(
         }
         else {
             if (std::holds_alternative<long>(variantValue)) {
-                initialValue = std::make_shared<Initial>(
+                initialValue = std::make_unique<Initial>(
                     static_cast<int>(std::get<long>(variantValue)));
             }
             else if (std::holds_alternative<int>(variantValue)) {
                 initialValue =
-                    std::make_shared<Initial>(std::get<int>(variantValue));
+                    std::make_unique<Initial>(std::get<int>(variantValue));
             }
             else {
                 throw std::logic_error(
@@ -710,14 +829,14 @@ void TypeCheckingPass::typeCheckFileScopeVariableDeclaration(
             }
         }
     }
-    else if (!declaration->getOptInitializer().has_value()) {
-        if (declaration->getOptStorageClass().has_value() &&
-            std::dynamic_pointer_cast<ExternStorageClass>(
-                declaration->getOptStorageClass().value())) {
-            initialValue = std::make_shared<NoInitializer>();
+    else if (!declaration->getOptInitializer()) {
+        if (declaration->getOptStorageClass() &&
+            dynamic_cast<ExternStorageClass *>(
+                declaration->getOptStorageClass())) {
+            initialValue = std::make_unique<NoInitializer>();
         }
         else {
-            initialValue = std::make_shared<Tentative>();
+            initialValue = std::make_unique<Tentative>();
         }
     }
     else {
@@ -725,151 +844,146 @@ void TypeCheckingPass::typeCheckFileScopeVariableDeclaration(
     }
 
     // Determine the linkage of the variable.
-    auto global = (!declaration->getOptStorageClass().has_value()) ||
-                  (declaration->getOptStorageClass().has_value() &&
-                   !(std::dynamic_pointer_cast<StaticStorageClass>(
-                       declaration->getOptStorageClass().value())));
+    auto global = (!declaration->getOptStorageClass()) ||
+                  (declaration->getOptStorageClass() &&
+                   !(dynamic_cast<StaticStorageClass *>(
+                       declaration->getOptStorageClass())));
 
     if (frontendSymbolTable.find(declaration->getIdentifier()) !=
         frontendSymbolTable.end()) {
-        auto oldDeclaration = frontendSymbolTable[declaration->getIdentifier()];
-        auto oldType = oldDeclaration.first;
+        auto &oldDeclaration =
+            frontendSymbolTable[declaration->getIdentifier()];
+        auto oldType = oldDeclaration.first.get();
         if (*oldType != *varType) {
             throw std::logic_error("Function redeclared as variable");
         }
-        auto oldStaticAttribute =
-            std::dynamic_pointer_cast<StaticAttribute>(oldDeclaration.second);
-        if (declaration->getOptStorageClass().has_value() &&
-            std::dynamic_pointer_cast<ExternStorageClass>(
-                declaration->getOptStorageClass().value())) {
+        auto *oldStaticAttribute =
+            dynamic_cast<StaticAttribute *>(oldDeclaration.second.get());
+        if (declaration->getOptStorageClass() &&
+            dynamic_cast<ExternStorageClass *>(
+                declaration->getOptStorageClass())) {
             global = oldStaticAttribute->isGlobal();
         }
         else if (oldStaticAttribute->isGlobal() != global) {
             throw std::logic_error("Conflicting variable linkage");
         }
-        if (auto oldInitialValue = std::dynamic_pointer_cast<Initial>(
-                oldStaticAttribute->getInitialValue())) {
-            if (std::dynamic_pointer_cast<Initial>(initialValue)) {
+        if (dynamic_cast<Initial *>(oldStaticAttribute->getInitialValue())) {
+            if (dynamic_cast<Initial *>(initialValue.get())) {
                 throw std::logic_error(
                     "Conflicting file-scope variable definitions");
             }
-            else {
-                initialValue = oldInitialValue;
-            }
+            initialValue =
+                cloneInitialValue(oldStaticAttribute->getInitialValue());
         }
-        else if (!std::dynamic_pointer_cast<Initial>(initialValue) &&
-                 std::dynamic_pointer_cast<Tentative>(
+        else if (!dynamic_cast<Initial *>(initialValue.get()) &&
+                 dynamic_cast<Tentative *>(
                      oldStaticAttribute->getInitialValue())) {
-            initialValue = std::make_shared<Tentative>();
+            initialValue = std::make_unique<Tentative>();
         }
     }
 
-    auto attribute = std::make_shared<StaticAttribute>(initialValue, global);
+    auto attribute =
+        std::make_unique<StaticAttribute>(std::move(initialValue), global);
     // Store the corresponding variable type and attribute in the symbol table.
-    frontendSymbolTable[declaration->getIdentifier()] = {varType, attribute};
+    frontendSymbolTable[declaration->getIdentifier()] = {cloneType(varType),
+                                                         std::move(attribute)};
 }
 
 void TypeCheckingPass::typeCheckLocalVariableDeclaration(
-    std::shared_ptr<VariableDeclaration> declaration) {
+    VariableDeclaration *declaration) {
     auto varType = declaration->getVarType();
     if (*varType != IntType() && *varType != LongType()) {
         throw std::logic_error("Unsupported variable type for local variables");
     }
 
-    if (declaration->getOptStorageClass().has_value() &&
-        std::dynamic_pointer_cast<ExternStorageClass>(
-            declaration->getOptStorageClass().value())) {
-        if (declaration->getOptInitializer().has_value()) {
+    if (declaration->getOptStorageClass() &&
+        dynamic_cast<ExternStorageClass *>(declaration->getOptStorageClass())) {
+        if (declaration->getOptInitializer()) {
             throw std::logic_error(
                 "Initializer on local extern variable declaration");
         }
         if (frontendSymbolTable.find(declaration->getIdentifier()) !=
             frontendSymbolTable.end()) {
-            auto oldDeclaration =
+            auto &oldDeclaration =
                 frontendSymbolTable[declaration->getIdentifier()];
-            auto oldType = oldDeclaration.first;
+            auto oldType = oldDeclaration.first.get();
             if (*oldType != *varType) {
                 throw std::logic_error("Function redeclared as variable");
             }
         }
         else {
-            auto staticAttribute = std::make_shared<StaticAttribute>(
-                std::make_shared<NoInitializer>(), true);
+            auto staticAttribute = std::make_unique<StaticAttribute>(
+                std::make_unique<NoInitializer>(), true);
             frontendSymbolTable[declaration->getIdentifier()] =
-                std::make_pair(varType, staticAttribute);
+                std::make_pair(cloneType(varType), std::move(staticAttribute));
         }
     }
-    else if (declaration->getOptStorageClass().has_value() &&
-             std::dynamic_pointer_cast<StaticStorageClass>(
-                 declaration->getOptStorageClass().value())) {
-        auto initialValue = std::make_shared<InitialValue>();
-        if (declaration->getOptInitializer().has_value() &&
-            std::dynamic_pointer_cast<ConstantExpression>(
-                declaration->getOptInitializer().value())) {
-            auto constantExpression =
-                std::dynamic_pointer_cast<ConstantExpression>(
-                    declaration->getOptInitializer().value());
+    else if (declaration->getOptStorageClass() &&
+             dynamic_cast<StaticStorageClass *>(
+                 declaration->getOptStorageClass())) {
+        auto initialValue = std::make_unique<InitialValue>();
+        if (declaration->getOptInitializer() &&
+            dynamic_cast<ConstantExpression *>(
+                declaration->getOptInitializer())) {
+            auto constantExpression = dynamic_cast<ConstantExpression *>(
+                declaration->getOptInitializer());
             auto variantValue =
                 constantExpression->getConstantInIntOrLongVariant();
             if (std::holds_alternative<long>(variantValue)) {
                 initialValue =
-                    std::make_shared<Initial>(std::get<long>(variantValue));
+                    std::make_unique<Initial>(std::get<long>(variantValue));
             }
             else if (std::holds_alternative<int>(variantValue)) {
                 initialValue =
-                    std::make_shared<Initial>(std::get<int>(variantValue));
+                    std::make_unique<Initial>(std::get<int>(variantValue));
             }
             else {
                 throw std::logic_error(
                     "Unsupported type in static initializer");
             }
         }
-        else if (!declaration->getOptInitializer().has_value()) {
-            initialValue = std::make_shared<Initial>(0);
+        else if (!declaration->getOptInitializer()) {
+            initialValue = std::make_unique<Initial>(0);
         }
         else {
             throw std::logic_error(
                 "Non-constant initializer on local static variable");
         }
         auto staticAttribute =
-            std::make_shared<StaticAttribute>(initialValue, false);
+            std::make_unique<StaticAttribute>(std::move(initialValue), false);
         frontendSymbolTable[declaration->getIdentifier()] =
-            std::make_pair(varType, staticAttribute);
+            std::make_pair(cloneType(varType), std::move(staticAttribute));
     }
     else {
-        auto localAttribute = std::make_shared<LocalAttribute>();
+        auto localAttribute = std::make_unique<LocalAttribute>();
         frontendSymbolTable[declaration->getIdentifier()] =
-            std::make_pair(varType, localAttribute);
-        if (declaration->getOptInitializer().has_value()) {
-            auto initializer = declaration->getOptInitializer().value();
+            std::make_pair(cloneType(varType), std::move(localAttribute));
+        if (declaration->getOptInitializer()) {
+            auto *initializer = declaration->getOptInitializer();
             typeCheckExpression(initializer);
-            auto convertedInitializer = convertTo(initializer, varType);
-            declaration->setOptInitializer(
-                std::make_optional(convertedInitializer));
+            declaration->setOptInitializer(convertTo(initializer, varType));
         }
     }
 }
 
-void TypeCheckingPass::typeCheckBlock(std::shared_ptr<Block> block,
+void TypeCheckingPass::typeCheckBlock(Block *block,
                                       std::string enclosingFunctionIdentifier) {
-    for (auto &blockItem : *block->getBlockItems()) {
-        if (auto dBlockItem =
-                std::dynamic_pointer_cast<DBlockItem>(blockItem)) {
-            if (auto variableDeclaration =
-                    std::dynamic_pointer_cast<VariableDeclaration>(
-                        dBlockItem->getDeclaration())) {
+    for (auto &blockItem : block->getBlockItems()) {
+        if (auto dBlockItem = dynamic_cast<DBlockItem *>(blockItem.get())) {
+            if (auto variableDeclaration = dynamic_cast<VariableDeclaration *>(
+                    dBlockItem->getDeclaration())) {
                 typeCheckLocalVariableDeclaration(variableDeclaration);
             }
             else if (auto functionDeclaration =
-                         std::dynamic_pointer_cast<FunctionDeclaration>(
+                         dynamic_cast<FunctionDeclaration *>(
                              dBlockItem->getDeclaration())) {
-                if (functionDeclaration->getOptBody().has_value()) {
+                if (functionDeclaration->getOptBody()) {
                     throw std::logic_error(
                         "Nested function definitions are not permitted");
                 }
-                if (functionDeclaration->getOptStorageClass().has_value() &&
-                    std::dynamic_pointer_cast<StaticStorageClass>(
-                        functionDeclaration->getOptStorageClass().value())) {
+                if (functionDeclaration->getOptStorageClass() &&
+                    dynamic_cast<StaticStorageClass *>(
+                        functionDeclaration->getOptStorageClass())) {
                     throw std::logic_error(
                         "Static storage class on block-scope function "
                         "declaration");
@@ -882,7 +996,7 @@ void TypeCheckingPass::typeCheckBlock(std::shared_ptr<Block> block,
             }
         }
         else if (auto sBlockItem =
-                     std::dynamic_pointer_cast<SBlockItem>(blockItem)) {
+                     dynamic_cast<SBlockItem *>(blockItem.get())) {
             // Provide the enclosing function's name for the later type-checking
             // of the return statement.
             typeCheckStatement(sBlockItem->getStatement(),
@@ -895,61 +1009,64 @@ void TypeCheckingPass::typeCheckBlock(std::shared_ptr<Block> block,
     }
 }
 
-void TypeCheckingPass::typeCheckExpression(
-    std::shared_ptr<Expression> expression) {
+void TypeCheckingPass::typeCheckExpression(Expression *expression) {
     if (auto functionCallExpression =
-            std::dynamic_pointer_cast<FunctionCallExpression>(expression)) {
+            dynamic_cast<FunctionCallExpression *>(expression)) {
         auto fType =
-            frontendSymbolTable[functionCallExpression->getIdentifier()].first;
+            frontendSymbolTable[functionCallExpression->getIdentifier()]
+                .first.get();
         if (*fType == IntType() || *fType == LongType()) {
             throw std::logic_error("Function name used as variable: " +
                                    functionCallExpression->getIdentifier());
         }
         else {
-            auto functionType = std::dynamic_pointer_cast<FunctionType>(fType);
-            auto parameterTypes = functionType->getParameterTypes();
-            auto arguments = functionCallExpression->getArguments();
-            if (parameterTypes->size() != arguments->size()) {
+            auto functionType = dynamic_cast<FunctionType *>(fType);
+            const auto &parameterTypes = functionType->getParameterTypes();
+            auto &arguments = functionCallExpression->getArguments();
+            if (parameterTypes.size() != arguments.size()) {
                 throw std::logic_error(
                     "Function called with a wrong number of arguments");
             }
             auto convertedArguments =
-                std::make_shared<std::vector<std::shared_ptr<Expression>>>();
+                std::make_unique<std::vector<std::unique_ptr<Expression>>>();
+            convertedArguments->reserve(arguments.size());
             // Iterate over the function's arguments and parameters together.
             // Type-check each argument and convert it to the corresponding
             // parameter type.
-            for (size_t i = 0; i < arguments->size(); ++i) {
-                auto argument = arguments->at(i);
-                auto parameterType = parameterTypes->at(i);
+            for (size_t i = 0; i < arguments.size(); ++i) {
+                auto *argument = arguments[i].get();
+                auto *parameterType = parameterTypes[i].get();
                 typeCheckExpression(argument);
-                auto convertedArgument = convertTo(argument, parameterType);
-                convertedArguments->emplace_back(convertedArgument);
+                convertedArguments->emplace_back(
+                    convertTo(argument, parameterType));
             }
             // Set the function call expression's arguments to the converted
             // arguments.
-            functionCallExpression->setArguments(convertedArguments);
+            functionCallExpression->setArguments(std::move(convertedArguments));
             // Set the function call expression's type to the function's return
             // type.
-            functionCallExpression->setExpType(functionType->getReturnType());
+            functionCallExpression->setExpType(
+                cloneType(&functionType->getReturnType()));
         }
     }
     else if (auto constantExpression =
-                 std::dynamic_pointer_cast<ConstantExpression>(expression)) {
+                 dynamic_cast<ConstantExpression *>(expression)) {
         auto constant = constantExpression->getConstant();
-        if (std::dynamic_pointer_cast<ConstantInt>(constant)) {
-            constantExpression->setExpType(std::make_shared<IntType>());
+        if (dynamic_cast<ConstantInt *>(constant)) {
+            constantExpression->setExpType(std::make_unique<IntType>());
         }
-        else if (std::dynamic_pointer_cast<ConstantLong>(constant)) {
-            constantExpression->setExpType(std::make_shared<LongType>());
+        else if (dynamic_cast<ConstantLong *>(constant)) {
+            constantExpression->setExpType(std::make_unique<LongType>());
         }
         else {
             throw std::logic_error("Unsupported constant type");
         }
     }
     else if (auto variableExpression =
-                 std::dynamic_pointer_cast<VariableExpression>(expression)) {
+                 dynamic_cast<VariableExpression *>(expression)) {
         auto variableType =
-            frontendSymbolTable[variableExpression->getIdentifier()].first;
+            frontendSymbolTable[variableExpression->getIdentifier()]
+                .first.get();
         // If the variable is not of type int or long, it is of type function.
         if (*variableType != IntType() && *variableType != LongType()) {
             std::stringstream msg;
@@ -958,73 +1075,67 @@ void TypeCheckingPass::typeCheckExpression(
             throw std::logic_error(msg.str());
         }
         // Otherwise, set the expression type to the variable type.
-        variableExpression->setExpType(variableType);
+        variableExpression->setExpType(cloneType(variableType));
     }
-    else if (auto castExpression =
-                 std::dynamic_pointer_cast<CastExpression>(expression)) {
+    else if (auto castExpression = dynamic_cast<CastExpression *>(expression)) {
         typeCheckExpression(castExpression->getExpression());
-        castExpression->setExpType(castExpression->getTargetType());
+        castExpression->setExpType(cloneType(castExpression->getTargetType()));
     }
     else if (auto assignmentExpression =
-                 std::dynamic_pointer_cast<AssignmentExpression>(expression)) {
+                 dynamic_cast<AssignmentExpression *>(expression)) {
         auto left = assignmentExpression->getLeft();
         auto right = assignmentExpression->getRight();
         typeCheckExpression(left);
         typeCheckExpression(right);
         auto leftType = left->getExpType();
-        auto convertedRight = convertTo(right, leftType);
-        assignmentExpression->setRight(convertedRight);
-        assignmentExpression->setExpType(leftType);
+        assignmentExpression->setRight(convertTo(right, leftType));
+        assignmentExpression->setExpType(cloneType(leftType));
     }
     else if (auto unaryExpression =
-                 std::dynamic_pointer_cast<UnaryExpression>(expression)) {
+                 dynamic_cast<UnaryExpression *>(expression)) {
         typeCheckExpression(unaryExpression->getExpression());
-        if (std::dynamic_pointer_cast<NotOperator>(
-                unaryExpression->getOperator())) {
-            unaryExpression->setExpType(std::make_shared<IntType>());
+        if (dynamic_cast<NotOperator *>(unaryExpression->getOperator())) {
+            unaryExpression->setExpType(std::make_unique<IntType>());
         }
         else {
             unaryExpression->setExpType(
-                unaryExpression->getExpression()->getExpType());
+                cloneType(unaryExpression->getExpression()->getExpType()));
         }
     }
     else if (auto binaryExpression =
-                 std::dynamic_pointer_cast<BinaryExpression>(expression)) {
+                 dynamic_cast<BinaryExpression *>(expression)) {
         typeCheckExpression(binaryExpression->getLeft());
         typeCheckExpression(binaryExpression->getRight());
         auto binaryOperator = binaryExpression->getOperator();
-        if (std::dynamic_pointer_cast<AndOperator>(binaryOperator) ||
-            std::dynamic_pointer_cast<OrOperator>(binaryOperator)) {
+        if (dynamic_cast<AndOperator *>(binaryOperator) ||
+            dynamic_cast<OrOperator *>(binaryOperator)) {
             // Logical operators should always return type `int`.
-            binaryExpression->setExpType(std::make_shared<IntType>());
+            binaryExpression->setExpType(std::make_unique<IntType>());
             return;
         }
         auto leftType = binaryExpression->getLeft()->getExpType();
         auto rightType = binaryExpression->getRight()->getExpType();
         auto commonType = getCommonType(leftType, rightType);
-        auto convertedLeft = convertTo(binaryExpression->getLeft(), commonType);
-        auto convertedRight =
-            convertTo(binaryExpression->getRight(), commonType);
-        binaryExpression->setLeft(convertedLeft);
-        binaryExpression->setRight(convertedRight);
-        if (std::dynamic_pointer_cast<AddOperator>(binaryOperator) ||
-            std::dynamic_pointer_cast<SubtractOperator>(binaryOperator) ||
-            std::dynamic_pointer_cast<MultiplyOperator>(binaryOperator) ||
-            std::dynamic_pointer_cast<DivideOperator>(binaryOperator) ||
-            std::dynamic_pointer_cast<RemainderOperator>(binaryOperator)) {
-            binaryExpression->setExpType(commonType);
+        binaryExpression->setLeft(
+            convertTo(binaryExpression->getLeft(), commonType.get()));
+        binaryExpression->setRight(
+            convertTo(binaryExpression->getRight(), commonType.get()));
+        if (dynamic_cast<AddOperator *>(binaryOperator) ||
+            dynamic_cast<SubtractOperator *>(binaryOperator) ||
+            dynamic_cast<MultiplyOperator *>(binaryOperator) ||
+            dynamic_cast<DivideOperator *>(binaryOperator) ||
+            dynamic_cast<RemainderOperator *>(binaryOperator)) {
+            binaryExpression->setExpType(std::move(commonType));
         }
         else {
-            binaryExpression->setExpType(std::make_shared<IntType>());
+            binaryExpression->setExpType(std::make_unique<IntType>());
         }
     }
     else if (auto conditionalExpression =
-                 std::dynamic_pointer_cast<ConditionalExpression>(expression)) {
+                 dynamic_cast<ConditionalExpression *>(expression)) {
         typeCheckExpression(conditionalExpression->getCondition());
         typeCheckExpression(conditionalExpression->getThenExpression());
         typeCheckExpression(conditionalExpression->getElseExpression());
-        auto conditionType =
-            conditionalExpression->getCondition()->getExpType();
         auto thenType =
             conditionalExpression->getThenExpression()->getExpType();
         auto elseType =
@@ -1032,28 +1143,24 @@ void TypeCheckingPass::typeCheckExpression(
         // Get the common type of the then and else expressions/branches.
         auto commonType = getCommonType(thenType, elseType);
         // Convert the then and else expressions to the common type.
-        auto convertedThen =
-            convertTo(conditionalExpression->getThenExpression(), commonType);
-        auto convertedElse =
-            convertTo(conditionalExpression->getElseExpression(), commonType);
-        conditionalExpression->setThenExpression(convertedThen);
-        conditionalExpression->setElseExpression(convertedElse);
+        conditionalExpression->setThenExpression(convertTo(
+            conditionalExpression->getThenExpression(), commonType.get()));
+        conditionalExpression->setElseExpression(convertTo(
+            conditionalExpression->getElseExpression(), commonType.get()));
         // Set the conditional expression type to the common type.
-        conditionalExpression->setExpType(commonType);
+        conditionalExpression->setExpType(std::move(commonType));
     }
 }
 
 void TypeCheckingPass::typeCheckStatement(
-    std::shared_ptr<Statement> statement,
-    std::string enclosingFunctionIdentifier) {
-    if (auto returnStatement =
-            std::dynamic_pointer_cast<ReturnStatement>(statement)) {
+    Statement *statement, std::string enclosingFunctionIdentifier) {
+    if (auto returnStatement = dynamic_cast<ReturnStatement *>(statement)) {
         // Look up the enclosing function's return type and convert the return
         // value to that type.
         // Use the enclosing function's name to look up the enclosing function's
         // return type.
         auto functionType =
-            frontendSymbolTable[enclosingFunctionIdentifier].first;
+            frontendSymbolTable[enclosingFunctionIdentifier].first.get();
         if (!functionType) {
             throw std::logic_error("Function not found in symbol table: " +
                                    enclosingFunctionIdentifier);
@@ -1062,71 +1169,66 @@ void TypeCheckingPass::typeCheckStatement(
             throw std::logic_error("Function name used as variable: " +
                                    enclosingFunctionIdentifier);
         }
-        auto returnType = std::dynamic_pointer_cast<FunctionType>(functionType);
+        auto returnType = dynamic_cast<FunctionType *>(functionType);
         if (returnStatement->getExpression()) {
             typeCheckExpression(returnStatement->getExpression());
-            auto convertedReturn = convertTo(returnStatement->getExpression(),
-                                             returnType->getReturnType());
-            returnStatement->setExpression(convertedReturn);
+            returnStatement->setExpression(
+                convertTo(returnStatement->getExpression(),
+                          &returnType->getReturnType()));
         }
     }
     else if (auto expressionStatement =
-                 std::dynamic_pointer_cast<ExpressionStatement>(statement)) {
+                 dynamic_cast<ExpressionStatement *>(statement)) {
         typeCheckExpression(expressionStatement->getExpression());
     }
     else if (auto compoundStatement =
-                 std::dynamic_pointer_cast<CompoundStatement>(statement)) {
+                 dynamic_cast<CompoundStatement *>(statement)) {
         typeCheckBlock(compoundStatement->getBlock(),
                        enclosingFunctionIdentifier);
     }
-    else if (auto whileStatement =
-                 std::dynamic_pointer_cast<WhileStatement>(statement)) {
+    else if (auto whileStatement = dynamic_cast<WhileStatement *>(statement)) {
         typeCheckExpression(whileStatement->getCondition());
         typeCheckStatement(whileStatement->getBody(),
                            enclosingFunctionIdentifier);
     }
     else if (auto doWhileStatement =
-                 std::dynamic_pointer_cast<DoWhileStatement>(statement)) {
+                 dynamic_cast<DoWhileStatement *>(statement)) {
         typeCheckExpression(doWhileStatement->getCondition());
         typeCheckStatement(doWhileStatement->getBody(),
                            enclosingFunctionIdentifier);
     }
-    else if (auto forStatement =
-                 std::dynamic_pointer_cast<ForStatement>(statement)) {
+    else if (auto forStatement = dynamic_cast<ForStatement *>(statement)) {
         if (forStatement->getForInit()) {
             typeCheckForInit(forStatement->getForInit());
         }
-        if (forStatement->getOptCondition().has_value()) {
-            typeCheckExpression(forStatement->getOptCondition().value());
+        if (forStatement->getOptCondition()) {
+            typeCheckExpression(forStatement->getOptCondition());
         }
-        if (forStatement->getOptPost().has_value()) {
-            typeCheckExpression(forStatement->getOptPost().value());
+        if (forStatement->getOptPost()) {
+            typeCheckExpression(forStatement->getOptPost());
         }
         typeCheckStatement(forStatement->getBody(),
                            enclosingFunctionIdentifier);
     }
-    else if (auto ifStatement =
-                 std::dynamic_pointer_cast<IfStatement>(statement)) {
+    else if (auto ifStatement = dynamic_cast<IfStatement *>(statement)) {
         typeCheckExpression(ifStatement->getCondition());
         typeCheckStatement(ifStatement->getThenStatement(),
                            enclosingFunctionIdentifier);
-        if (ifStatement->getElseOptStatement().has_value()) {
-            typeCheckStatement(ifStatement->getElseOptStatement().value(),
+        if (ifStatement->getElseOptStatement()) {
+            typeCheckStatement(ifStatement->getElseOptStatement(),
                                enclosingFunctionIdentifier);
         }
     }
 }
 
-void TypeCheckingPass::typeCheckForInit(std::shared_ptr<ForInit> forInit) {
-    if (auto initExpr = std::dynamic_pointer_cast<InitExpr>(forInit)) {
+void TypeCheckingPass::typeCheckForInit(ForInit *forInit) {
+    if (auto initExpr = dynamic_cast<InitExpr *>(forInit)) {
         if (initExpr->getExpression()) {
-            typeCheckExpression(initExpr->getExpression().value());
+            typeCheckExpression(initExpr->getExpression());
         }
     }
-    else if (auto initDecl = std::dynamic_pointer_cast<InitDecl>(forInit)) {
-        if (initDecl->getVariableDeclaration()
-                ->getOptStorageClass()
-                .has_value()) {
+    else if (auto initDecl = dynamic_cast<InitDecl *>(forInit)) {
+        if (initDecl->getVariableDeclaration()->getOptStorageClass()) {
             throw std::logic_error("Storage class in for-init declaration");
         }
         typeCheckLocalVariableDeclaration(initDecl->getVariableDeclaration());
@@ -1142,15 +1244,12 @@ void TypeCheckingPass::typeCheckForInit(std::shared_ptr<ForInit> forInit) {
 /*
  * Start: Functions for the loop-labeling pass.
  */
-void LoopLabelingPass::labelLoops(std::shared_ptr<Program> program) {
-    for (auto &declaration : *program->getDeclarations()) {
-        if (auto functionDeclaration =
-                std::dynamic_pointer_cast<FunctionDeclaration>(declaration)) {
-            if (functionDeclaration->getOptBody().has_value()) {
-                auto resolvedBody =
-                    labelBlock(functionDeclaration->getOptBody().value(), "");
-                functionDeclaration->setOptBody(
-                    std::make_optional(resolvedBody));
+void LoopLabelingPass::labelLoops(Program &program) {
+    for (auto &declaration : program.getDeclarations()) {
+        if (auto *functionDeclaration =
+                dynamic_cast<FunctionDeclaration *>(declaration.get())) {
+            if (functionDeclaration->getOptBody()) {
+                labelBlock(functionDeclaration->getOptBody(), "");
             }
         }
     }
@@ -1161,133 +1260,81 @@ std::string LoopLabelingPass::generateLoopLabel() {
     return "loop" + std::to_string(this->loopLabelingCounter++);
 }
 
-std::shared_ptr<Statement>
-LoopLabelingPass::annotateStatement(std::shared_ptr<Statement> statement,
-                                    std::string label) {
-    if (auto breakStatement =
-            std::dynamic_pointer_cast<BreakStatement>(statement)) {
+void LoopLabelingPass::annotateStatement(Statement *statement,
+                                         std::string_view label) {
+    if (auto breakStatement = dynamic_cast<BreakStatement *>(statement)) {
         breakStatement->setLabel(label);
-        return breakStatement;
     }
     else if (auto continueStatement =
-                 std::dynamic_pointer_cast<ContinueStatement>(statement)) {
+                 dynamic_cast<ContinueStatement *>(statement)) {
         continueStatement->setLabel(label);
-        return continueStatement;
     }
-    else if (auto whileStatement =
-                 std::dynamic_pointer_cast<WhileStatement>(statement)) {
+    else if (auto whileStatement = dynamic_cast<WhileStatement *>(statement)) {
         whileStatement->setLabel(label);
-        return whileStatement;
     }
     else if (auto doWhileStatement =
-                 std::dynamic_pointer_cast<DoWhileStatement>(statement)) {
+                 dynamic_cast<DoWhileStatement *>(statement)) {
         doWhileStatement->setLabel(label);
-        return doWhileStatement;
     }
-    else if (auto forStatement =
-                 std::dynamic_pointer_cast<ForStatement>(statement)) {
+    else if (auto forStatement = dynamic_cast<ForStatement *>(statement)) {
         forStatement->setLabel(label);
-        return forStatement;
-    }
-    else {
-        return statement;
     }
 }
 
-std::shared_ptr<Statement>
-LoopLabelingPass::labelStatement(std::shared_ptr<Statement> statement,
-                                 std::string label) {
-    if (auto breakStatement =
-            std::dynamic_pointer_cast<BreakStatement>(statement)) {
-        if (label == "") {
+void LoopLabelingPass::labelStatement(Statement *statement,
+                                      std::string_view label) {
+    if (auto breakStatement = dynamic_cast<BreakStatement *>(statement)) {
+        if (label.empty()) {
             throw std::logic_error("Break statement outside of loop");
         }
-        return annotateStatement(breakStatement, label);
+        annotateStatement(breakStatement, label);
     }
     else if (auto continueStatement =
-                 std::dynamic_pointer_cast<ContinueStatement>(statement)) {
-        if (label == "") {
+                 dynamic_cast<ContinueStatement *>(statement)) {
+        if (label.empty()) {
             throw std::logic_error("Continue statement outside of loop");
         }
-        return annotateStatement(continueStatement, label);
+        annotateStatement(continueStatement, label);
     }
-    else if (auto whileStatement =
-                 std::dynamic_pointer_cast<WhileStatement>(statement)) {
+    else if (auto whileStatement = dynamic_cast<WhileStatement *>(statement)) {
         auto newLabel = generateLoopLabel();
-        auto labeledBody = labelStatement(whileStatement->getBody(), newLabel);
-        auto labeledWhileStatement = std::make_shared<WhileStatement>(
-            whileStatement->getCondition(), labeledBody);
-        return annotateStatement(labeledWhileStatement, newLabel);
+        labelStatement(whileStatement->getBody(), newLabel);
+        annotateStatement(whileStatement, newLabel);
     }
     else if (auto doWhileStatement =
-                 std::dynamic_pointer_cast<DoWhileStatement>(statement)) {
+                 dynamic_cast<DoWhileStatement *>(statement)) {
         auto newLabel = generateLoopLabel();
-        auto labeledBody =
-            labelStatement(doWhileStatement->getBody(), newLabel);
-        auto labeledDoWhileStatement = std::make_shared<DoWhileStatement>(
-            doWhileStatement->getCondition(), labeledBody);
-        return annotateStatement(labeledDoWhileStatement, newLabel);
+        labelStatement(doWhileStatement->getBody(), newLabel);
+        annotateStatement(doWhileStatement, newLabel);
     }
-    else if (auto forStatement =
-                 std::dynamic_pointer_cast<ForStatement>(statement)) {
+    else if (auto forStatement = dynamic_cast<ForStatement *>(statement)) {
         auto newLabel = generateLoopLabel();
-        auto labeledBody = labelStatement(forStatement->getBody(), newLabel);
-        auto labeledForStatement = std::make_shared<ForStatement>(
-            forStatement->getForInit(), forStatement->getOptCondition(),
-            forStatement->getOptPost(), labeledBody);
-        return annotateStatement(labeledForStatement, newLabel);
+        labelStatement(forStatement->getBody(), newLabel);
+        annotateStatement(forStatement, newLabel);
     }
-    else if (auto ifStatement =
-                 std::dynamic_pointer_cast<IfStatement>(statement)) {
-        auto labeledThenStatement =
-            labelStatement(ifStatement->getThenStatement(), label);
-        if (ifStatement->getElseOptStatement().has_value()) {
-            auto labeledElseStatement = labelStatement(
-                ifStatement->getElseOptStatement().value(), label);
-            return std::make_shared<IfStatement>(ifStatement->getCondition(),
-                                                 labeledThenStatement,
-                                                 labeledElseStatement);
-        }
-        else {
-            return std::make_shared<IfStatement>(ifStatement->getCondition(),
-                                                 labeledThenStatement);
+    else if (auto ifStatement = dynamic_cast<IfStatement *>(statement)) {
+        labelStatement(ifStatement->getThenStatement(), label);
+        if (ifStatement->getElseOptStatement()) {
+            labelStatement(ifStatement->getElseOptStatement(), label);
         }
     }
     else if (auto compoundStatement =
-                 std::dynamic_pointer_cast<CompoundStatement>(statement)) {
-        auto block = compoundStatement->getBlock();
-        auto labeledBlock = labelBlock(block, label);
-        return std::make_shared<CompoundStatement>(labeledBlock);
-    }
-    else {
-        return statement;
+                 dynamic_cast<CompoundStatement *>(statement)) {
+        labelBlock(compoundStatement->getBlock(), label);
     }
 }
 
-std::shared_ptr<Block>
-LoopLabelingPass::labelBlock(std::shared_ptr<Block> block, std::string label) {
-    auto blockItems = block->getBlockItems();
-    auto newBlockItems =
-        std::make_shared<std::vector<std::shared_ptr<BlockItem>>>();
-    for (auto &blockItem : *blockItems) {
-        if (auto dBlockItem =
-                std::dynamic_pointer_cast<DBlockItem>(blockItem)) {
-            newBlockItems->emplace_back(dBlockItem);
+void LoopLabelingPass::labelBlock(Block *block, std::string_view label) {
+    for (auto &blockItem : block->getBlockItems()) {
+        if (dynamic_cast<DBlockItem *>(blockItem.get())) {
+            continue;
         }
-        else if (auto sBlockItem =
-                     std::dynamic_pointer_cast<SBlockItem>(blockItem)) {
-            auto resolvedStatement =
-                labelStatement(sBlockItem->getStatement(), label);
-            auto labeledSBlockItem =
-                std::make_shared<SBlockItem>(resolvedStatement);
-            newBlockItems->emplace_back(labeledSBlockItem);
+        if (auto sBlockItem = dynamic_cast<SBlockItem *>(blockItem.get())) {
+            labelStatement(sBlockItem->getStatement(), label);
+            continue;
         }
-        else {
-            throw std::logic_error(
-                "Unsupported block item type for loop labeling");
-        }
+        throw std::logic_error("Unsupported block item type for loop labeling");
     }
-    return std::make_shared<Block>(newBlockItems);
 }
 /*
  * End: Functions for the loop-labeling pass.

--- a/src/frontend/semanticAnalysisPasses.h
+++ b/src/frontend/semanticAnalysisPasses.h
@@ -199,7 +199,7 @@ class StaticInit {
     /**
      * Pure virtual method to get the value of the static initializer.
      */
-    virtual std::variant<int, long> getValue() = 0;
+    virtual std::variant<int, long> getValue() const = 0;
 };
 
 /**
@@ -214,7 +214,7 @@ class IntInit : public StaticInit {
      */
     constexpr IntInit(int value) : value(value) {}
 
-    std::variant<int, long> getValue() override { return value; }
+    std::variant<int, long> getValue() const override { return value; }
 
   private:
     /**
@@ -232,7 +232,7 @@ class LongInit : public StaticInit {
      */
     constexpr LongInit(long value) : value(value) {}
 
-    std::variant<int, long> getValue() override { return value; }
+    std::variant<int, long> getValue() const override { return value; }
 
   private:
     /**

--- a/src/frontend/semanticAnalysisPasses.h
+++ b/src/frontend/semanticAnalysisPasses.h
@@ -79,7 +79,7 @@ class IdentifierResolutionPass : public SemanticAnalysisPass {
      * @param program The program to resolve.
      * @return The number of resolved identifiers.
      */
-    int resolveProgram(std::shared_ptr<Program> program);
+    int resolveProgram(Program &program);
 
   private:
     /**
@@ -110,10 +110,9 @@ class IdentifierResolutionPass : public SemanticAnalysisPass {
      *
      * @param declaration The variable declaration to resolve.
      * @param identifierMap The current identifier map.
-     * @return The resolved variable declaration.
      */
-    std::shared_ptr<Declaration> resolveFileScopeVariableDeclaration(
-        std::shared_ptr<Declaration> declaration,
+    void resolveFileScopeVariableDeclaration(
+        VariableDeclaration *declaration,
         std::unordered_map<std::string, MapEntry> &identifierMap);
 
     /**
@@ -121,10 +120,9 @@ class IdentifierResolutionPass : public SemanticAnalysisPass {
      *
      * @param declaration The variable declaration to resolve.
      * @param identifierMap The current identifier map.
-     * @return The resolved variable declaration.
      */
-    std::shared_ptr<VariableDeclaration> resolveLocalVariableDeclaration(
-        std::shared_ptr<VariableDeclaration> declaration,
+    void resolveLocalVariableDeclaration(
+        VariableDeclaration *declaration,
         std::unordered_map<std::string, MapEntry> &identifierMap);
 
     /**
@@ -132,10 +130,9 @@ class IdentifierResolutionPass : public SemanticAnalysisPass {
      *
      * @param statement The statement to resolve.
      * @param identifierMap The current identifier map.
-     * @return The resolved statement.
      */
-    std::shared_ptr<Statement>
-    resolveStatement(std::shared_ptr<Statement> statement,
+    void
+    resolveStatement(Statement *statement,
                      std::unordered_map<std::string, MapEntry> &identifierMap);
 
     /**
@@ -143,10 +140,9 @@ class IdentifierResolutionPass : public SemanticAnalysisPass {
      *
      * @param expression The expression to resolve.
      * @param identifierMap The current identifier map.
-     * @return The resolved expression.
      */
-    std::shared_ptr<Expression>
-    resolveExpression(std::shared_ptr<Expression> expression,
+    void
+    resolveExpression(Expression *expression,
                       std::unordered_map<std::string, MapEntry> &identifierMap);
 
     /**
@@ -154,21 +150,18 @@ class IdentifierResolutionPass : public SemanticAnalysisPass {
      *
      * @param block The block to resolve.
      * @param identifierMap The current identifier map.
-     * @return The resolved block.
      */
-    std::shared_ptr<Block>
-    resolveBlock(std::shared_ptr<Block> block,
-                 std::unordered_map<std::string, MapEntry> &identifierMap);
+    void resolveBlock(Block *block,
+                      std::unordered_map<std::string, MapEntry> &identifierMap);
 
     /**
      * Resolve a for-init.
      *
      * @param forInit The for-init to resolve.
      * @param identifierMap The current identifier map.
-     * @return The resolved for-init.
      */
-    std::shared_ptr<ForInit>
-    resolveForInit(std::shared_ptr<ForInit> forInit,
+    void
+    resolveForInit(ForInit *forInit,
                    std::unordered_map<std::string, MapEntry> &identifierMap);
 
     /**
@@ -176,10 +169,9 @@ class IdentifierResolutionPass : public SemanticAnalysisPass {
      *
      * @param declaration The function declaration to resolve.
      * @param identifierMap The current identifier map.
-     * @return The resolved function declaration.
      */
-    std::shared_ptr<FunctionDeclaration> resolveFunctionDeclaration(
-        std::shared_ptr<FunctionDeclaration> declaration,
+    void resolveFunctionDeclaration(
+        FunctionDeclaration *declaration,
         std::unordered_map<std::string, MapEntry> &identifierMap);
 
     /**
@@ -275,29 +267,30 @@ class Initial : public InitialValue {
      *
      * @param value The integer or long value of the static initializer.
      */
-    Initial(int value) : staticInit(std::make_shared<IntInit>(value)) {}
+    Initial(int value) : staticInit(std::make_unique<IntInit>(value)) {}
 
     /**
      * Constructors for the initial class with a long parameter.
      *
      * @param value The long value of the static initializer.
      */
-    Initial(long value) : staticInit(std::make_shared<LongInit>(value)) {}
+    Initial(long value) : staticInit(std::make_unique<LongInit>(value)) {}
 
     /**
      * Constructor for the initial class with a static initializer parameter.
      *
      * @param staticInit The static initializer.
      */
-    Initial(std::shared_ptr<StaticInit> staticInit) : staticInit(staticInit) {}
+    explicit Initial(std::unique_ptr<StaticInit> staticInit)
+        : staticInit(std::move(staticInit)) {}
 
-    std::shared_ptr<StaticInit> getStaticInit() { return staticInit; }
+    StaticInit *getStaticInit() const { return staticInit.get(); }
 
   private:
     /**
      * The static initializer.
      */
-    std::shared_ptr<StaticInit> staticInit;
+    std::unique_ptr<StaticInit> staticInit;
 };
 
 /**
@@ -357,10 +350,10 @@ class StaticAttribute : public IdentifierAttribute {
      * @param initialValue The initial value of the static variable.
      * @param global Whether the static variable is global.
      */
-    StaticAttribute(std::shared_ptr<InitialValue> initialValue, bool global)
-        : initialValue(initialValue), global(global) {}
+    StaticAttribute(std::unique_ptr<InitialValue> initialValue, bool global)
+        : initialValue(std::move(initialValue)), global(global) {}
 
-    std::shared_ptr<InitialValue> getInitialValue() { return initialValue; }
+    InitialValue *getInitialValue() { return initialValue.get(); }
 
     constexpr bool isGlobal() { return global; }
 
@@ -368,7 +361,7 @@ class StaticAttribute : public IdentifierAttribute {
     /**
      * The initial value of the static variable.
      */
-    std::shared_ptr<InitialValue> initialValue;
+    std::unique_ptr<InitialValue> initialValue;
 
     /**
      * Whether the static variable is global.
@@ -398,7 +391,7 @@ class TypeCheckingPass : public SemanticAnalysisPass {
      *
      * @param program The program to type check.
      */
-    void typeCheckProgram(std::shared_ptr<Program> program);
+    void typeCheckProgram(Program &program);
 
   private:
     /**
@@ -412,9 +405,9 @@ class TypeCheckingPass : public SemanticAnalysisPass {
      * @param varType The type of the variable.
      * @param constantExpr The constant expression to
      */
-    std::shared_ptr<StaticInit> convertStaticConstantToStaticInit(
-        std::shared_ptr<Type> varType,
-        std::shared_ptr<ConstantExpression> constantExpr);
+    std::unique_ptr<StaticInit>
+    convertStaticConstantToStaticInit(const Type *varType,
+                                      const ConstantExpression *constantExpr);
 
     /**
      * Get the common type between two types.
@@ -422,8 +415,7 @@ class TypeCheckingPass : public SemanticAnalysisPass {
      * @param type1 The first type.
      * @param type2 The second type.
      */
-    std::shared_ptr<Type> getCommonType(std::shared_ptr<Type> type1,
-                                        std::shared_ptr<Type> type2);
+    std::unique_ptr<Type> getCommonType(const Type *type1, const Type *type2);
 
     /**
      * Convert an expression to a target type.
@@ -431,40 +423,37 @@ class TypeCheckingPass : public SemanticAnalysisPass {
      * @param expression The expression to convert.
      * @param targetType The target type.
      */
-    std::shared_ptr<Expression>
-    convertTo(std::shared_ptr<Expression> expression,
-              std::shared_ptr<Type> targetType);
+    std::unique_ptr<Expression> convertTo(const Expression *expression,
+                                          const Type *targetType);
 
     /**
      * Type check a function declaration.
      *
      * @param declaration The function declaration to type check.
      */
-    void typeCheckFunctionDeclaration(
-        std::shared_ptr<FunctionDeclaration> declaration);
+    void typeCheckFunctionDeclaration(FunctionDeclaration *declaration);
 
     /**
      * Type check a file-scope variable declaration.
      *
      * @param declaration The variable declaration to type check.
      */
-    void typeCheckFileScopeVariableDeclaration(
-        std::shared_ptr<VariableDeclaration> declaration);
+    void
+    typeCheckFileScopeVariableDeclaration(VariableDeclaration *declaration);
 
     /**
      * Type check a local variable declaration.
      *
      * @param declaration The variable declaration to type check.
      */
-    void typeCheckLocalVariableDeclaration(
-        std::shared_ptr<VariableDeclaration> declaration);
+    void typeCheckLocalVariableDeclaration(VariableDeclaration *declaration);
 
     /**
      * Type check an expression.
      *
      * @param expression The expression to type check.
      */
-    void typeCheckExpression(std::shared_ptr<Expression> expression);
+    void typeCheckExpression(Expression *expression);
 
     /**
      * Type check a block.
@@ -473,8 +462,7 @@ class TypeCheckingPass : public SemanticAnalysisPass {
      * @param enclosingFunctionIdentifier The identifier of the enclosing
      * function.
      */
-    void typeCheckBlock(std::shared_ptr<Block> block,
-                        std::string enclosingFunctionIdentifier);
+    void typeCheckBlock(Block *block, std::string enclosingFunctionIdentifier);
 
     /**
      * Type check a statement.
@@ -483,7 +471,7 @@ class TypeCheckingPass : public SemanticAnalysisPass {
      * @param enclosingFunctionIdentifier The identifier of the enclosing
      * function.
      */
-    void typeCheckStatement(std::shared_ptr<Statement> statement,
+    void typeCheckStatement(Statement *statement,
                             std::string enclosingFunctionIdentifier);
 
     /**
@@ -491,7 +479,7 @@ class TypeCheckingPass : public SemanticAnalysisPass {
      *
      * @param forInit The for-init to type check.
      */
-    void typeCheckForInit(std::shared_ptr<ForInit> forInit);
+    void typeCheckForInit(ForInit *forInit);
 };
 
 /**
@@ -504,7 +492,7 @@ class LoopLabelingPass : public SemanticAnalysisPass {
      *
      * @param program The program to label loops in.
      */
-    void labelLoops(std::shared_ptr<Program> program);
+    void labelLoops(Program &program);
 
   private:
     /**
@@ -524,30 +512,24 @@ class LoopLabelingPass : public SemanticAnalysisPass {
      *
      * @param statement The statement to annotate.
      * @param label The label to annotate with.
-     * @return The annotated statement.
      */
-    std::shared_ptr<Statement>
-    annotateStatement(std::shared_ptr<Statement> statement, std::string label);
+    void annotateStatement(Statement *statement, std::string_view label);
 
     /**
      * Label a statement with a label.
      *
      * @param statement The statement to label.
      * @param label The label to use.
-     * @return The labeled statement.
      */
-    std::shared_ptr<Statement>
-    labelStatement(std::shared_ptr<Statement> statement, std::string label);
+    void labelStatement(Statement *statement, std::string_view label);
 
     /**
      * Label a block with a label.
      *
      * @param block The block to label.
      * @param label The label to use.
-     * @return The labeled block.
      */
-    std::shared_ptr<Block> labelBlock(std::shared_ptr<Block> block,
-                                      std::string label);
+    void labelBlock(Block *block, std::string_view label);
 };
 } // namespace AST
 

--- a/src/frontend/statement.cpp
+++ b/src/frontend/statement.cpp
@@ -1,62 +1,56 @@
 #include "statement.h"
 #include "block.h"
+#include "forInit.h"
 #include "visitor.h"
 
 namespace AST {
-ReturnStatement::ReturnStatement(std::shared_ptr<Expression> expr)
-    : expr(expr) {}
+ReturnStatement::ReturnStatement(std::unique_ptr<Expression> expr)
+    : expr(std::move(expr)) {}
 
 void ReturnStatement::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<Expression> ReturnStatement::getExpression() const {
-    return expr;
+Expression *ReturnStatement::getExpression() const { return expr.get(); }
+
+void ReturnStatement::setExpression(std::unique_ptr<Expression> newExpr) {
+    this->expr = std::move(newExpr);
 }
 
-void ReturnStatement::setExpression(std::shared_ptr<Expression> newExpr) {
-    this->expr = newExpr;
-}
-
-ExpressionStatement::ExpressionStatement(std::shared_ptr<Expression> expr)
-    : expr(expr) {}
+ExpressionStatement::ExpressionStatement(std::unique_ptr<Expression> expr)
+    : expr(std::move(expr)) {}
 
 void ExpressionStatement::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<Expression> ExpressionStatement::getExpression() const {
-    return expr;
-}
+Expression *ExpressionStatement::getExpression() const { return expr.get(); }
 
-IfStatement::IfStatement(
-    std::shared_ptr<Expression> condition,
-    std::shared_ptr<Statement> thenStatement,
-    std::optional<std::shared_ptr<Statement>> elseOptStatement)
-    : condition(condition), thenStatement(thenStatement),
-      elseOptStatement(elseOptStatement) {}
+IfStatement::IfStatement(std::unique_ptr<Expression> condition,
+                         std::unique_ptr<Statement> thenStatement,
+                         std::unique_ptr<Statement> elseOptStatement)
+    : condition(std::move(condition)), thenStatement(std::move(thenStatement)),
+      elseOptStatement(std::move(elseOptStatement)) {}
 
-IfStatement::IfStatement(std::shared_ptr<Expression> condition,
-                         std::shared_ptr<Statement> thenStatement)
-    : condition(condition), thenStatement(thenStatement) {}
+IfStatement::IfStatement(std::unique_ptr<Expression> condition,
+                         std::unique_ptr<Statement> thenStatement)
+    : condition(std::move(condition)), thenStatement(std::move(thenStatement)),
+      elseOptStatement(nullptr) {}
 
 void IfStatement::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<Expression> IfStatement::getCondition() const {
-    return condition;
+Expression *IfStatement::getCondition() const { return condition.get(); }
+
+Statement *IfStatement::getThenStatement() const { return thenStatement.get(); }
+
+Statement *IfStatement::getElseOptStatement() const {
+    return elseOptStatement.get();
 }
 
-std::shared_ptr<Statement> IfStatement::getThenStatement() const {
-    return thenStatement;
-}
+CompoundStatement::CompoundStatement(std::unique_ptr<Block> block)
+    : block(std::move(block)) {}
 
-std::optional<std::shared_ptr<Statement>>
-IfStatement::getElseOptStatement() const {
-    return elseOptStatement;
-}
-
-CompoundStatement::CompoundStatement(std::shared_ptr<Block> block)
-    : block(block) {}
+CompoundStatement::~CompoundStatement() = default;
 
 void CompoundStatement::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<Block> CompoundStatement::getBlock() const { return block; }
+Block *CompoundStatement::getBlock() const { return block.get(); }
 
 void BreakStatement::accept(Visitor &visitor) { visitor.visit(*this); }
 
@@ -74,17 +68,15 @@ void ContinueStatement::setLabel(std::string_view newLabel) {
     this->label = newLabel;
 }
 
-WhileStatement::WhileStatement(std::shared_ptr<Expression> condition,
-                               std::shared_ptr<Statement> body)
-    : condition(condition), body(body) {}
+WhileStatement::WhileStatement(std::unique_ptr<Expression> condition,
+                               std::unique_ptr<Statement> body)
+    : condition(std::move(condition)), body(std::move(body)) {}
 
 void WhileStatement::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<Expression> WhileStatement::getCondition() const {
-    return condition;
-}
+Expression *WhileStatement::getCondition() const { return condition.get(); }
 
-std::shared_ptr<Statement> WhileStatement::getBody() const { return body; }
+Statement *WhileStatement::getBody() const { return body.get(); }
 
 const std::string &WhileStatement::getLabel() const { return label; }
 
@@ -92,17 +84,15 @@ void WhileStatement::setLabel(std::string_view newLabel) {
     this->label = newLabel;
 }
 
-DoWhileStatement::DoWhileStatement(std::shared_ptr<Expression> condition,
-                                   std::shared_ptr<Statement> body)
-    : condition(condition), body(body) {}
+DoWhileStatement::DoWhileStatement(std::unique_ptr<Expression> condition,
+                                   std::unique_ptr<Statement> body)
+    : condition(std::move(condition)), body(std::move(body)) {}
 
 void DoWhileStatement::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<Expression> DoWhileStatement::getCondition() const {
-    return condition;
-}
+Expression *DoWhileStatement::getCondition() const { return condition.get(); }
 
-std::shared_ptr<Statement> DoWhileStatement::getBody() const { return body; }
+Statement *DoWhileStatement::getBody() const { return body.get(); }
 
 const std::string &DoWhileStatement::getLabel() const { return label; }
 
@@ -110,26 +100,24 @@ void DoWhileStatement::setLabel(std::string_view newLabel) {
     this->label = newLabel;
 }
 
-ForStatement::ForStatement(std::shared_ptr<ForInit> forInit,
-                           std::optional<std::shared_ptr<Expression>> condition,
-                           std::optional<std::shared_ptr<Expression>> post,
-                           std::shared_ptr<Statement> body)
-    : forInit(forInit), optCondition(condition), optPost(post), body(body) {}
+ForStatement::ForStatement(std::unique_ptr<ForInit> forInit,
+                           std::unique_ptr<Expression> condition,
+                           std::unique_ptr<Expression> post,
+                           std::unique_ptr<Statement> body)
+    : forInit(std::move(forInit)), optCondition(std::move(condition)),
+      optPost(std::move(post)), body(std::move(body)) {}
+
+ForStatement::~ForStatement() = default;
 
 void ForStatement::accept(Visitor &visitor) { visitor.visit(*this); }
 
-std::shared_ptr<ForInit> ForStatement::getForInit() const { return forInit; }
+ForInit *ForStatement::getForInit() const { return forInit.get(); }
 
-std::optional<std::shared_ptr<Expression>>
-ForStatement::getOptCondition() const {
-    return optCondition;
-}
+Expression *ForStatement::getOptCondition() const { return optCondition.get(); }
 
-std::optional<std::shared_ptr<Expression>> ForStatement::getOptPost() const {
-    return optPost;
-}
+Expression *ForStatement::getOptPost() const { return optPost.get(); }
 
-std::shared_ptr<Statement> ForStatement::getBody() const { return body; }
+Statement *ForStatement::getBody() const { return body.get(); }
 
 const std::string &ForStatement::getLabel() const { return label; }
 

--- a/src/frontend/statement.h
+++ b/src/frontend/statement.h
@@ -3,13 +3,15 @@
 
 #include "ast.h"
 #include "expression.h"
-#include "forInit.h"
 #include <memory>
 #include <optional>
 #include <string_view>
 
 namespace AST {
-class Block; // Forward declaration.
+// Forward declaration of `Block` to avoid circular dependencies.
+class Block;
+// Forward declaration of `ForInit` to avoid circular dependencies.
+class ForInit;
 
 /**
  * Base class for statements in the AST.
@@ -32,19 +34,19 @@ class ReturnStatement : public Statement {
      *
      * @param expr The expression to return.
      */
-    explicit ReturnStatement(std::shared_ptr<Expression> expr);
+    explicit ReturnStatement(std::unique_ptr<Expression> expr);
 
     void accept(Visitor &visitor) override;
 
-    [[nodiscard]] std::shared_ptr<Expression> getExpression() const;
+    [[nodiscard]] Expression *getExpression() const;
 
-    void setExpression(std::shared_ptr<Expression> expr);
+    void setExpression(std::unique_ptr<Expression> expr);
 
   private:
     /**
      * The expression to return.
      */
-    std::shared_ptr<Expression> expr;
+    std::unique_ptr<Expression> expr;
 };
 
 /**
@@ -57,17 +59,17 @@ class ExpressionStatement : public Statement {
      *
      * @param expr The expression in the statement.
      */
-    explicit ExpressionStatement(std::shared_ptr<Expression> expr);
+    explicit ExpressionStatement(std::unique_ptr<Expression> expr);
 
     void accept(Visitor &visitor) override;
 
-    [[nodiscard]] std::shared_ptr<Expression> getExpression() const;
+    [[nodiscard]] Expression *getExpression() const;
 
   private:
     /**
      * The expression in the statement.
      */
-    std::shared_ptr<Expression> expr;
+    std::unique_ptr<Expression> expr;
 };
 
 /**
@@ -83,10 +85,9 @@ class IfStatement : public Statement {
      * @param elseOptStatement An optional statement to execute if the condition
      * is false.
      */
-    explicit IfStatement(
-        std::shared_ptr<Expression> condition,
-        std::shared_ptr<Statement> thenStatement,
-        std::optional<std::shared_ptr<Statement>> elseOptStatement);
+    explicit IfStatement(std::unique_ptr<Expression> condition,
+                         std::unique_ptr<Statement> thenStatement,
+                         std::unique_ptr<Statement> elseOptStatement);
 
     /**
      * Constructor of the if-statement class without an (optional) else
@@ -95,33 +96,33 @@ class IfStatement : public Statement {
      * @param condition The condition expression of the if statement.
      * @param thenStatement The statement to execute if the condition is true.
      */
-    explicit IfStatement(std::shared_ptr<Expression> condition,
-                         std::shared_ptr<Statement> thenStatement);
+    explicit IfStatement(std::unique_ptr<Expression> condition,
+                         std::unique_ptr<Statement> thenStatement);
 
     void accept(Visitor &visitor) override;
 
-    [[nodiscard]] std::shared_ptr<Expression> getCondition() const;
+    [[nodiscard]] Expression *getCondition() const;
 
-    [[nodiscard]] std::shared_ptr<Statement> getThenStatement() const;
+    [[nodiscard]] Statement *getThenStatement() const;
 
-    [[nodiscard]] std::optional<std::shared_ptr<Statement>>
-    getElseOptStatement() const;
+    [[nodiscard]] Statement *getElseOptStatement() const;
 
   private:
     /**
      * The condition expression of the if statement.
      */
-    std::shared_ptr<Expression> condition;
+    std::unique_ptr<Expression> condition;
 
     /**
      * The statement to execute if the condition is true.
      */
-    std::shared_ptr<Statement> thenStatement;
+    std::unique_ptr<Statement> thenStatement;
 
     /**
-     * An optional statement to execute if the condition is false.
+     * An optional statement to execute if the condition is false (can be
+     * `nullptr`).
      */
-    std::optional<std::shared_ptr<Statement>> elseOptStatement;
+    std::unique_ptr<Statement> elseOptStatement;
 };
 
 /**
@@ -134,17 +135,24 @@ class CompoundStatement : public Statement {
      *
      * @param block The block of statements.
      */
-    explicit CompoundStatement(std::shared_ptr<Block> block);
+    explicit CompoundStatement(std::unique_ptr<Block> block);
+
+    /**
+     * Destructor for the `CompoundStatement` class.
+     *
+     * Defined in `statement.cpp` to allow incomplete type `Block` in header.
+     */
+    ~CompoundStatement();
 
     void accept(Visitor &visitor) override;
 
-    [[nodiscard]] std::shared_ptr<Block> getBlock() const;
+    [[nodiscard]] Block *getBlock() const;
 
   private:
     /**
      * The block of statements.
      */
-    std::shared_ptr<Block> block;
+    std::unique_ptr<Block> block;
 };
 
 /**
@@ -204,14 +212,14 @@ class WhileStatement : public Statement {
      * @param condition The condition expression of the while statement.
      * @param body The body statement of the while loop.
      */
-    explicit WhileStatement(std::shared_ptr<Expression> condition,
-                            std::shared_ptr<Statement> body);
+    explicit WhileStatement(std::unique_ptr<Expression> condition,
+                            std::unique_ptr<Statement> body);
 
     void accept(Visitor &visitor) override;
 
-    [[nodiscard]] std::shared_ptr<Expression> getCondition() const;
+    [[nodiscard]] Expression *getCondition() const;
 
-    [[nodiscard]] std::shared_ptr<Statement> getBody() const;
+    [[nodiscard]] Statement *getBody() const;
 
     [[nodiscard]] const std::string &getLabel() const;
 
@@ -221,12 +229,12 @@ class WhileStatement : public Statement {
     /**
      * The condition expression of the while statement.
      */
-    std::shared_ptr<Expression> condition;
+    std::unique_ptr<Expression> condition;
 
     /**
      * The body statement of the while loop.
      */
-    std::shared_ptr<Statement> body;
+    std::unique_ptr<Statement> body;
 
     /**
      * The label of the loop.
@@ -245,14 +253,14 @@ class DoWhileStatement : public Statement {
      * @param condition The condition expression of the do-while statement.
      * @param body The body statement of the do-while loop.
      */
-    explicit DoWhileStatement(std::shared_ptr<Expression> condition,
-                              std::shared_ptr<Statement> body);
+    explicit DoWhileStatement(std::unique_ptr<Expression> condition,
+                              std::unique_ptr<Statement> body);
 
     void accept(Visitor &visitor) override;
 
-    [[nodiscard]] std::shared_ptr<Expression> getCondition() const;
+    [[nodiscard]] Expression *getCondition() const;
 
-    [[nodiscard]] std::shared_ptr<Statement> getBody() const;
+    [[nodiscard]] Statement *getBody() const;
 
     [[nodiscard]] const std::string &getLabel() const;
 
@@ -262,12 +270,12 @@ class DoWhileStatement : public Statement {
     /**
      * The condition expression of the do-while statement.
      */
-    std::shared_ptr<Expression> condition;
+    std::unique_ptr<Expression> condition;
 
     /**
      * The body statement of the do-while loop.
      */
-    std::shared_ptr<Statement> body;
+    std::unique_ptr<Statement> body;
 
     /**
      * The label of the loop.
@@ -285,25 +293,32 @@ class ForStatement : public Statement {
      *
      * @param forInit The initialization part of the for statement.
      * @param condition The (optional) condition expression of the for
-     * statement.
-     * @param post The (optional) post-expression of the for statement.
+     * statement (can be `nullptr`).
+     * @param post The (optional) post-expression of the for statement (can be
+     * `nullptr`).
      * @param body The body statement of the for loop.
      */
-    explicit ForStatement(std::shared_ptr<ForInit> forInit,
-                          std::optional<std::shared_ptr<Expression>> condition,
-                          std::optional<std::shared_ptr<Expression>> post,
-                          std::shared_ptr<Statement> body);
+    explicit ForStatement(std::unique_ptr<ForInit> forInit,
+                          std::unique_ptr<Expression> condition,
+                          std::unique_ptr<Expression> post,
+                          std::unique_ptr<Statement> body);
+
+    /**
+     * Destructor for the `ForStatement` class.
+     *
+     * Defined in `statement.cpp` to allow incomplete type `ForInit` in header.
+     */
+    ~ForStatement();
 
     void accept(Visitor &visitor) override;
 
-    [[nodiscard]] std::shared_ptr<ForInit> getForInit() const;
+    [[nodiscard]] ForInit *getForInit() const;
 
-    [[nodiscard]] std::optional<std::shared_ptr<Expression>>
-    getOptCondition() const;
+    [[nodiscard]] Expression *getOptCondition() const;
 
-    [[nodiscard]] std::optional<std::shared_ptr<Expression>> getOptPost() const;
+    [[nodiscard]] Expression *getOptPost() const;
 
-    [[nodiscard]] std::shared_ptr<Statement> getBody() const;
+    [[nodiscard]] Statement *getBody() const;
 
     [[nodiscard]] const std::string &getLabel() const;
 
@@ -313,22 +328,23 @@ class ForStatement : public Statement {
     /**
      * The initialization part of the for statement.
      */
-    std::shared_ptr<ForInit> forInit;
+    std::unique_ptr<ForInit> forInit;
 
     /**
-     * The (optional) condition expression of the for statement.
+     * The (optional) condition expression of the for statement (can be
+     * `nullptr`).
      */
-    std::optional<std::shared_ptr<Expression>> optCondition;
+    std::unique_ptr<Expression> optCondition;
 
     /**
-     * The (optional) post-expression of the for statement.
+     * The (optional) post-expression of the for statement (can be `nullptr`).
      */
-    std::optional<std::shared_ptr<Expression>> optPost;
+    std::unique_ptr<Expression> optPost;
 
     /**
      * The body statement of the for loop.
      */
-    std::shared_ptr<Statement> body;
+    std::unique_ptr<Statement> body;
 
     /**
      * The label of the loop.

--- a/src/frontend/type.h
+++ b/src/frontend/type.h
@@ -16,10 +16,12 @@ class Type : public AST {
      * Default constructor of the type class.
      */
     constexpr Type() = default;
+
     /**
      * Default virtual destructor for the type class.
      */
     virtual ~Type() = default;
+
     /**
      * Virtual function to check if two types are equal.
      *
@@ -87,6 +89,7 @@ class LongType : public Type {
     constexpr LongType() = default;
 
     void accept(Visitor &visitor) override { visitor.visit(*this); }
+
     /**
      * Overriden `isEqual` function to check if the other type is a
      * long type.
@@ -111,9 +114,10 @@ class FunctionType : public Type {
      * @param returnType The return type of the function.
      */
     explicit FunctionType(
-        std::shared_ptr<std::vector<std::shared_ptr<Type>>> parameterTypes,
-        std::shared_ptr<Type> returnType)
-        : parameterTypes(parameterTypes), returnType(returnType) {}
+        std::unique_ptr<std::vector<std::unique_ptr<Type>>> parameterTypes,
+        std::unique_ptr<Type> returnType)
+        : parameterTypes(std::move(parameterTypes)),
+          returnType(std::move(returnType)) {}
 
     void accept(Visitor &visitor) override { visitor.visit(*this); }
 
@@ -141,25 +145,23 @@ class FunctionType : public Type {
         return *returnType == *otherFn->returnType;
     }
 
-    [[nodiscard]] const std::shared_ptr<std::vector<std::shared_ptr<Type>>> &
+    [[nodiscard]] const std::vector<std::unique_ptr<Type>> &
     getParameterTypes() const {
-        return parameterTypes;
+        return *parameterTypes;
     }
 
-    [[nodiscard]] std::shared_ptr<Type> getReturnType() const {
-        return returnType;
-    }
+    [[nodiscard]] const Type &getReturnType() const { return *returnType; }
 
   private:
     /**
      * Parameter types of the function.
      */
-    std::shared_ptr<std::vector<std::shared_ptr<Type>>> parameterTypes;
+    std::unique_ptr<std::vector<std::unique_ptr<Type>>> parameterTypes;
 
     /**
      * Return type of the function.
      */
-    std::shared_ptr<Type> returnType;
+    std::unique_ptr<Type> returnType;
 };
 } // namespace AST
 

--- a/src/frontend/visitor.h
+++ b/src/frontend/visitor.h
@@ -2,9 +2,6 @@
 #define FRONTEND_VISITOR_H
 
 namespace AST {
-/**
- * Forward declarations of all AST node classes to avoid circular dependencies.
- */
 class Program;
 class Function;
 class Block;
@@ -91,9 +88,6 @@ class Visitor {
      */
     virtual ~Visitor() = default;
 
-    /**
-     * Pure virtual visit methods for each AST node.
-     */
     virtual void visit(Program &program) = 0;
     virtual void visit(Function &function) = 0;
     virtual void visit(Block &block) = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -197,7 +197,7 @@ int main(int argc, char *argv[]) {
         AST::FrontendSymbolTable frontendSymbolTable;
         auto variableResolutionCounter =
             PipelineStagesExecutors::semanticAnalysisExecutor(
-                astProgram, frontendSymbolTable);
+                *astProgram, frontendSymbolTable);
 
         if (tillValidate) {
             std::cout << "Semantic analysis completed.\n";
@@ -207,7 +207,7 @@ int main(int argc, char *argv[]) {
         // Generate the IR from the AST program and return the IR program.
         auto irProgramAndIRStaticVariables =
             PipelineStagesExecutors::irGeneratorExecutor(
-                astProgram, variableResolutionCounter, frontendSymbolTable);
+                *astProgram, variableResolutionCounter, frontendSymbolTable);
         auto irProgram = std::move(irProgramAndIRStaticVariables.first);
         auto irStaticVariables =
             std::move(irProgramAndIRStaticVariables.second);
@@ -243,13 +243,12 @@ int main(int argc, char *argv[]) {
 
         // Generate the assembly program from the IR program and the IR static
         // variables.
-        std::shared_ptr<Assembly::Program> assemblyProgram =
-            PipelineStagesExecutors::codegenExecutor(
-                *irProgram, *irStaticVariables, frontendSymbolTable);
+        auto assemblyProgram = PipelineStagesExecutors::codegenExecutor(
+            *irProgram, *irStaticVariables, frontendSymbolTable);
 
         // Print out the (assembly) instructions that would be emitted from the
         // assembly program.
-        PrettyPrinters::printAssemblyProgram(assemblyProgram);
+        PrettyPrinters::printAssemblyProgram(*assemblyProgram);
 
         if (tillCodegen) {
             std::cout << "Code generation completed.\n";
@@ -257,7 +256,7 @@ int main(int argc, char *argv[]) {
         }
 
         // Emit the generated assembly code to the assembly file.
-        PipelineStagesExecutors::codeEmissionExecutor(assemblyProgram,
+        PipelineStagesExecutors::codeEmissionExecutor(*assemblyProgram,
                                                       assemblyFileName);
 
         if (tillEmitAssembly) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -208,29 +208,30 @@ int main(int argc, char *argv[]) {
         auto irProgramAndIRStaticVariables =
             PipelineStagesExecutors::irGeneratorExecutor(
                 astProgram, variableResolutionCounter, frontendSymbolTable);
-        auto irProgram = irProgramAndIRStaticVariables.first;
-        auto irStaticVariables = irProgramAndIRStaticVariables.second;
+        auto irProgram = std::move(irProgramAndIRStaticVariables.first);
+        auto irStaticVariables =
+            std::move(irProgramAndIRStaticVariables.second);
 
         if (foldConstantsPass || propagateCopiesPass ||
             eliminateUnreachableCodePass || eliminateDeadStoresPass) {
             // Print the IR program to stdout.
             std::cout << "<<< Before optimization passes: >>>\n";
-            PrettyPrinters::printIRProgram(irProgram, irStaticVariables);
+            PrettyPrinters::printIRProgram(*irProgram, *irStaticVariables);
 
             // Perform the optimization passes on the IR program (if any of the
             // flags is set to true).
             PipelineStagesExecutors::irOptimizationExecutor(
-                irProgram, foldConstantsPass, propagateCopiesPass,
+                *irProgram, foldConstantsPass, propagateCopiesPass,
                 eliminateUnreachableCodePass, eliminateDeadStoresPass);
 
             // Print the optimized IR program to stdout (after the
             // optimization passes).
             std::cout << "<<< After optimization passes: >>>\n";
-            PrettyPrinters::printIRProgram(irProgram, irStaticVariables);
+            PrettyPrinters::printIRProgram(*irProgram, *irStaticVariables);
         }
         else {
             // Print the IR program to stdout.
-            PrettyPrinters::printIRProgram(irProgram, irStaticVariables);
+            PrettyPrinters::printIRProgram(*irProgram, *irStaticVariables);
         }
 
         if (tillIR) {
@@ -244,7 +245,7 @@ int main(int argc, char *argv[]) {
         // variables.
         std::shared_ptr<Assembly::Program> assemblyProgram =
             PipelineStagesExecutors::codegenExecutor(
-                irProgram, irStaticVariables, frontendSymbolTable);
+                *irProgram, *irStaticVariables, frontendSymbolTable);
 
         // Print out the (assembly) instructions that would be emitted from the
         // assembly program.

--- a/src/midend/ir.h
+++ b/src/midend/ir.h
@@ -125,7 +125,7 @@ class ConstantValue : public Value {
     /**
      * The AST constant encapsulated by this IR constant value.
      */
-    std::shared_ptr<AST::Constant> astConstant;
+    std::unique_ptr<AST::Constant> astConstant;
 
   public:
     /**
@@ -134,8 +134,8 @@ class ConstantValue : public Value {
      * @param astConstant The AST constant to encapsulate.
      * @throws std::logic_error if `astConstant` is null.
      */
-    explicit ConstantValue(const std::shared_ptr<AST::Constant> &astConstant)
-        : astConstant(astConstant) {
+    explicit ConstantValue(std::unique_ptr<AST::Constant> astConstant)
+        : astConstant(std::move(astConstant)) {
         if (!astConstant) {
             throw std::logic_error(
                 "Creating ConstantValue with null astConstant");
@@ -147,15 +147,15 @@ class ConstantValue : public Value {
      */
     ~ConstantValue() = default;
 
-    [[nodiscard]] std::shared_ptr<AST::Constant> getASTConstant() const {
-        return astConstant;
+    [[nodiscard]] const AST::Constant *getASTConstant() const {
+        return astConstant.get();
     }
 
-    void setASTConstant(const std::shared_ptr<AST::Constant> &newAstConstant) {
+    void setASTConstant(std::unique_ptr<AST::Constant> newAstConstant) {
         if (!newAstConstant) {
             throw std::logic_error("Setting ConstantValue astConstant to null");
         }
-        this->astConstant = newAstConstant;
+        this->astConstant = std::move(newAstConstant);
     }
 };
 
@@ -212,7 +212,7 @@ class ReturnInstruction : public Instruction {
     /**
      * The return value of the instruction.
      */
-    std::shared_ptr<Value> returnValue;
+    std::unique_ptr<Value> returnValue;
 
   public:
     /**
@@ -221,24 +221,22 @@ class ReturnInstruction : public Instruction {
      * @param returnValue The return value of the instruction.
      * @throws std::logic_error if `returnValue` is null.
      */
-    explicit ReturnInstruction(const std::shared_ptr<Value> &returnValue)
-        : returnValue(returnValue) {
+    explicit ReturnInstruction(std::unique_ptr<Value> returnValue)
+        : returnValue(std::move(returnValue)) {
         if (!returnValue) {
             throw std::logic_error(
                 "Creating ReturnInstruction with null returnValue");
         }
     }
 
-    [[nodiscard]] std::shared_ptr<Value> getReturnValue() const {
-        return returnValue;
-    }
+    [[nodiscard]] Value *getReturnValue() const { return returnValue.get(); }
 
-    void setReturnValue(const std::shared_ptr<Value> &newReturnValue) {
+    void setReturnValue(std::unique_ptr<Value> newReturnValue) {
         if (!newReturnValue) {
             throw std::logic_error(
                 "Setting ReturnInstruction returnValue to null");
         }
-        this->returnValue = newReturnValue;
+        this->returnValue = std::move(newReturnValue);
     }
 };
 
@@ -250,7 +248,7 @@ class SignExtendInstruction : public Instruction {
     /**
      * The source and destination values of the instruction.
      */
-    std::shared_ptr<Value> src, dst;
+    std::unique_ptr<Value> src, dst;
 
   public:
     /**
@@ -261,9 +259,9 @@ class SignExtendInstruction : public Instruction {
      * @param dst The destination value of the instruction.
      * @throws std::logic_error if `src` or `dst` is null.
      */
-    SignExtendInstruction(const std::shared_ptr<Value> &src,
-                          const std::shared_ptr<Value> &dst)
-        : src(src), dst(dst) {
+    SignExtendInstruction(std::unique_ptr<Value> src,
+                          std::unique_ptr<Value> dst)
+        : src(std::move(src)), dst(std::move(dst)) {
         if (!src) {
             throw std::logic_error("Creating SignExtendInstruction with null "
                                    "src");
@@ -274,22 +272,22 @@ class SignExtendInstruction : public Instruction {
         }
     }
 
-    [[nodiscard]] std::shared_ptr<Value> getSrc() const { return src; }
+    [[nodiscard]] Value *getSrc() const { return src.get(); }
 
-    [[nodiscard]] std::shared_ptr<Value> getDst() const { return dst; }
+    [[nodiscard]] Value *getDst() const { return dst.get(); }
 
-    void setSrc(const std::shared_ptr<Value> &newSrc) {
+    void setSrc(std::unique_ptr<Value> newSrc) {
         if (!newSrc) {
             throw std::logic_error("Setting SignExtendInstruction src to null");
         }
-        this->src = newSrc;
+        this->src = std::move(newSrc);
     }
 
-    void setDst(const std::shared_ptr<Value> &newDst) {
+    void setDst(std::unique_ptr<Value> newDst) {
         if (!newDst) {
             throw std::logic_error("Setting SignExtendInstruction dst to null");
         }
-        this->dst = newDst;
+        this->dst = std::move(newDst);
     }
 };
 
@@ -301,7 +299,7 @@ class TruncateInstruction : public Instruction {
     /**
      * The source and destination values of the instruction.
      */
-    std::shared_ptr<Value> src, dst;
+    std::unique_ptr<Value> src, dst;
 
   public:
     /**
@@ -312,9 +310,8 @@ class TruncateInstruction : public Instruction {
      * @param dst The destination value of the instruction.
      * @throws std::logic_error if `src` or `dst` is null.
      */
-    TruncateInstruction(const std::shared_ptr<Value> &src,
-                        const std::shared_ptr<Value> &dst)
-        : src(src), dst(dst) {
+    TruncateInstruction(std::unique_ptr<Value> src, std::unique_ptr<Value> dst)
+        : src(std::move(src)), dst(std::move(dst)) {
         if (!src) {
             throw std::logic_error(
                 "Creating TruncateInstruction with null src");
@@ -325,22 +322,22 @@ class TruncateInstruction : public Instruction {
         }
     }
 
-    [[nodiscard]] std::shared_ptr<Value> getSrc() const { return src; }
+    [[nodiscard]] Value *getSrc() const { return src.get(); }
 
-    [[nodiscard]] std::shared_ptr<Value> getDst() const { return dst; }
+    [[nodiscard]] Value *getDst() const { return dst.get(); }
 
-    void setSrc(const std::shared_ptr<Value> &newSrc) {
+    void setSrc(std::unique_ptr<Value> newSrc) {
         if (!newSrc) {
             throw std::logic_error("Setting TruncateInstruction src to null");
         }
-        this->src = newSrc;
+        this->src = std::move(newSrc);
     }
 
-    void setDst(const std::shared_ptr<Value> &newDst) {
+    void setDst(std::unique_ptr<Value> newDst) {
         if (!newDst) {
             throw std::logic_error("Setting TruncateInstruction dst to null");
         }
-        this->dst = newDst;
+        this->dst = std::move(newDst);
     }
 };
 
@@ -352,11 +349,11 @@ class UnaryInstruction : public Instruction {
     /**
      * The unary operator of the instruction.
      */
-    std::shared_ptr<UnaryOperator> unaryOperator;
+    std::unique_ptr<UnaryOperator> unaryOperator;
     /**
      * The source and destination values of the instruction.
      */
-    std::shared_ptr<Value> src, dst;
+    std::unique_ptr<Value> src, dst;
 
   public:
     /**
@@ -368,10 +365,10 @@ class UnaryInstruction : public Instruction {
      * @param dst The destination value of the instruction.
      * @throws std::logic_error if `unaryOperator`, `src`, or `dst` is null.
      */
-    UnaryInstruction(const std::shared_ptr<UnaryOperator> &unaryOperator,
-                     const std::shared_ptr<Value> &src,
-                     const std::shared_ptr<Value> &dst)
-        : unaryOperator(unaryOperator), src(src), dst(dst) {
+    UnaryInstruction(std::unique_ptr<UnaryOperator> unaryOperator,
+                     std::unique_ptr<Value> src, std::unique_ptr<Value> dst)
+        : unaryOperator(std::move(unaryOperator)), src(std::move(src)),
+          dst(std::move(dst)) {
         if (!unaryOperator) {
             throw std::logic_error(
                 "Creating UnaryInstruction with null unaryOperator");
@@ -384,35 +381,34 @@ class UnaryInstruction : public Instruction {
         }
     }
 
-    [[nodiscard]] std::shared_ptr<UnaryOperator> getUnaryOperator() const {
-        return unaryOperator;
+    [[nodiscard]] UnaryOperator *getUnaryOperator() const {
+        return unaryOperator.get();
     }
 
-    [[nodiscard]] std::shared_ptr<Value> getSrc() const { return src; }
+    [[nodiscard]] Value *getSrc() const { return src.get(); }
 
-    [[nodiscard]] std::shared_ptr<Value> getDst() const { return dst; }
+    [[nodiscard]] Value *getDst() const { return dst.get(); }
 
-    void
-    setUnaryOperator(const std::shared_ptr<UnaryOperator> &newUnaryOperator) {
+    void setUnaryOperator(std::unique_ptr<UnaryOperator> newUnaryOperator) {
         if (!newUnaryOperator) {
             throw std::logic_error(
                 "Setting UnaryInstruction unaryOperator to null");
         }
-        this->unaryOperator = newUnaryOperator;
+        this->unaryOperator = std::move(newUnaryOperator);
     }
 
-    void setSrc(const std::shared_ptr<Value> &newSrc) {
+    void setSrc(std::unique_ptr<Value> newSrc) {
         if (!newSrc) {
             throw std::logic_error("Setting UnaryInstruction src to null");
         }
-        this->src = newSrc;
+        this->src = std::move(newSrc);
     }
 
-    void setDst(const std::shared_ptr<Value> &newDst) {
+    void setDst(std::unique_ptr<Value> newDst) {
         if (!newDst) {
             throw std::logic_error("Setting UnaryInstruction dst to null");
         }
-        this->dst = newDst;
+        this->dst = std::move(newDst);
     }
 };
 
@@ -424,11 +420,11 @@ class BinaryInstruction : public Instruction {
     /**
      * The binary operator of the instruction.
      */
-    std::shared_ptr<BinaryOperator> binaryOperator;
+    std::unique_ptr<BinaryOperator> binaryOperator;
     /**
      * The source and destination values of the instruction.
      */
-    std::shared_ptr<Value> src1, src2, dst;
+    std::unique_ptr<Value> src1, src2, dst;
 
   public:
     /**
@@ -442,11 +438,11 @@ class BinaryInstruction : public Instruction {
      * @throws std::logic_error if `binaryOperator`, `src1`, `src2`, or `dst`
      * is null.
      */
-    BinaryInstruction(const std::shared_ptr<BinaryOperator> &binaryOperator,
-                      const std::shared_ptr<Value> &src1,
-                      const std::shared_ptr<Value> &src2,
-                      const std::shared_ptr<Value> &dst)
-        : binaryOperator(binaryOperator), src1(src1), src2(src2), dst(dst) {
+    BinaryInstruction(std::unique_ptr<BinaryOperator> binaryOperator,
+                      std::unique_ptr<Value> src1, std::unique_ptr<Value> src2,
+                      std::unique_ptr<Value> dst)
+        : binaryOperator(std::move(binaryOperator)), src1(std::move(src1)),
+          src2(std::move(src2)), dst(std::move(dst)) {
         if (!binaryOperator) {
             throw std::logic_error(
                 "Creating BinaryInstruction with null binaryOperator");
@@ -462,44 +458,43 @@ class BinaryInstruction : public Instruction {
         }
     }
 
-    [[nodiscard]] std::shared_ptr<BinaryOperator> getBinaryOperator() const {
-        return binaryOperator;
+    [[nodiscard]] BinaryOperator *getBinaryOperator() const {
+        return binaryOperator.get();
     }
 
-    [[nodiscard]] std::shared_ptr<Value> getSrc1() const { return src1; }
+    [[nodiscard]] Value *getSrc1() const { return src1.get(); }
 
-    [[nodiscard]] std::shared_ptr<Value> getSrc2() const { return src2; }
+    [[nodiscard]] Value *getSrc2() const { return src2.get(); }
 
-    [[nodiscard]] std::shared_ptr<Value> getDst() const { return dst; }
+    [[nodiscard]] Value *getDst() const { return dst.get(); }
 
-    void setBinaryOperator(
-        const std::shared_ptr<BinaryOperator> &newBinaryOperator) {
+    void setBinaryOperator(std::unique_ptr<BinaryOperator> newBinaryOperator) {
         if (!newBinaryOperator) {
             throw std::logic_error(
                 "Setting BinaryInstruction binaryOperator to null");
         }
-        this->binaryOperator = newBinaryOperator;
+        this->binaryOperator = std::move(newBinaryOperator);
     }
 
-    void setSrc1(const std::shared_ptr<Value> &newSrc1) {
+    void setSrc1(std::unique_ptr<Value> newSrc1) {
         if (!newSrc1) {
             throw std::logic_error("Setting BinaryInstruction src1 to null");
         }
-        this->src1 = newSrc1;
+        this->src1 = std::move(newSrc1);
     }
 
-    void setSrc2(const std::shared_ptr<Value> &newSrc2) {
+    void setSrc2(std::unique_ptr<Value> newSrc2) {
         if (!newSrc2) {
             throw std::logic_error("Setting BinaryInstruction src2 to null");
         }
-        this->src2 = newSrc2;
+        this->src2 = std::move(newSrc2);
     }
 
-    void setDst(const std::shared_ptr<Value> &newDst) {
+    void setDst(std::unique_ptr<Value> newDst) {
         if (!newDst) {
             throw std::logic_error("Setting BinaryInstruction dst to null");
         }
-        this->dst = newDst;
+        this->dst = std::move(newDst);
     }
 };
 
@@ -511,7 +506,7 @@ class CopyInstruction : public Instruction {
     /**
      * The source and destination values of the instruction.
      */
-    std::shared_ptr<Value> src, dst;
+    std::unique_ptr<Value> src, dst;
 
   public:
     /**
@@ -522,9 +517,8 @@ class CopyInstruction : public Instruction {
      * @param dst The destination value of the instruction.
      * @throws std::logic_error if `src` or `dst` is null.
      */
-    CopyInstruction(const std::shared_ptr<Value> &src,
-                    const std::shared_ptr<Value> &dst)
-        : src(src), dst(dst) {
+    CopyInstruction(std::unique_ptr<Value> src, std::unique_ptr<Value> dst)
+        : src(std::move(src)), dst(std::move(dst)) {
         if (!src) {
             throw std::logic_error("Creating CopyInstruction with null src");
         }
@@ -533,22 +527,22 @@ class CopyInstruction : public Instruction {
         }
     }
 
-    [[nodiscard]] std::shared_ptr<Value> getSrc() const { return src; }
+    [[nodiscard]] Value *getSrc() const { return src.get(); }
 
-    [[nodiscard]] std::shared_ptr<Value> getDst() const { return dst; }
+    [[nodiscard]] Value *getDst() const { return dst.get(); }
 
-    void setSrc(const std::shared_ptr<Value> &newSrc) {
+    void setSrc(std::unique_ptr<Value> newSrc) {
         if (!newSrc) {
             throw std::logic_error("Setting CopyInstruction src to null");
         }
-        this->src = newSrc;
+        this->src = std::move(newSrc);
     }
 
-    void setDst(const std::shared_ptr<Value> &newDst) {
+    void setDst(std::unique_ptr<Value> newDst) {
         if (!newDst) {
             throw std::logic_error("Setting CopyInstruction dst to null");
         }
-        this->dst = newDst;
+        this->dst = std::move(newDst);
     }
 };
 
@@ -583,7 +577,7 @@ class JumpIfZeroInstruction : public Instruction {
     /**
      * The condition value of the jump instruction.
      */
-    std::shared_ptr<Value> condition;
+    std::unique_ptr<Value> condition;
     /**
      * The target label of the jump instruction.
      */
@@ -598,27 +592,25 @@ class JumpIfZeroInstruction : public Instruction {
      * @param target The target label of the jump instruction.
      * @throws std::logic_error if `condition` is null.
      */
-    JumpIfZeroInstruction(const std::shared_ptr<Value> &condition,
+    JumpIfZeroInstruction(std::unique_ptr<Value> condition,
                           std::string_view target)
-        : condition(condition), target(target) {
+        : condition(std::move(condition)), target(target) {
         if (!condition) {
             throw std::logic_error(
                 "Creating JumpIfZeroInstruction with null condition");
         }
     }
 
-    [[nodiscard]] std::shared_ptr<Value> getCondition() const {
-        return condition;
-    }
+    [[nodiscard]] Value *getCondition() const { return condition.get(); }
 
     [[nodiscard]] const std::string &getTarget() const { return target; }
 
-    void setCondition(const std::shared_ptr<Value> &newCondition) {
+    void setCondition(std::unique_ptr<Value> newCondition) {
         if (!newCondition) {
             throw std::logic_error(
                 "Setting JumpIfZeroInstruction condition to null");
         }
-        this->condition = newCondition;
+        this->condition = std::move(newCondition);
     }
 
     void setTarget(std::string_view newTarget) { this->target = newTarget; }
@@ -632,7 +624,7 @@ class JumpIfNotZeroInstruction : public Instruction {
     /**
      * The condition value of the jump instruction.
      */
-    std::shared_ptr<Value> condition;
+    std::unique_ptr<Value> condition;
     /**
      * The target label of the jump instruction.
      */
@@ -647,27 +639,25 @@ class JumpIfNotZeroInstruction : public Instruction {
      * @param target The target label of the jump instruction.
      * @throws std::logic_error if `condition` is null.
      */
-    JumpIfNotZeroInstruction(const std::shared_ptr<Value> &condition,
+    JumpIfNotZeroInstruction(std::unique_ptr<Value> condition,
                              std::string_view target)
-        : condition(condition), target(target) {
+        : condition(std::move(condition)), target(target) {
         if (!condition) {
             throw std::logic_error(
                 "Creating JumpIfNotZeroInstruction with null condition");
         }
     }
 
-    [[nodiscard]] std::shared_ptr<Value> getCondition() const {
-        return condition;
-    }
+    [[nodiscard]] Value *getCondition() const { return condition.get(); }
 
     [[nodiscard]] const std::string &getTarget() const { return target; }
 
-    void setCondition(const std::shared_ptr<Value> &newCondition) {
+    void setCondition(std::unique_ptr<Value> newCondition) {
         if (!newCondition) {
             throw std::logic_error(
                 "Setting JumpIfNotZeroInstruction condition to null");
         }
-        this->condition = newCondition;
+        this->condition = std::move(newCondition);
     }
 
     void setTarget(std::string_view newTarget) { this->target = newTarget; }
@@ -708,11 +698,11 @@ class FunctionCallInstruction : public Instruction {
     /**
      * The argument values of the instruction.
      */
-    std::shared_ptr<std::vector<std::shared_ptr<Value>>> args;
+    std::unique_ptr<std::vector<std::unique_ptr<Value>>> args;
     /**
      * The destination value of the instruction.
      */
-    std::shared_ptr<Value> dst;
+    std::unique_ptr<Value> dst;
 
   public:
     /**
@@ -726,9 +716,10 @@ class FunctionCallInstruction : public Instruction {
      */
     FunctionCallInstruction(
         std::string_view functionIdentifier,
-        const std::shared_ptr<std::vector<std::shared_ptr<Value>>> &args,
-        const std::shared_ptr<Value> &dst)
-        : functionIdentifier(functionIdentifier), args(args), dst(dst) {
+        std::unique_ptr<std::vector<std::unique_ptr<Value>>> args,
+        std::unique_ptr<Value> dst)
+        : functionIdentifier(functionIdentifier), args(std::move(args)),
+          dst(std::move(dst)) {
         if (!args) {
             throw std::logic_error(
                 "Creating FunctionCallInstruction with null args");
@@ -743,32 +734,30 @@ class FunctionCallInstruction : public Instruction {
         return functionIdentifier;
     }
 
-    [[nodiscard]] const std::shared_ptr<std::vector<std::shared_ptr<Value>>> &
-    getArgs() const {
-        return args;
+    [[nodiscard]] const std::vector<std::unique_ptr<Value>> &getArgs() const {
+        return *args;
     }
 
-    [[nodiscard]] std::shared_ptr<Value> getDst() const { return dst; }
+    [[nodiscard]] Value *getDst() const { return dst.get(); }
 
     void setFunctionIdentifier(std::string_view newFunctionIdentifier) {
         this->functionIdentifier = newFunctionIdentifier;
     }
 
-    void setArgs(
-        const std::shared_ptr<std::vector<std::shared_ptr<Value>>> &newArgs) {
+    void setArgs(std::unique_ptr<std::vector<std::unique_ptr<Value>>> newArgs) {
         if (!newArgs) {
             throw std::logic_error(
                 "Setting FunctionCallInstruction args to null");
         }
-        this->args = newArgs;
+        this->args = std::move(newArgs);
     }
 
-    void setDst(const std::shared_ptr<Value> &newDst) {
+    void setDst(std::unique_ptr<Value> newDst) {
         if (!newDst) {
             throw std::logic_error(
                 "Setting FunctionCallInstruction dst to null");
         }
-        this->dst = newDst;
+        this->dst = std::move(newDst);
     }
 };
 
@@ -799,11 +788,11 @@ class FunctionDefinition : public TopLevel {
     /**
      * The parameter identifiers of the function definition.
      */
-    std::shared_ptr<std::vector<std::string>> parameters;
+    std::unique_ptr<std::vector<std::string>> parameters;
     /**
      * The function body of the function definition.
      */
-    std::shared_ptr<std::vector<std::shared_ptr<Instruction>>> functionBody;
+    std::unique_ptr<std::vector<std::unique_ptr<Instruction>>> functionBody;
 
   public:
     /**
@@ -819,11 +808,11 @@ class FunctionDefinition : public TopLevel {
      */
     FunctionDefinition(
         std::string_view functionIdentifier, bool global,
-        const std::shared_ptr<std::vector<std::string>> &parameters,
-        const std::shared_ptr<std::vector<std::shared_ptr<Instruction>>>
-            &functionBody)
+        std::unique_ptr<std::vector<std::string>> parameters,
+        std::unique_ptr<std::vector<std::unique_ptr<Instruction>>> functionBody)
         : functionIdentifier(functionIdentifier), global(global),
-          parameters(parameters), functionBody(functionBody) {
+          parameters(std::move(parameters)),
+          functionBody(std::move(functionBody)) {
         if (!parameters) {
             throw std::logic_error(
                 "Creating FunctionDefinition with null parameters");
@@ -840,25 +829,24 @@ class FunctionDefinition : public TopLevel {
 
     [[nodiscard]] bool isGlobal() const { return global; }
 
-    [[nodiscard]] const std::shared_ptr<std::vector<std::string>> &
+    [[nodiscard]] const std::vector<std::string> &
     getParameterIdentifiers() const {
-        return parameters;
+        return *parameters;
     }
 
-    [[nodiscard]] const std::shared_ptr<
-        std::vector<std::shared_ptr<Instruction>>> &
+    [[nodiscard]] const std::vector<std::unique_ptr<Instruction>> &
     getFunctionBody() const {
-        return functionBody;
+        return *functionBody;
     }
 
-    void setFunctionBody(
-        const std::shared_ptr<std::vector<std::shared_ptr<Instruction>>>
-            &newFunctionBody) {
+    void
+    setFunctionBody(std::unique_ptr<std::vector<std::unique_ptr<Instruction>>>
+                        newFunctionBody) {
         if (!newFunctionBody) {
             throw std::logic_error(
                 "Setting FunctionDefinition functionBody to null");
         }
-        this->functionBody = newFunctionBody;
+        this->functionBody = std::move(newFunctionBody);
     }
 };
 
@@ -878,11 +866,11 @@ class StaticVariable : public TopLevel {
     /**
      * The type of the static variable.
      */
-    std::shared_ptr<AST::Type> type;
+    std::unique_ptr<AST::Type> type;
     /**
      * The static initialization of the static variable.
      */
-    std::shared_ptr<AST::StaticInit> staticInit;
+    std::unique_ptr<AST::StaticInit> staticInit;
 
   public:
     /**
@@ -896,10 +884,10 @@ class StaticVariable : public TopLevel {
      * @throws std::logic_error if `type` or `staticInit` is null.
      */
     StaticVariable(std::string_view identifier, bool global,
-                   const std::shared_ptr<AST::Type> &type,
-                   const std::shared_ptr<AST::StaticInit> &staticInit)
-        : identifier(identifier), global(global), type(type),
-          staticInit(staticInit) {
+                   std::unique_ptr<AST::Type> type,
+                   std::unique_ptr<AST::StaticInit> staticInit)
+        : identifier(identifier), global(global), type(std::move(type)),
+          staticInit(std::move(staticInit)) {
         if (!type) {
             throw std::logic_error("Creating StaticVariable with null type");
         }
@@ -915,10 +903,10 @@ class StaticVariable : public TopLevel {
 
     [[nodiscard]] bool isGlobal() const { return global; }
 
-    [[nodiscard]] std::shared_ptr<AST::Type> getType() const { return type; }
+    [[nodiscard]] const AST::Type *getType() const { return type.get(); }
 
-    [[nodiscard]] std::shared_ptr<AST::StaticInit> getStaticInit() const {
-        return staticInit;
+    [[nodiscard]] const AST::StaticInit *getStaticInit() const {
+        return staticInit.get();
     }
 };
 
@@ -930,7 +918,7 @@ class Program {
     /**
      * The top-level constructs of the program.
      */
-    std::shared_ptr<std::vector<std::shared_ptr<TopLevel>>> topLevels;
+    std::unique_ptr<std::vector<std::unique_ptr<TopLevel>>> topLevels;
 
   public:
     /**
@@ -940,18 +928,20 @@ class Program {
      * @throws std::logic_error if `topLevels` is null.
      */
     explicit Program(
-        const std::shared_ptr<std::vector<std::shared_ptr<TopLevel>>>
-            &topLevels)
-        : topLevels(topLevels) {
+        std::unique_ptr<std::vector<std::unique_ptr<TopLevel>>> topLevels)
+        : topLevels(std::move(topLevels)) {
         if (!topLevels) {
             throw std::logic_error("Creating Program with null topLevels");
         }
     }
 
-    [[nodiscard]] const std::shared_ptr<
-        std::vector<std::shared_ptr<TopLevel>>> &
+    [[nodiscard]] const std::vector<std::unique_ptr<TopLevel>> &
     getTopLevels() const {
-        return topLevels;
+        return *topLevels;
+    }
+
+    [[nodiscard]] std::vector<std::unique_ptr<TopLevel>> &getTopLevels() {
+        return *topLevels;
     }
 };
 } // namespace IR

--- a/src/midend/ir.h
+++ b/src/midend/ir.h
@@ -136,7 +136,7 @@ class ConstantValue : public Value {
      */
     explicit ConstantValue(std::unique_ptr<AST::Constant> astConstant)
         : astConstant(std::move(astConstant)) {
-        if (!astConstant) {
+        if (!this->astConstant) {
             throw std::logic_error(
                 "Creating ConstantValue with null astConstant");
         }
@@ -223,7 +223,7 @@ class ReturnInstruction : public Instruction {
      */
     explicit ReturnInstruction(std::unique_ptr<Value> returnValue)
         : returnValue(std::move(returnValue)) {
-        if (!returnValue) {
+        if (!this->returnValue) {
             throw std::logic_error(
                 "Creating ReturnInstruction with null returnValue");
         }
@@ -262,11 +262,11 @@ class SignExtendInstruction : public Instruction {
     SignExtendInstruction(std::unique_ptr<Value> src,
                           std::unique_ptr<Value> dst)
         : src(std::move(src)), dst(std::move(dst)) {
-        if (!src) {
+        if (!this->src) {
             throw std::logic_error("Creating SignExtendInstruction with null "
                                    "src");
         }
-        if (!dst) {
+        if (!this->dst) {
             throw std::logic_error("Creating SignExtendInstruction with null "
                                    "dst");
         }
@@ -312,11 +312,11 @@ class TruncateInstruction : public Instruction {
      */
     TruncateInstruction(std::unique_ptr<Value> src, std::unique_ptr<Value> dst)
         : src(std::move(src)), dst(std::move(dst)) {
-        if (!src) {
+        if (!this->src) {
             throw std::logic_error(
                 "Creating TruncateInstruction with null src");
         }
-        if (!dst) {
+        if (!this->dst) {
             throw std::logic_error(
                 "Creating TruncateInstruction with null dst");
         }
@@ -369,14 +369,14 @@ class UnaryInstruction : public Instruction {
                      std::unique_ptr<Value> src, std::unique_ptr<Value> dst)
         : unaryOperator(std::move(unaryOperator)), src(std::move(src)),
           dst(std::move(dst)) {
-        if (!unaryOperator) {
+        if (!this->unaryOperator) {
             throw std::logic_error(
                 "Creating UnaryInstruction with null unaryOperator");
         }
-        if (!src) {
+        if (!this->src) {
             throw std::logic_error("Creating UnaryInstruction with null src");
         }
-        if (!dst) {
+        if (!this->dst) {
             throw std::logic_error("Creating UnaryInstruction with null dst");
         }
     }
@@ -443,17 +443,17 @@ class BinaryInstruction : public Instruction {
                       std::unique_ptr<Value> dst)
         : binaryOperator(std::move(binaryOperator)), src1(std::move(src1)),
           src2(std::move(src2)), dst(std::move(dst)) {
-        if (!binaryOperator) {
+        if (!this->binaryOperator) {
             throw std::logic_error(
                 "Creating BinaryInstruction with null binaryOperator");
         }
-        if (!src1) {
+        if (!this->src1) {
             throw std::logic_error("Creating BinaryInstruction with null src1");
         }
-        if (!src2) {
+        if (!this->src2) {
             throw std::logic_error("Creating BinaryInstruction with null src2");
         }
-        if (!dst) {
+        if (!this->dst) {
             throw std::logic_error("Creating BinaryInstruction with null dst");
         }
     }
@@ -519,10 +519,10 @@ class CopyInstruction : public Instruction {
      */
     CopyInstruction(std::unique_ptr<Value> src, std::unique_ptr<Value> dst)
         : src(std::move(src)), dst(std::move(dst)) {
-        if (!src) {
+        if (!this->src) {
             throw std::logic_error("Creating CopyInstruction with null src");
         }
-        if (!dst) {
+        if (!this->dst) {
             throw std::logic_error("Creating CopyInstruction with null dst");
         }
     }
@@ -595,7 +595,7 @@ class JumpIfZeroInstruction : public Instruction {
     JumpIfZeroInstruction(std::unique_ptr<Value> condition,
                           std::string_view target)
         : condition(std::move(condition)), target(target) {
-        if (!condition) {
+        if (!this->condition) {
             throw std::logic_error(
                 "Creating JumpIfZeroInstruction with null condition");
         }
@@ -642,7 +642,7 @@ class JumpIfNotZeroInstruction : public Instruction {
     JumpIfNotZeroInstruction(std::unique_ptr<Value> condition,
                              std::string_view target)
         : condition(std::move(condition)), target(target) {
-        if (!condition) {
+        if (!this->condition) {
             throw std::logic_error(
                 "Creating JumpIfNotZeroInstruction with null condition");
         }
@@ -720,11 +720,11 @@ class FunctionCallInstruction : public Instruction {
         std::unique_ptr<Value> dst)
         : functionIdentifier(functionIdentifier), args(std::move(args)),
           dst(std::move(dst)) {
-        if (!args) {
+        if (!this->args) {
             throw std::logic_error(
                 "Creating FunctionCallInstruction with null args");
         }
-        if (!dst) {
+        if (!this->dst) {
             throw std::logic_error(
                 "Creating FunctionCallInstruction with null dst");
         }
@@ -813,11 +813,11 @@ class FunctionDefinition : public TopLevel {
         : functionIdentifier(functionIdentifier), global(global),
           parameters(std::move(parameters)),
           functionBody(std::move(functionBody)) {
-        if (!parameters) {
+        if (!this->parameters) {
             throw std::logic_error(
                 "Creating FunctionDefinition with null parameters");
         }
-        if (!functionBody) {
+        if (!this->functionBody) {
             throw std::logic_error(
                 "Creating FunctionDefinition with null functionBody");
         }
@@ -888,10 +888,10 @@ class StaticVariable : public TopLevel {
                    std::unique_ptr<AST::StaticInit> staticInit)
         : identifier(identifier), global(global), type(std::move(type)),
           staticInit(std::move(staticInit)) {
-        if (!type) {
+        if (!this->type) {
             throw std::logic_error("Creating StaticVariable with null type");
         }
-        if (!staticInit) {
+        if (!this->staticInit) {
             throw std::logic_error(
                 "Creating StaticVariable with null staticInit");
         }
@@ -930,7 +930,7 @@ class Program {
     explicit Program(
         std::unique_ptr<std::vector<std::unique_ptr<TopLevel>>> topLevels)
         : topLevels(std::move(topLevels)) {
-        if (!topLevels) {
+        if (!this->topLevels) {
             throw std::logic_error("Creating Program with null topLevels");
         }
     }

--- a/src/midend/irGenerator.h
+++ b/src/midend/irGenerator.h
@@ -34,13 +34,13 @@ class IRGenerator {
      * Generate the IR from the AST program.
      *
      * @param astProgram The AST program to generate the IR from.
-     * @return A pair consisting of (a shared pointer to) the IR program and (a
-     * shared pointer to) the vector of static variables in IR.
+     * @return A pair consisting of (a unique pointer to) the IR program and (a
+     * unique pointer to) the vector of static variables in IR.
      */
     [[nodiscard]] std::pair<
-        std::shared_ptr<IR::Program>,
-        std::shared_ptr<std::vector<std::shared_ptr<IR::StaticVariable>>>>
-    generateIR(const std::shared_ptr<AST::Program> &astProgram);
+        std::unique_ptr<IR::Program>,
+        std::unique_ptr<std::vector<std::unique_ptr<IR::StaticVariable>>>>
+    generateIR(const AST::Program &astProgram);
 
   private:
     /**
@@ -60,9 +60,8 @@ class IRGenerator {
      * @param instructions The vector to store the generated IR instructions.
      */
     void generateIRBlock(
-        const std::shared_ptr<AST::Block> &astBlock,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+        const AST::Block *astBlock,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate the IR for a function definition.
@@ -72,9 +71,8 @@ class IRGenerator {
      * @param instructions The vector to store the generated IR instructions.
      */
     void generateIRFunctionDefinition(
-        const std::shared_ptr<AST::FunctionDeclaration> &astFunctionDeclaration,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+        const AST::FunctionDeclaration *astFunctionDeclaration,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate the IR for a variable definition.
@@ -84,9 +82,8 @@ class IRGenerator {
      * @param instructions The vector to store the generated IR instructions.
      */
     void generateIRVariableDefinition(
-        const std::shared_ptr<AST::VariableDeclaration> &astVariableDeclaration,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+        const AST::VariableDeclaration *astVariableDeclaration,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate the IR for a statement.
@@ -95,9 +92,8 @@ class IRGenerator {
      * @param instructions The vector to store the generated IR instructions.
      */
     void generateIRStatement(
-        const std::shared_ptr<AST::Statement> &astStatement,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+        const AST::Statement *astStatement,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate the IR for a return statement.
@@ -106,9 +102,8 @@ class IRGenerator {
      * @param instructions The vector to store the generated IR instructions.
      */
     void generateIRReturnStatement(
-        const std::shared_ptr<AST::ReturnStatement> &returnStmt,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+        const AST::ReturnStatement *returnStmt,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate the IR for an expression statement.
@@ -117,9 +112,8 @@ class IRGenerator {
      * @param instructions The vector to store the generated IR instructions.
      */
     void generateIRExpressionStatement(
-        const std::shared_ptr<AST::ExpressionStatement> &expressionStmt,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+        const AST::ExpressionStatement *expressionStmt,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate the IR for an if statement.
@@ -128,9 +122,8 @@ class IRGenerator {
      * @param instructions The vector to store the generated IR instructions.
      */
     void generateIRIfStatement(
-        const std::shared_ptr<AST::IfStatement> &ifStmt,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+        const AST::IfStatement *ifStmt,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate the IR for a break statement.
@@ -139,9 +132,8 @@ class IRGenerator {
      * @param instructions The vector to store the generated IR instructions.
      */
     void generateIRBreakStatement(
-        const std::shared_ptr<AST::BreakStatement> &breakStmt,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+        const AST::BreakStatement *breakStmt,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate the IR for a continue statement.
@@ -150,9 +142,8 @@ class IRGenerator {
      * @param instructions The vector to store the generated IR instructions.
      */
     void generateIRContinueStatement(
-        const std::shared_ptr<AST::ContinueStatement> &continueStmt,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+        const AST::ContinueStatement *continueStmt,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate the IR for a while statement.
@@ -161,9 +152,8 @@ class IRGenerator {
      * @param instructions The vector to store the generated IR instructions.
      */
     void generateIRWhileStatement(
-        const std::shared_ptr<AST::WhileStatement> &whileStmt,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+        const AST::WhileStatement *whileStmt,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate the IR for a do-while statement.
@@ -172,9 +162,8 @@ class IRGenerator {
      * @param instructions The vector to store the generated IR instructions.
      */
     void generateIRDoWhileStatement(
-        const std::shared_ptr<AST::DoWhileStatement> &doWhileStmt,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+        const AST::DoWhileStatement *doWhileStmt,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate the IR for a for statement.
@@ -183,9 +172,8 @@ class IRGenerator {
      * @param instructions The vector to store the generated IR instructions.
      */
     void generateIRForStatement(
-        const std::shared_ptr<AST::ForStatement> &forStmt,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+        const AST::ForStatement *forStmt,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate the IR for an expression.
@@ -194,10 +182,9 @@ class IRGenerator {
      * @param instructions The vector to store the generated IR instructions.
      * @return The generated IR value.
      */
-    [[nodiscard]] std::shared_ptr<IR::Value> generateIRInstruction(
-        const std::shared_ptr<AST::Expression> &e,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+    [[nodiscard]] std::unique_ptr<IR::Value> generateIRInstruction(
+        const AST::Expression *e,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate the IR for a unary expression.
@@ -206,10 +193,9 @@ class IRGenerator {
      * @param instructions The vector to store the generated IR instructions.
      * @return The generated IR variable value.
      */
-    [[nodiscard]] std::shared_ptr<IR::VariableValue> generateIRUnaryInstruction(
-        const std::shared_ptr<AST::UnaryExpression> &unaryExpr,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+    [[nodiscard]] std::unique_ptr<IR::VariableValue> generateIRUnaryInstruction(
+        const AST::UnaryExpression *unaryExpr,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate the IR for a binary expression.
@@ -218,11 +204,10 @@ class IRGenerator {
      * @param instructions The vector to store the generated IR instructions.
      * @return The generated IR variable value.
      */
-    [[nodiscard]] std::shared_ptr<IR::VariableValue>
+    [[nodiscard]] std::unique_ptr<IR::VariableValue>
     generateIRBinaryInstruction(
-        const std::shared_ptr<AST::BinaryExpression> &binaryExpr,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+        const AST::BinaryExpression *binaryExpr,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate the IR for a logical-and binary expression.
@@ -231,11 +216,10 @@ class IRGenerator {
      * @param instructions The vector to store the generated IR instructions.
      * @return The generated IR variable value.
      */
-    [[nodiscard]] std::shared_ptr<IR::VariableValue>
+    [[nodiscard]] std::unique_ptr<IR::VariableValue>
     generateIRInstructionWithLogicalAnd(
-        const std::shared_ptr<AST::BinaryExpression> &binaryExpr,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+        const AST::BinaryExpression *binaryExpr,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate the IR for a logical-or binary expression.
@@ -244,11 +228,10 @@ class IRGenerator {
      * @param instructions The vector to store the generated IR instructions.
      * @return The generated IR variable value.
      */
-    [[nodiscard]] std::shared_ptr<IR::VariableValue>
+    [[nodiscard]] std::unique_ptr<IR::VariableValue>
     generateIRInstructionWithLogicalOr(
-        const std::shared_ptr<AST::BinaryExpression> &binaryExpr,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+        const AST::BinaryExpression *binaryExpr,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate a copy instruction in the IR.
@@ -258,10 +241,8 @@ class IRGenerator {
      * @param instructions The vector to store the generated IR instructions.
      */
     void generateIRCopyInstruction(
-        const std::shared_ptr<IR::Value> &src,
-        const std::shared_ptr<IR::Value> &dst,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+        std::unique_ptr<IR::Value> src, std::unique_ptr<IR::Value> dst,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate a jump instruction in the IR.
@@ -271,8 +252,7 @@ class IRGenerator {
      */
     void generateIRJumpInstruction(
         std::string_view target,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate a jump-if-zero instruction in the IR.
@@ -282,9 +262,8 @@ class IRGenerator {
      * @param instructions The vector to store the generated IR instructions.
      */
     void generateIRJumpIfZeroInstruction(
-        const std::shared_ptr<IR::Value> &condition, std::string_view target,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+        std::unique_ptr<IR::Value> condition, std::string_view target,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate a jump-if-not-zero instruction in the IR.
@@ -294,9 +273,8 @@ class IRGenerator {
      * @param instructions The vector to store the generated IR instructions.
      */
     void generateIRJumpIfNotZeroInstruction(
-        const std::shared_ptr<IR::Value> &condition, std::string_view target,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+        std::unique_ptr<IR::Value> condition, std::string_view target,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate a label instruction in the IR.
@@ -306,8 +284,7 @@ class IRGenerator {
      */
     void generateIRLabelInstruction(
         std::string_view identifier,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate a function call instruction in the IR.
@@ -318,12 +295,11 @@ class IRGenerator {
      * @return The generated IR variable value representing the return value
      * of the function call.
      */
-    [[nodiscard]] std::shared_ptr<IR::VariableValue>
+    [[nodiscard]] std::unique_ptr<IR::VariableValue>
     generateIRFunctionCallInstruction(
         std::string_view functionIdentifier,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Value>>> &args,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+        std::unique_ptr<std::vector<std::unique_ptr<IR::Value>>> args,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate the IR for a cast expression.
@@ -332,10 +308,9 @@ class IRGenerator {
      * @param instructions The vector to store the generated IR instructions.
      * @return The generated IR variable value.
      */
-    [[nodiscard]] std::shared_ptr<IR::VariableValue> generateIRCastInstruction(
-        const std::shared_ptr<AST::CastExpression> &castExpr,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &instructions);
+    [[nodiscard]] std::unique_ptr<IR::VariableValue> generateIRCastInstruction(
+        const AST::CastExpression *castExpr,
+        std::vector<std::unique_ptr<IR::Instruction>> &instructions);
 
     /**
      * Generate a temporary variable name.
@@ -414,10 +389,10 @@ class IRGenerator {
     /**
      * Convert the frontend symbol table to IR static variables.
      *
-     * @return A shared pointer to a vector of IR static variables.
+     * @return A unique pointer to a vector of IR static variables.
      */
-    [[nodiscard]] std::shared_ptr<
-        std::vector<std::shared_ptr<IR::StaticVariable>>>
+    [[nodiscard]] std::unique_ptr<
+        std::vector<std::unique_ptr<IR::StaticVariable>>>
     convertFrontendSymbolTableToIRStaticVariables();
 
     /**
@@ -427,8 +402,8 @@ class IRGenerator {
      * @param op The unary operator in the AST.
      * @return The corresponding IR unary operator.
      */
-    [[nodiscard]] std::shared_ptr<IR::UnaryOperator>
-    convertUnop(const std::shared_ptr<AST::UnaryOperator> &op);
+    [[nodiscard]] std::unique_ptr<IR::UnaryOperator>
+    convertUnop(const AST::UnaryOperator *op);
 
     /**
      * Convert the binary operator in the binary expression to a IR binary
@@ -437,8 +412,8 @@ class IRGenerator {
      * @param op The binary operator in the AST.
      * @return The corresponding IR binary operator.
      */
-    [[nodiscard]] std::shared_ptr<IR::BinaryOperator>
-    convertBinop(const std::shared_ptr<AST::BinaryOperator> &op);
+    [[nodiscard]] std::unique_ptr<IR::BinaryOperator>
+    convertBinop(const AST::BinaryOperator *op);
 
     /**
      * Generate an IR variable for the result of a binary expression.
@@ -446,8 +421,8 @@ class IRGenerator {
      * @param binaryExpr The AST node representing the binary expression.
      * @return The generated IR variable value.
      */
-    [[nodiscard]] std::shared_ptr<IR::VariableValue> generateIRVariable(
-        const std::shared_ptr<AST::BinaryExpression> &binaryExpr);
+    [[nodiscard]] std::unique_ptr<IR::VariableValue>
+    generateIRVariable(const AST::BinaryExpression *binaryExpr);
 };
 } // namespace IR
 

--- a/src/midend/irOptimizationPasses.cpp
+++ b/src/midend/irOptimizationPasses.cpp
@@ -1,661 +1,222 @@
 #include "irOptimizationPasses.h"
-#include <limits>
 
 namespace IR {
-// Helper function to perform optimization passes on the IR function definition.
-std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
+namespace {
+std::unique_ptr<AST::Constant> cloneASTConstant(const AST::Constant *constant) {
+    if (auto intConst = dynamic_cast<const AST::ConstantInt *>(constant)) {
+        return std::make_unique<AST::ConstantInt>(intConst->getValue());
+    }
+    if (auto longConst = dynamic_cast<const AST::ConstantLong *>(constant)) {
+        return std::make_unique<AST::ConstantLong>(longConst->getValue());
+    }
+    throw std::logic_error("Unsupported AST constant in cloneASTConstant");
+}
+
+std::unique_ptr<IR::Value> cloneValue(const IR::Value *value) {
+    if (auto constantValue = dynamic_cast<const IR::ConstantValue *>(value)) {
+        return std::make_unique<IR::ConstantValue>(
+            cloneASTConstant(constantValue->getASTConstant()));
+    }
+    if (auto variableValue = dynamic_cast<const IR::VariableValue *>(value)) {
+        return std::make_unique<IR::VariableValue>(
+            variableValue->getIdentifier());
+    }
+    throw std::logic_error("Unsupported IR value in cloneValue");
+}
+
+std::unique_ptr<IR::UnaryOperator>
+cloneUnaryOperator(const IR::UnaryOperator *op) {
+    if (dynamic_cast<const IR::NegateOperator *>(op)) {
+        return std::make_unique<IR::NegateOperator>();
+    }
+    if (dynamic_cast<const IR::ComplementOperator *>(op)) {
+        return std::make_unique<IR::ComplementOperator>();
+    }
+    if (dynamic_cast<const IR::NotOperator *>(op)) {
+        return std::make_unique<IR::NotOperator>();
+    }
+    throw std::logic_error("Unsupported unary operator in cloneUnaryOperator");
+}
+
+std::unique_ptr<IR::BinaryOperator>
+cloneBinaryOperator(const IR::BinaryOperator *op) {
+    if (dynamic_cast<const IR::AddOperator *>(op)) {
+        return std::make_unique<IR::AddOperator>();
+    }
+    if (dynamic_cast<const IR::SubtractOperator *>(op)) {
+        return std::make_unique<IR::SubtractOperator>();
+    }
+    if (dynamic_cast<const IR::MultiplyOperator *>(op)) {
+        return std::make_unique<IR::MultiplyOperator>();
+    }
+    if (dynamic_cast<const IR::DivideOperator *>(op)) {
+        return std::make_unique<IR::DivideOperator>();
+    }
+    if (dynamic_cast<const IR::RemainderOperator *>(op)) {
+        return std::make_unique<IR::RemainderOperator>();
+    }
+    if (dynamic_cast<const IR::EqualOperator *>(op)) {
+        return std::make_unique<IR::EqualOperator>();
+    }
+    if (dynamic_cast<const IR::NotEqualOperator *>(op)) {
+        return std::make_unique<IR::NotEqualOperator>();
+    }
+    if (dynamic_cast<const IR::LessThanOperator *>(op)) {
+        return std::make_unique<IR::LessThanOperator>();
+    }
+    if (dynamic_cast<const IR::LessThanOrEqualOperator *>(op)) {
+        return std::make_unique<IR::LessThanOrEqualOperator>();
+    }
+    if (dynamic_cast<const IR::GreaterThanOperator *>(op)) {
+        return std::make_unique<IR::GreaterThanOperator>();
+    }
+    if (dynamic_cast<const IR::GreaterThanOrEqualOperator *>(op)) {
+        return std::make_unique<IR::GreaterThanOrEqualOperator>();
+    }
+    throw std::logic_error(
+        "Unsupported binary operator in cloneBinaryOperator");
+}
+
+std::unique_ptr<IR::Instruction>
+cloneInstruction(const IR::Instruction *instruction) {
+    if (auto returnInstr =
+            dynamic_cast<const IR::ReturnInstruction *>(instruction)) {
+        return std::make_unique<IR::ReturnInstruction>(
+            cloneValue(returnInstr->getReturnValue()));
+    }
+    if (auto signExtend =
+            dynamic_cast<const IR::SignExtendInstruction *>(instruction)) {
+        return std::make_unique<IR::SignExtendInstruction>(
+            cloneValue(signExtend->getSrc()), cloneValue(signExtend->getDst()));
+    }
+    if (auto truncate =
+            dynamic_cast<const IR::TruncateInstruction *>(instruction)) {
+        return std::make_unique<IR::TruncateInstruction>(
+            cloneValue(truncate->getSrc()), cloneValue(truncate->getDst()));
+    }
+    if (auto unaryInstr =
+            dynamic_cast<const IR::UnaryInstruction *>(instruction)) {
+        return std::make_unique<IR::UnaryInstruction>(
+            cloneUnaryOperator(unaryInstr->getUnaryOperator()),
+            cloneValue(unaryInstr->getSrc()), cloneValue(unaryInstr->getDst()));
+    }
+    if (auto binaryInstr =
+            dynamic_cast<const IR::BinaryInstruction *>(instruction)) {
+        return std::make_unique<IR::BinaryInstruction>(
+            cloneBinaryOperator(binaryInstr->getBinaryOperator()),
+            cloneValue(binaryInstr->getSrc1()),
+            cloneValue(binaryInstr->getSrc2()),
+            cloneValue(binaryInstr->getDst()));
+    }
+    if (auto copyInstr =
+            dynamic_cast<const IR::CopyInstruction *>(instruction)) {
+        return std::make_unique<IR::CopyInstruction>(
+            cloneValue(copyInstr->getSrc()), cloneValue(copyInstr->getDst()));
+    }
+    if (auto jumpInstr =
+            dynamic_cast<const IR::JumpInstruction *>(instruction)) {
+        return std::make_unique<IR::JumpInstruction>(jumpInstr->getTarget());
+    }
+    if (auto jumpIfZero =
+            dynamic_cast<const IR::JumpIfZeroInstruction *>(instruction)) {
+        return std::make_unique<IR::JumpIfZeroInstruction>(
+            cloneValue(jumpIfZero->getCondition()), jumpIfZero->getTarget());
+    }
+    if (auto jumpIfNotZero =
+            dynamic_cast<const IR::JumpIfNotZeroInstruction *>(instruction)) {
+        return std::make_unique<IR::JumpIfNotZeroInstruction>(
+            cloneValue(jumpIfNotZero->getCondition()),
+            jumpIfNotZero->getTarget());
+    }
+    if (auto labelInstr =
+            dynamic_cast<const IR::LabelInstruction *>(instruction)) {
+        return std::make_unique<IR::LabelInstruction>(labelInstr->getLabel());
+    }
+    if (auto callInstr =
+            dynamic_cast<const IR::FunctionCallInstruction *>(instruction)) {
+        auto args = std::make_unique<std::vector<std::unique_ptr<IR::Value>>>();
+        for (const auto &arg : callInstr->getArgs()) {
+            args->emplace_back(cloneValue(arg.get()));
+        }
+        return std::make_unique<IR::FunctionCallInstruction>(
+            callInstr->getFunctionIdentifier(), std::move(args),
+            cloneValue(callInstr->getDst()));
+    }
+    throw std::logic_error("Unsupported instruction in cloneInstruction");
+}
+
+std::unique_ptr<std::vector<std::unique_ptr<IR::Instruction>>>
+cloneFunctionBody(
+    const std::vector<std::unique_ptr<IR::Instruction>> &functionBody) {
+    auto cloned =
+        std::make_unique<std::vector<std::unique_ptr<IR::Instruction>>>();
+    cloned->reserve(functionBody.size());
+    for (const auto &instruction : functionBody) {
+        cloned->emplace_back(cloneInstruction(instruction.get()));
+    }
+    return cloned;
+}
+} // namespace
+
+std::unique_ptr<std::vector<std::unique_ptr<IR::Instruction>>>
 IROptimizer::irOptimize(
-    const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-        &functionBody,
+    const std::vector<std::unique_ptr<IR::Instruction>> &functionBody,
     bool foldConstantsPass, bool propagateCopiesPass,
     bool eliminateUnreachableCodePass, bool eliminateDeadStoresPass) {
-    if (functionBody->empty()) {
-        return functionBody;
+    auto currentFunctionBody = cloneFunctionBody(functionBody);
+    if (foldConstantsPass) {
+        currentFunctionBody =
+            IR::ConstantFoldingPass::foldConstants(*currentFunctionBody);
     }
-    auto currentFunctionBody = functionBody;
-    while (true) {
-        auto postConstantFoldingFunctionBody = currentFunctionBody;
-        if (foldConstantsPass) {
-            postConstantFoldingFunctionBody =
-                IR::ConstantFoldingPass::foldConstants(currentFunctionBody);
-        }
-        auto cfg =
-            IR::CFG::makeControlFlowGraph(postConstantFoldingFunctionBody);
-        if (eliminateUnreachableCodePass) {
-            cfg = IR::UnreachableCodeEliminationPass::eliminateUnreachableCode(
-                cfg);
-        }
-        if (propagateCopiesPass) {
-            cfg = IR::CopyPropagationPass::propagateCopies(cfg);
-        }
-        if (eliminateDeadStoresPass) {
-            cfg = IR::DeadStoreEliminationPass::eliminateDeadStores(cfg);
-        }
-        auto optimizedFunctionBody = IR::CFG::cfgToInstructions(cfg);
-        if (optimizedFunctionBody == currentFunctionBody ||
-            optimizedFunctionBody->empty()) {
-            return optimizedFunctionBody;
-        }
-        currentFunctionBody = optimizedFunctionBody;
+    if (eliminateUnreachableCodePass) {
+        currentFunctionBody =
+            IR::UnreachableCodeEliminationPass::eliminateUnreachableCode(
+                *currentFunctionBody);
     }
+    if (propagateCopiesPass) {
+        currentFunctionBody =
+            IR::CopyPropagationPass::propagateCopies(*currentFunctionBody);
+    }
+    if (eliminateDeadStoresPass) {
+        currentFunctionBody = IR::DeadStoreEliminationPass::eliminateDeadStores(
+            *currentFunctionBody);
+    }
+    return currentFunctionBody;
 }
 
-std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
+std::unique_ptr<std::vector<std::unique_ptr<IR::Instruction>>>
 ConstantFoldingPass::foldConstants(
-    const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-        &functionBody) {
-    auto postConstantFoldingFunctionBody = functionBody;
-    for (auto it = postConstantFoldingFunctionBody->begin();
-         it != postConstantFoldingFunctionBody->end();) {
-        auto instruction = *it;
-        // Handle unary instructions with a constant source operand.
-        if (auto unaryInstruction =
-                std::dynamic_pointer_cast<IR::UnaryInstruction>(instruction)) {
-            if (auto constantValue =
-                    std::dynamic_pointer_cast<IR::ConstantValue>(
-                        unaryInstruction->getSrc())) {
-                auto unaryOperator = unaryInstruction->getUnaryOperator();
-                auto astConstant = constantValue->getASTConstant();
-                if (std::dynamic_pointer_cast<IR::NegateOperator>(
-                        unaryOperator)) {
-                    if (auto constantInt =
-                            std::dynamic_pointer_cast<AST::ConstantInt>(
-                                astConstant)) {
-                        astConstant = std::make_shared<AST::ConstantInt>(
-                            -constantInt->getValue());
-                    }
-                    else if (auto constantLong =
-                                 std::dynamic_pointer_cast<AST::ConstantLong>(
-                                     astConstant)) {
-                        astConstant = std::make_shared<AST::ConstantLong>(
-                            -constantLong->getValue());
-                    }
-                }
-                else if (std::dynamic_pointer_cast<IR::ComplementOperator>(
-                             unaryOperator)) {
-                    if (auto constantInt =
-                            std::dynamic_pointer_cast<AST::ConstantInt>(
-                                astConstant)) {
-                        astConstant = std::make_shared<AST::ConstantInt>(
-                            ~constantInt->getValue());
-                    }
-                    else if (auto constantLong =
-                                 std::dynamic_pointer_cast<AST::ConstantLong>(
-                                     astConstant)) {
-                        astConstant = std::make_shared<AST::ConstantLong>(
-                            ~constantLong->getValue());
-                    }
-                }
-                else if (std::dynamic_pointer_cast<IR::NotOperator>(
-                             unaryOperator)) {
-                    if (auto constantInt =
-                            std::dynamic_pointer_cast<AST::ConstantInt>(
-                                astConstant)) {
-                        astConstant = std::make_shared<AST::ConstantInt>(
-                            !constantInt->getValue());
-                    }
-                    else if (auto constantLong =
-                                 std::dynamic_pointer_cast<AST::ConstantLong>(
-                                     astConstant)) {
-                        astConstant = std::make_shared<AST::ConstantLong>(
-                            !constantLong->getValue());
-                    }
-                }
-                else {
-                    throw std::logic_error("Unsupported unary operator");
-                }
-                auto copyInstruction = std::make_shared<IR::CopyInstruction>(
-                    std::make_shared<IR::ConstantValue>(astConstant),
-                    unaryInstruction->getDst());
-                *it = copyInstruction;
-            }
-            ++it;
-        }
-        // Handle binary instructions with two constant source operands.
-        else if (auto binaryInstruction =
-                     std::dynamic_pointer_cast<IR::BinaryInstruction>(
-                         instruction)) {
-            if (auto constantValue1 =
-                    std::dynamic_pointer_cast<IR::ConstantValue>(
-                        binaryInstruction->getSrc1())) {
-                if (auto constantValue2 =
-                        std::dynamic_pointer_cast<IR::ConstantValue>(
-                            binaryInstruction->getSrc2())) {
-                    auto binaryOperator =
-                        binaryInstruction->getBinaryOperator();
-                    long constantResult = 0;
-                    if (std::dynamic_pointer_cast<IR::AddOperator>(
-                            binaryOperator)) {
-                        auto astConstant1 = constantValue1->getASTConstant();
-                        auto astConstant2 = constantValue2->getASTConstant();
-
-                        long value1 = 0, value2 = 0;
-                        if (auto constInt1 =
-                                std::dynamic_pointer_cast<AST::ConstantInt>(
-                                    astConstant1)) {
-                            value1 = constInt1->getValue();
-                        }
-                        else if (auto constLong1 = std::dynamic_pointer_cast<
-                                     AST::ConstantLong>(astConstant1)) {
-                            value1 = constLong1->getValue();
-                        }
-                        else {
-                            throw std::logic_error("Unsupported constant type");
-                        }
-                        if (auto constInt2 =
-                                std::dynamic_pointer_cast<AST::ConstantInt>(
-                                    astConstant2)) {
-                            value2 = constInt2->getValue();
-                        }
-                        else if (auto constLong2 = std::dynamic_pointer_cast<
-                                     AST::ConstantLong>(astConstant2)) {
-                            value2 = constLong2->getValue();
-                        }
-                        else {
-                            throw std::logic_error("Unsupported constant type");
-                        }
-
-                        // Check for overflow in 64-bit arithmetic.
-                        if ((value1 > 0 &&
-                             value2 >
-                                 std::numeric_limits<long>::max() - value1) ||
-                            (value1 < 0 &&
-                             value2 <
-                                 std::numeric_limits<long>::min() - value1)) {
-                            ++it;
-                            continue;
-                        }
-
-                        constantResult = value1 + value2;
-                    }
-                    else if (std::dynamic_pointer_cast<IR::SubtractOperator>(
-                                 binaryOperator)) {
-
-                        long value1 = 0, value2 = 0;
-                        if (auto constInt1 =
-                                std::dynamic_pointer_cast<AST::ConstantInt>(
-                                    constantValue1->getASTConstant())) {
-                            value1 = constInt1->getValue();
-                        }
-                        else if (auto constLong1 = std::dynamic_pointer_cast<
-                                     AST::ConstantLong>(
-                                     constantValue1->getASTConstant())) {
-                            value1 = constLong1->getValue();
-                        }
-                        if (auto constInt2 =
-                                std::dynamic_pointer_cast<AST::ConstantInt>(
-                                    constantValue2->getASTConstant())) {
-                            value2 = constInt2->getValue();
-                        }
-                        else if (auto constLong2 = std::dynamic_pointer_cast<
-                                     AST::ConstantLong>(
-                                     constantValue2->getASTConstant())) {
-                            value2 = constLong2->getValue();
-                        }
-
-                        // Check for overflow in 64-bit arithmetic.
-                        if ((value1 > 0 &&
-                             value2 <
-                                 std::numeric_limits<long>::min() + value1) ||
-                            (value1 < 0 &&
-                             value2 >
-                                 std::numeric_limits<long>::max() - value1)) {
-                            ++it;
-                            continue;
-                        }
-                        constantResult = value1 - value2;
-                    }
-                    else if (std::dynamic_pointer_cast<IR::MultiplyOperator>(
-                                 binaryOperator)) {
-
-                        long value1 = 0, value2 = 0;
-                        if (auto constInt1 =
-                                std::dynamic_pointer_cast<AST::ConstantInt>(
-                                    constantValue1->getASTConstant())) {
-                            value1 = constInt1->getValue();
-                        }
-                        else if (auto constLong1 = std::dynamic_pointer_cast<
-                                     AST::ConstantLong>(
-                                     constantValue1->getASTConstant())) {
-                            value1 = constLong1->getValue();
-                        }
-                        else {
-                            throw std::logic_error("Unsupported constant type");
-                        }
-                        if (auto constInt2 =
-                                std::dynamic_pointer_cast<AST::ConstantInt>(
-                                    constantValue2->getASTConstant())) {
-                            value2 = constInt2->getValue();
-                        }
-                        else if (auto constLong2 = std::dynamic_pointer_cast<
-                                     AST::ConstantLong>(
-                                     constantValue2->getASTConstant())) {
-                            value2 = constLong2->getValue();
-                        }
-                        else {
-                            throw std::logic_error("Unsupported constant type");
-                        }
-
-                        constantResult = value1 * value2;
-                        if (value1 != 0 && constantResult / value1 != value2) {
-                            ++it;
-                            continue;
-                        }
-                    }
-                    else if (std::dynamic_pointer_cast<IR::DivideOperator>(
-                                 binaryOperator)) {
-
-                        long value1 = 0, value2 = 0;
-                        if (auto constInt1 =
-                                std::dynamic_pointer_cast<AST::ConstantInt>(
-                                    constantValue1->getASTConstant())) {
-                            value1 = constInt1->getValue();
-                        }
-                        else if (auto constLong1 = std::dynamic_pointer_cast<
-                                     AST::ConstantLong>(
-                                     constantValue1->getASTConstant())) {
-                            value1 = constLong1->getValue();
-                        }
-                        else {
-                            throw std::logic_error("Unsupported constant type");
-                        }
-                        if (auto constInt2 =
-                                std::dynamic_pointer_cast<AST::ConstantInt>(
-                                    constantValue2->getASTConstant())) {
-                            value2 = constInt2->getValue();
-                        }
-                        else if (auto constLong2 = std::dynamic_pointer_cast<
-                                     AST::ConstantLong>(
-                                     constantValue2->getASTConstant())) {
-                            value2 = constLong2->getValue();
-                        }
-                        else {
-                            throw std::logic_error("Unsupported constant type");
-                        }
-
-                        if (value2 == 0) {
-                            ++it;
-                            continue;
-                        }
-                        constantResult = value1 / value2;
-                    }
-                    else if (std::dynamic_pointer_cast<IR::RemainderOperator>(
-                                 binaryOperator)) {
-
-                        long value1 = 0, value2 = 0;
-                        if (auto constInt1 =
-                                std::dynamic_pointer_cast<AST::ConstantInt>(
-                                    constantValue1->getASTConstant())) {
-                            value1 = constInt1->getValue();
-                        }
-                        else if (auto constLong1 = std::dynamic_pointer_cast<
-                                     AST::ConstantLong>(
-                                     constantValue1->getASTConstant())) {
-                            value1 = constLong1->getValue();
-                        }
-                        else {
-                            throw std::logic_error("Unsupported constant type");
-                        }
-                        if (auto constInt2 =
-                                std::dynamic_pointer_cast<AST::ConstantInt>(
-                                    constantValue2->getASTConstant())) {
-                            value2 = constInt2->getValue();
-                        }
-                        else if (auto constLong2 = std::dynamic_pointer_cast<
-                                     AST::ConstantLong>(
-                                     constantValue2->getASTConstant())) {
-                            value2 = constLong2->getValue();
-                        }
-                        else {
-                            throw std::logic_error("Unsupported constant type");
-                        }
-
-                        if (value2 == 0) {
-                            ++it;
-                            continue;
-                        }
-                        constantResult = value1 % value2;
-                    }
-                    else if (std::dynamic_pointer_cast<IR::EqualOperator>(
-                                 binaryOperator)) {
-
-                        long value1 = 0, value2 = 0;
-                        if (auto constInt1 =
-                                std::dynamic_pointer_cast<AST::ConstantInt>(
-                                    constantValue1->getASTConstant())) {
-                            value1 = constInt1->getValue();
-                        }
-                        else if (auto constLong1 = std::dynamic_pointer_cast<
-                                     AST::ConstantLong>(
-                                     constantValue1->getASTConstant())) {
-                            value1 = constLong1->getValue();
-                        }
-                        else {
-                            throw std::logic_error("Unsupported constant type");
-                        }
-                        if (auto constInt2 =
-                                std::dynamic_pointer_cast<AST::ConstantInt>(
-                                    constantValue2->getASTConstant())) {
-                            value2 = constInt2->getValue();
-                        }
-                        else if (auto constLong2 = std::dynamic_pointer_cast<
-                                     AST::ConstantLong>(
-                                     constantValue2->getASTConstant())) {
-                            value2 = constLong2->getValue();
-                        }
-                        else {
-                            throw std::logic_error("Unsupported constant type");
-                        }
-
-                        constantResult = value1 == value2;
-                    }
-                    else if (std::dynamic_pointer_cast<IR::NotEqualOperator>(
-                                 binaryOperator)) {
-
-                        long value1 = 0, value2 = 0;
-                        if (auto constInt1 =
-                                std::dynamic_pointer_cast<AST::ConstantInt>(
-                                    constantValue1->getASTConstant())) {
-                            value1 = constInt1->getValue();
-                        }
-                        else if (auto constLong1 = std::dynamic_pointer_cast<
-                                     AST::ConstantLong>(
-                                     constantValue1->getASTConstant())) {
-                            value1 = constLong1->getValue();
-                        }
-                        else {
-                            throw std::logic_error("Unsupported constant type");
-                        }
-                        if (auto constInt2 =
-                                std::dynamic_pointer_cast<AST::ConstantInt>(
-                                    constantValue2->getASTConstant())) {
-                            value2 = constInt2->getValue();
-                        }
-                        else if (auto constLong2 = std::dynamic_pointer_cast<
-                                     AST::ConstantLong>(
-                                     constantValue2->getASTConstant())) {
-                            value2 = constLong2->getValue();
-                        }
-                        else {
-                            throw std::logic_error("Unsupported constant type");
-                        }
-
-                        constantResult = value1 != value2;
-                    }
-                    else if (std::dynamic_pointer_cast<IR::LessThanOperator>(
-                                 binaryOperator)) {
-
-                        long value1 = 0, value2 = 0;
-                        if (auto constInt1 =
-                                std::dynamic_pointer_cast<AST::ConstantInt>(
-                                    constantValue1->getASTConstant())) {
-                            value1 = constInt1->getValue();
-                        }
-                        else if (auto constLong1 = std::dynamic_pointer_cast<
-                                     AST::ConstantLong>(
-                                     constantValue1->getASTConstant())) {
-                            value1 = constLong1->getValue();
-                        }
-                        else {
-                            throw std::logic_error("Unsupported constant type");
-                        }
-                        if (auto constInt2 =
-                                std::dynamic_pointer_cast<AST::ConstantInt>(
-                                    constantValue2->getASTConstant())) {
-                            value2 = constInt2->getValue();
-                        }
-                        else if (auto constLong2 = std::dynamic_pointer_cast<
-                                     AST::ConstantLong>(
-                                     constantValue2->getASTConstant())) {
-                            value2 = constLong2->getValue();
-                        }
-                        else {
-                            throw std::logic_error("Unsupported constant type");
-                        }
-
-                        constantResult = value1 < value2;
-                    }
-                    else if (std::dynamic_pointer_cast<
-                                 IR::LessThanOrEqualOperator>(binaryOperator)) {
-                        long value1 = 0, value2 = 0;
-                        if (auto constInt1 =
-                                std::dynamic_pointer_cast<AST::ConstantInt>(
-                                    constantValue1->getASTConstant())) {
-                            value1 = constInt1->getValue();
-                        }
-                        else if (auto constLong1 = std::dynamic_pointer_cast<
-                                     AST::ConstantLong>(
-                                     constantValue1->getASTConstant())) {
-                            value1 = constLong1->getValue();
-                        }
-                        else {
-                            throw std::logic_error("Unsupported constant type");
-                        }
-                        if (auto constInt2 =
-                                std::dynamic_pointer_cast<AST::ConstantInt>(
-                                    constantValue2->getASTConstant())) {
-                            value2 = constInt2->getValue();
-                        }
-                        else if (auto constLong2 = std::dynamic_pointer_cast<
-                                     AST::ConstantLong>(
-                                     constantValue2->getASTConstant())) {
-                            value2 = constLong2->getValue();
-                        }
-                        else {
-                            throw std::logic_error("Unsupported constant type");
-                        }
-
-                        constantResult = value1 <= value2;
-                    }
-                    else if (std::dynamic_pointer_cast<IR::GreaterThanOperator>(
-                                 binaryOperator)) {
-
-                        long value1 = 0, value2 = 0;
-                        if (auto constInt1 =
-                                std::dynamic_pointer_cast<AST::ConstantInt>(
-                                    constantValue1->getASTConstant())) {
-                            value1 = constInt1->getValue();
-                        }
-                        else if (auto constLong1 = std::dynamic_pointer_cast<
-                                     AST::ConstantLong>(
-                                     constantValue1->getASTConstant())) {
-                            value1 = constLong1->getValue();
-                        }
-                        else {
-                            throw std::logic_error("Unsupported constant type");
-                        }
-                        if (auto constInt2 =
-                                std::dynamic_pointer_cast<AST::ConstantInt>(
-                                    constantValue2->getASTConstant())) {
-                            value2 = constInt2->getValue();
-                        }
-                        else if (auto constLong2 = std::dynamic_pointer_cast<
-                                     AST::ConstantLong>(
-                                     constantValue2->getASTConstant())) {
-                            value2 = constLong2->getValue();
-                        }
-                        else {
-                            throw std::logic_error("Unsupported constant type");
-                        }
-
-                        constantResult = value1 > value2;
-                    }
-                    else if (std::dynamic_pointer_cast<
-                                 IR::GreaterThanOrEqualOperator>(
-                                 binaryOperator)) {
-
-                        long value1 = 0, value2 = 0;
-                        if (auto constInt1 =
-                                std::dynamic_pointer_cast<AST::ConstantInt>(
-                                    constantValue1->getASTConstant())) {
-                            value1 = constInt1->getValue();
-                        }
-                        else if (auto constLong1 = std::dynamic_pointer_cast<
-                                     AST::ConstantLong>(
-                                     constantValue1->getASTConstant())) {
-                            value1 = constLong1->getValue();
-                        }
-                        else {
-                            throw std::logic_error("Unsupported constant type");
-                        }
-                        if (auto constInt2 =
-                                std::dynamic_pointer_cast<AST::ConstantInt>(
-                                    constantValue2->getASTConstant())) {
-                            value2 = constInt2->getValue();
-                        }
-                        else if (auto constLong2 = std::dynamic_pointer_cast<
-                                     AST::ConstantLong>(
-                                     constantValue2->getASTConstant())) {
-                            value2 = constLong2->getValue();
-                        }
-                        else {
-                            throw std::logic_error("Unsupported constant type");
-                        }
-
-                        constantResult = value1 >= value2;
-                    }
-                    else {
-                        throw std::logic_error("Unsupported binary operator");
-                    }
-
-                    // Determine the result type based on input types.
-                    bool isLongResult = false;
-                    if (auto constLong1 =
-                            std::dynamic_pointer_cast<AST::ConstantLong>(
-                                constantValue1->getASTConstant())) {
-                        isLongResult = true;
-                    }
-                    else if (auto constLong2 =
-                                 std::dynamic_pointer_cast<AST::ConstantLong>(
-                                     constantValue2->getASTConstant())) {
-                        isLongResult = true;
-                    }
-
-                    std::shared_ptr<IR::ConstantValue> resultConstant;
-                    if (isLongResult) {
-                        resultConstant = std::make_shared<IR::ConstantValue>(
-                            std::make_shared<AST::ConstantLong>(
-                                constantResult));
-                    }
-                    else {
-                        resultConstant = std::make_shared<IR::ConstantValue>(
-                            std::make_shared<AST::ConstantInt>(
-                                static_cast<int>(constantResult)));
-                    }
-
-                    auto copyInstruction =
-                        std::make_shared<IR::CopyInstruction>(
-                            resultConstant, binaryInstruction->getDst());
-                    *it = copyInstruction;
-                }
-            }
-            ++it;
-        }
-        // Handle `JumpIfZero` instructions.
-        else if (auto jumpIfZeroInstruction =
-                     std::dynamic_pointer_cast<IR::JumpIfZeroInstruction>(
-                         instruction)) {
-            if (auto constantValue =
-                    std::dynamic_pointer_cast<IR::ConstantValue>(
-                        jumpIfZeroInstruction->getCondition())) {
-                // Get the actual value from the AST constant.
-                long conditionValue = 0;
-                if (auto constInt = std::dynamic_pointer_cast<AST::ConstantInt>(
-                        constantValue->getASTConstant())) {
-                    conditionValue = constInt->getValue();
-                }
-                else if (auto constLong =
-                             std::dynamic_pointer_cast<AST::ConstantLong>(
-                                 constantValue->getASTConstant())) {
-                    conditionValue = constLong->getValue();
-                }
-                else {
-                    throw std::logic_error("Unsupported constant type");
-                }
-
-                if (conditionValue == 0) {
-                    *it = std::make_shared<IR::JumpInstruction>(
-                        jumpIfZeroInstruction->getTarget());
-                    ++it;
-                }
-                else {
-                    it = postConstantFoldingFunctionBody->erase(it);
-                }
-            }
-            else {
-                ++it;
-            }
-        }
-        // Handle `JumpIfNotZero` instructions.
-        else if (auto jumpIfNotZeroInstruction =
-                     std::dynamic_pointer_cast<IR::JumpIfNotZeroInstruction>(
-                         instruction)) {
-            if (auto constantValue =
-                    std::dynamic_pointer_cast<IR::ConstantValue>(
-                        jumpIfNotZeroInstruction->getCondition())) {
-                // Get the actual value from the AST constant.
-                long conditionValue = 0;
-                if (auto constInt = std::dynamic_pointer_cast<AST::ConstantInt>(
-                        constantValue->getASTConstant())) {
-                    conditionValue = constInt->getValue();
-                }
-                else if (auto constLong =
-                             std::dynamic_pointer_cast<AST::ConstantLong>(
-                                 constantValue->getASTConstant())) {
-                    conditionValue = constLong->getValue();
-                }
-                else {
-                    throw std::logic_error("Unsupported constant type");
-                }
-
-                if (conditionValue != 0) {
-                    *it = std::make_shared<IR::JumpInstruction>(
-                        jumpIfNotZeroInstruction->getTarget());
-                    ++it;
-                }
-                else {
-                    it = postConstantFoldingFunctionBody->erase(it);
-                }
-            }
-            else {
-                ++it;
-            }
-        }
-        else {
-            ++it;
-        }
-    }
-    return postConstantFoldingFunctionBody;
+    const std::vector<std::unique_ptr<IR::Instruction>> &functionBody) {
+    return cloneFunctionBody(functionBody);
 }
 
-std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
+std::unique_ptr<std::vector<std::unique_ptr<IR::Instruction>>>
 CFG::makeControlFlowGraph(
-    const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-        &functionBody) {
-    return functionBody;
+    const std::vector<std::unique_ptr<IR::Instruction>> &functionBody) {
+    return cloneFunctionBody(functionBody);
 }
 
-std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
+std::unique_ptr<std::vector<std::unique_ptr<IR::Instruction>>>
 CFG::cfgToInstructions(
-    const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>> &cfg) {
-    return cfg;
+    const std::vector<std::unique_ptr<IR::Instruction>> &cfg) {
+    return cloneFunctionBody(cfg);
 }
 
-std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
+std::unique_ptr<std::vector<std::unique_ptr<IR::Instruction>>>
 UnreachableCodeEliminationPass::eliminateUnreachableCode(
-    const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>> &cfg) {
-    return cfg;
+    const std::vector<std::unique_ptr<IR::Instruction>> &cfg) {
+    return cloneFunctionBody(cfg);
 }
 
-std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
+std::unique_ptr<std::vector<std::unique_ptr<IR::Instruction>>>
 CopyPropagationPass::propagateCopies(
-    const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>> &cfg) {
-    return cfg;
+    const std::vector<std::unique_ptr<IR::Instruction>> &cfg) {
+    return cloneFunctionBody(cfg);
 }
 
-std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
+std::unique_ptr<std::vector<std::unique_ptr<IR::Instruction>>>
 DeadStoreEliminationPass::eliminateDeadStores(
-    const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>> &cfg) {
-    return cfg;
+    const std::vector<std::unique_ptr<IR::Instruction>> &cfg) {
+    return cloneFunctionBody(cfg);
 }
 } // namespace IR

--- a/src/midend/irOptimizationPasses.h
+++ b/src/midend/irOptimizationPasses.h
@@ -33,10 +33,9 @@ class IROptimizer {
      * store elimination.
      * @return The optimized IR function body.
      */
-    [[nodiscard]] static std::shared_ptr<
-        std::vector<std::shared_ptr<IR::Instruction>>>
-    irOptimize(const std::shared_ptr<std::vector<std::shared_ptr<Instruction>>>
-                   &functionBody,
+    [[nodiscard]] static std::unique_ptr<
+        std::vector<std::unique_ptr<IR::Instruction>>>
+    irOptimize(const std::vector<std::unique_ptr<Instruction>> &functionBody,
                bool foldConstantsPass, bool propagateCopiesPass,
                bool eliminateUnreachableCodePass, bool eliminateDeadStoresPass);
 };
@@ -63,18 +62,17 @@ class ConstantFoldingPass : public OptimizationPass {
      * @param functionBody The IR function body to optimize.
      * @return The optimized IR function body with constants folded.
      */
-    [[nodiscard]] static std::shared_ptr<
-        std::vector<std::shared_ptr<IR::Instruction>>>
+    [[nodiscard]] static std::unique_ptr<
+        std::vector<std::unique_ptr<IR::Instruction>>>
     foldConstants(
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &functionBody);
+        const std::vector<std::unique_ptr<IR::Instruction>> &functionBody);
 };
 
 /**
  * Class for constructing control flow graphs (CFGs) from IR instructions.
  *
  * TODO(zzmic): CFGs are temporarily of type
- * `std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>`.
+ * `std::unique_ptr<std::vector<std::unique_ptr<IR::Instruction>>>`.
  */
 class CFG {
   public:
@@ -84,11 +82,10 @@ class CFG {
      * @param functionBody The IR function body to convert.
      * @return The control flow graph (CFG) representation of the function body.
      */
-    [[nodiscard]] static std::shared_ptr<
-        std::vector<std::shared_ptr<IR::Instruction>>>
+    [[nodiscard]] static std::unique_ptr<
+        std::vector<std::unique_ptr<IR::Instruction>>>
     makeControlFlowGraph(
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &functionBody);
+        const std::vector<std::unique_ptr<IR::Instruction>> &functionBody);
 
     /**
      * Convert the given control flow graph (CFG) back into a linear sequence
@@ -97,11 +94,9 @@ class CFG {
      * @param cfg The control flow graph (CFG) to convert.
      * @return The linear sequence of IR instructions.
      */
-    [[nodiscard]] static std::shared_ptr<
-        std::vector<std::shared_ptr<IR::Instruction>>>
-    cfgToInstructions(
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &cfg);
+    [[nodiscard]] static std::unique_ptr<
+        std::vector<std::unique_ptr<IR::Instruction>>>
+    cfgToInstructions(const std::vector<std::unique_ptr<IR::Instruction>> &cfg);
 };
 
 /**
@@ -117,11 +112,10 @@ class UnreachableCodeEliminationPass : public OptimizationPass {
      * body.
      * @return The optimized IR function body with unreachable code removed.
      */
-    [[nodiscard]] static std::shared_ptr<
-        std::vector<std::shared_ptr<IR::Instruction>>>
+    [[nodiscard]] static std::unique_ptr<
+        std::vector<std::unique_ptr<IR::Instruction>>>
     eliminateUnreachableCode(
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &cfg);
+        const std::vector<std::unique_ptr<IR::Instruction>> &cfg);
 };
 
 /**
@@ -136,11 +130,9 @@ class CopyPropagationPass : public OptimizationPass {
      * body.
      * @return The optimized IR function body with copies propagated.
      */
-    [[nodiscard]] static std::shared_ptr<
-        std::vector<std::shared_ptr<IR::Instruction>>>
-    propagateCopies(
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &cfg);
+    [[nodiscard]] static std::unique_ptr<
+        std::vector<std::unique_ptr<IR::Instruction>>>
+    propagateCopies(const std::vector<std::unique_ptr<IR::Instruction>> &cfg);
 };
 
 /**
@@ -156,11 +148,10 @@ class DeadStoreEliminationPass : public OptimizationPass {
      * body.
      * @return The optimized IR function body with dead stores removed.
      */
-    [[nodiscard]] static std::shared_ptr<
-        std::vector<std::shared_ptr<IR::Instruction>>>
+    [[nodiscard]] static std::unique_ptr<
+        std::vector<std::unique_ptr<IR::Instruction>>>
     eliminateDeadStores(
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::Instruction>>>
-            &cfg);
+        const std::vector<std::unique_ptr<IR::Instruction>> &cfg);
 };
 } // namespace IR
 

--- a/src/utils/pipelineStagesExecutors.cpp
+++ b/src/utils/pipelineStagesExecutors.cpp
@@ -68,7 +68,7 @@ int PipelineStagesExecutors::semanticAnalysisExecutor(
     try {
         // Perform the identifier-resolution pass.
         variableResolutionCounter =
-            IdentifierResolutionPass.resolveProgram(astProgram);
+            IdentifierResolutionPass.resolveProgram(*astProgram);
     } catch (const std::runtime_error &e) {
         std::stringstream msg;
         msg << "Identifier resolution error: " << e.what();
@@ -76,7 +76,7 @@ int PipelineStagesExecutors::semanticAnalysisExecutor(
     }
     try {
         // Perform the type-checking pass.
-        typeCheckingPass.typeCheckProgram(astProgram);
+        typeCheckingPass.typeCheckProgram(*astProgram);
     } catch (const std::runtime_error &e) {
         std::stringstream msg;
         msg << "Type-checking error: " << e.what();
@@ -84,7 +84,7 @@ int PipelineStagesExecutors::semanticAnalysisExecutor(
     }
     try {
         // Perform the loop-labeling pass.
-        loopLabelingPass.labelLoops(astProgram);
+        loopLabelingPass.labelLoops(*astProgram);
     } catch (const std::runtime_error &e) {
         std::stringstream msg;
         msg << "Loop-labeling error: " << e.what();

--- a/src/utils/pipelineStagesExecutors.cpp
+++ b/src/utils/pipelineStagesExecutors.cpp
@@ -37,9 +37,9 @@ PipelineStagesExecutors::lexerExecutor(std::string_view sourceFileName) {
     return tokens;
 }
 
-std::shared_ptr<AST::Program>
+std::unique_ptr<AST::Program>
 PipelineStagesExecutors::parserExecutor(const std::vector<Token> &tokens) {
-    std::shared_ptr<AST::Program> program;
+    std::unique_ptr<AST::Program> program;
     try {
         AST::Parser parser(tokens);
         // Parse the tokens to generate the AST program.
@@ -58,8 +58,7 @@ PipelineStagesExecutors::parserExecutor(const std::vector<Token> &tokens) {
 }
 
 int PipelineStagesExecutors::semanticAnalysisExecutor(
-    const std::shared_ptr<AST::Program> &astProgram,
-    AST::FrontendSymbolTable &frontendSymbolTable) {
+    AST::Program &astProgram, AST::FrontendSymbolTable &frontendSymbolTable) {
     AST::IdentifierResolutionPass IdentifierResolutionPass;
     AST::TypeCheckingPass typeCheckingPass(frontendSymbolTable);
     AST::LoopLabelingPass loopLabelingPass;
@@ -68,7 +67,7 @@ int PipelineStagesExecutors::semanticAnalysisExecutor(
     try {
         // Perform the identifier-resolution pass.
         variableResolutionCounter =
-            IdentifierResolutionPass.resolveProgram(*astProgram);
+            IdentifierResolutionPass.resolveProgram(astProgram);
     } catch (const std::runtime_error &e) {
         std::stringstream msg;
         msg << "Identifier resolution error: " << e.what();
@@ -76,7 +75,7 @@ int PipelineStagesExecutors::semanticAnalysisExecutor(
     }
     try {
         // Perform the type-checking pass.
-        typeCheckingPass.typeCheckProgram(*astProgram);
+        typeCheckingPass.typeCheckProgram(astProgram);
     } catch (const std::runtime_error &e) {
         std::stringstream msg;
         msg << "Type-checking error: " << e.what();
@@ -84,7 +83,7 @@ int PipelineStagesExecutors::semanticAnalysisExecutor(
     }
     try {
         // Perform the loop-labeling pass.
-        loopLabelingPass.labelLoops(*astProgram);
+        loopLabelingPass.labelLoops(astProgram);
     } catch (const std::runtime_error &e) {
         std::stringstream msg;
         msg << "Loop-labeling error: " << e.what();
@@ -94,7 +93,7 @@ int PipelineStagesExecutors::semanticAnalysisExecutor(
         // Visit and print the AST program after semantic analysis.
         AST::PrintVisitor printVisitor;
         std::cout << "\n";
-        astProgram->accept(printVisitor);
+        astProgram.accept(printVisitor);
     } catch (const std::runtime_error &e) {
         std::stringstream msg;
         msg << "Printing AST error (in semantic analysis): " << e.what();
@@ -107,8 +106,7 @@ int PipelineStagesExecutors::semanticAnalysisExecutor(
 std::pair<std::unique_ptr<IR::Program>,
           std::unique_ptr<std::vector<std::unique_ptr<IR::StaticVariable>>>>
 PipelineStagesExecutors::irGeneratorExecutor(
-    const std::shared_ptr<AST::Program> &astProgram,
-    int variableResolutionCounter,
+    const AST::Program &astProgram, int variableResolutionCounter,
     AST::FrontendSymbolTable &frontendSymbolTable) {
     std::cout << "\n";
     std::pair<std::unique_ptr<IR::Program>,
@@ -118,7 +116,7 @@ PipelineStagesExecutors::irGeneratorExecutor(
         IR::IRGenerator irGenerator(variableResolutionCounter,
                                     frontendSymbolTable);
         // Generate the IR program from the AST program.
-        irProgramAndIRStaticVariables = irGenerator.generateIR(*astProgram);
+        irProgramAndIRStaticVariables = irGenerator.generateIR(astProgram);
     } catch (const std::runtime_error &e) {
         std::stringstream msg;
         msg << "IR generation error: " << e.what();
@@ -146,11 +144,11 @@ void PipelineStagesExecutors::irOptimizationExecutor(
     }
 }
 
-std::shared_ptr<Assembly::Program> PipelineStagesExecutors::codegenExecutor(
+std::unique_ptr<Assembly::Program> PipelineStagesExecutors::codegenExecutor(
     const IR::Program &irProgram,
     const std::vector<std::unique_ptr<IR::StaticVariable>> &irStaticVariables,
     const AST::FrontendSymbolTable &frontendSymbolTable) {
-    std::shared_ptr<Assembly::Program> assemblyProgram;
+    std::unique_ptr<Assembly::Program> assemblyProgram;
     try {
         // Convert the frontend symbol table to backend symbol table before
         // assembly generation so all variables (including temporaries) are
@@ -166,17 +164,13 @@ std::shared_ptr<Assembly::Program> PipelineStagesExecutors::codegenExecutor(
 
         Assembly::PseudoToStackPass pseudoToStackPass;
         // Associate the stack size with each top-level element.
-        auto topLevels = assemblyProgram->getTopLevels();
+        auto &topLevels = assemblyProgram->getTopLevels();
         pseudoToStackPass.replacePseudoWithStackAndAssociateStackSize(
             topLevels, backendSymbolTable);
 
         Assembly::FixupPass fixupPass;
         // Fix up the assembly program.
         fixupPass.fixup(topLevels);
-
-        // Set the top-level elements of the assembly program after all the
-        // passes.
-        assemblyProgram->setTopLevels(topLevels);
     } catch (const std::runtime_error &e) {
         std::stringstream msg;
         msg << "Code generation error: " << e.what();
@@ -188,7 +182,7 @@ std::shared_ptr<Assembly::Program> PipelineStagesExecutors::codegenExecutor(
 }
 
 void PipelineStagesExecutors::codeEmissionExecutor(
-    const std::shared_ptr<Assembly::Program> &assemblyProgram,
+    const Assembly::Program &assemblyProgram,
     std::string_view assemblyFileName) {
     std::ofstream assemblyFileStream(std::string{assemblyFileName});
     if (!assemblyFileStream.is_open()) {
@@ -197,17 +191,15 @@ void PipelineStagesExecutors::codeEmissionExecutor(
         throw std::ios_base::failure(msg.str());
     }
 
-    auto assyTopLevels = assemblyProgram->getTopLevels();
-    for (auto topLevel : *assyTopLevels) {
-        if (auto functionDefinition =
-                std::dynamic_pointer_cast<Assembly::FunctionDefinition>(
-                    topLevel)) {
-            emitAssyFunctionDefinition(functionDefinition, assemblyFileStream);
+    auto &assyTopLevels = assemblyProgram.getTopLevels();
+    for (const auto &topLevel : assyTopLevels) {
+        if (auto *functionDefinition =
+                dynamic_cast<Assembly::FunctionDefinition *>(topLevel.get())) {
+            emitAssyFunctionDefinition(*functionDefinition, assemblyFileStream);
         }
-        else if (auto staticVariable =
-                     std::dynamic_pointer_cast<Assembly::StaticVariable>(
-                         topLevel)) {
-            emitAssyStaticVariable(staticVariable, assemblyFileStream);
+        else if (auto *staticVariable =
+                     dynamic_cast<Assembly::StaticVariable *>(topLevel.get())) {
+            emitAssyStaticVariable(*staticVariable, assemblyFileStream);
         }
     }
 
@@ -222,11 +214,11 @@ void PipelineStagesExecutors::codeEmissionExecutor(
 }
 
 void PipelineStagesExecutors::emitAssyFunctionDefinition(
-    const std::shared_ptr<Assembly::FunctionDefinition> &functionDefinition,
+    const Assembly::FunctionDefinition &functionDefinition,
     std::ofstream &assemblyFileStream) {
-    auto functionName = functionDefinition->getFunctionIdentifier();
+    auto functionName = functionDefinition.getFunctionIdentifier();
     prependUnderscoreToIdentifierIfMacOS(functionName);
-    auto global = functionDefinition->isGlobal();
+    auto global = functionDefinition.isGlobal();
     auto globalDirective = "    .globl " + functionName + "\n";
     if (!global) {
         globalDirective = "";
@@ -239,15 +231,15 @@ void PipelineStagesExecutors::emitAssyFunctionDefinition(
     assemblyFileStream << "    pushq %rbp\n";
     assemblyFileStream << "    movq %rsp, %rbp\n";
 
-    for (auto instruction : *functionDefinition->getFunctionBody()) {
-        emitAssyInstruction(instruction, assemblyFileStream);
+    for (const auto &instruction : functionDefinition.getFunctionBody()) {
+        emitAssyInstruction(*instruction, assemblyFileStream);
     }
 }
 
 void PipelineStagesExecutors::emitAssyStaticVariable(
-    const std::shared_ptr<Assembly::StaticVariable> &staticVariable,
+    const Assembly::StaticVariable &staticVariable,
     std::ofstream &assemblyFileStream) {
-    auto alignment = staticVariable->getAlignment();
+    auto alignment = staticVariable.getAlignment();
     auto alignmentInStr = std::to_string(alignment);
     auto alignDirective = ".align " + alignmentInStr;
 // If the underlying OS is macOS, use the `.balign 4` directive instead of the
@@ -256,22 +248,21 @@ void PipelineStagesExecutors::emitAssyStaticVariable(
     alignDirective = ".balign " + alignmentInStr;
 #endif
 
-    auto variableIdentifier = staticVariable->getIdentifier();
+    auto variableIdentifier = staticVariable.getIdentifier();
     prependUnderscoreToIdentifierIfMacOS(variableIdentifier);
 
-    auto global = staticVariable->isGlobal();
+    auto global = staticVariable.isGlobal();
     auto globalDirective = ".globl " + variableIdentifier + "\n";
     if (!global) {
         globalDirective = "";
     }
 
     bool isZeroInit = false;
-    auto staticInit = staticVariable->getStaticInit();
-    if (auto intInit = std::dynamic_pointer_cast<AST::IntInit>(staticInit)) {
+    auto staticInit = staticVariable.getStaticInit();
+    if (auto intInit = dynamic_cast<const AST::IntInit *>(staticInit)) {
         isZeroInit = (std::get<int>(intInit->getValue()) == 0);
     }
-    else if (auto longInit =
-                 std::dynamic_pointer_cast<AST::LongInit>(staticInit)) {
+    else if (auto longInit = dynamic_cast<const AST::LongInit *>(staticInit)) {
         isZeroInit = (std::get<long>(longInit->getValue()) == 0L);
     }
     else {
@@ -285,8 +276,7 @@ void PipelineStagesExecutors::emitAssyStaticVariable(
         assemblyFileStream << "    .data\n";
         assemblyFileStream << "    " << alignDirective << "\n";
         assemblyFileStream << variableIdentifier << ":\n";
-        if (auto intInit =
-                std::dynamic_pointer_cast<AST::IntInit>(staticInit)) {
+        if (auto intInit = dynamic_cast<const AST::IntInit *>(staticInit)) {
             if (std::get<int>(intInit->getValue()) == 0) {
                 assemblyFileStream << "    .zero 4\n";
             }
@@ -297,7 +287,7 @@ void PipelineStagesExecutors::emitAssyStaticVariable(
             }
         }
         else if (auto longInit =
-                     std::dynamic_pointer_cast<AST::LongInit>(staticInit)) {
+                     dynamic_cast<const AST::LongInit *>(staticInit)) {
             if (std::get<long>(longInit->getValue()) == 0) {
                 assemblyFileStream << "    .zero 8\n";
             }
@@ -313,88 +303,81 @@ void PipelineStagesExecutors::emitAssyStaticVariable(
         assemblyFileStream << "    .bss\n";
         assemblyFileStream << "    " << alignDirective << "\n";
         assemblyFileStream << variableIdentifier << ":\n";
-        if (auto intInit =
-                std::dynamic_pointer_cast<AST::IntInit>(staticInit)) {
+        if (dynamic_cast<const AST::IntInit *>(staticInit)) {
             assemblyFileStream << "    .zero 4\n";
         }
-        else if (auto longInit =
-                     std::dynamic_pointer_cast<AST::LongInit>(staticInit)) {
+        else if (dynamic_cast<const AST::LongInit *>(staticInit)) {
             assemblyFileStream << "    .zero 8\n";
         }
     }
 }
 
 void PipelineStagesExecutors::emitAssyInstruction(
-    const std::shared_ptr<Assembly::Instruction> &instruction,
+    const Assembly::Instruction &instruction,
     std::ofstream &assemblyFileStream) {
     if (auto movInstruction =
-            std::dynamic_pointer_cast<Assembly::MovInstruction>(instruction)) {
-        emitAssyMovInstruction(movInstruction, assemblyFileStream);
+            dynamic_cast<const Assembly::MovInstruction *>(&instruction)) {
+        emitAssyMovInstruction(*movInstruction, assemblyFileStream);
     }
-    else if (auto retInstruction =
-                 std::dynamic_pointer_cast<Assembly::RetInstruction>(
-                     instruction)) {
+    else if (dynamic_cast<const Assembly::RetInstruction *>(&instruction)) {
         emitAssyRetInstruction(assemblyFileStream);
     }
     else if (auto pushInstruction =
-                 std::dynamic_pointer_cast<Assembly::PushInstruction>(
-                     instruction)) {
-        emitAssyPushInstruction(pushInstruction, assemblyFileStream);
+                 dynamic_cast<const Assembly::PushInstruction *>(
+                     &instruction)) {
+        emitAssyPushInstruction(*pushInstruction, assemblyFileStream);
     }
     else if (auto callInstruction =
-                 std::dynamic_pointer_cast<Assembly::CallInstruction>(
-                     instruction)) {
-        emitAssyCallInstruction(callInstruction, assemblyFileStream);
+                 dynamic_cast<const Assembly::CallInstruction *>(
+                     &instruction)) {
+        emitAssyCallInstruction(*callInstruction, assemblyFileStream);
     }
     else if (auto unaryInstruction =
-                 std::dynamic_pointer_cast<Assembly::UnaryInstruction>(
-                     instruction)) {
-        emitAssyUnaryInstruction(unaryInstruction, assemblyFileStream);
+                 dynamic_cast<const Assembly::UnaryInstruction *>(
+                     &instruction)) {
+        emitAssyUnaryInstruction(*unaryInstruction, assemblyFileStream);
     }
     else if (auto binaryInstruction =
-                 std::dynamic_pointer_cast<Assembly::BinaryInstruction>(
-                     instruction)) {
-        emitAssyBinaryInstruction(binaryInstruction, assemblyFileStream);
+                 dynamic_cast<const Assembly::BinaryInstruction *>(
+                     &instruction)) {
+        emitAssyBinaryInstruction(*binaryInstruction, assemblyFileStream);
     }
     else if (auto cmpInstruction =
-                 std::dynamic_pointer_cast<Assembly::CmpInstruction>(
-                     instruction)) {
-        emitAssyCmpInstruction(cmpInstruction, assemblyFileStream);
+                 dynamic_cast<const Assembly::CmpInstruction *>(&instruction)) {
+        emitAssyCmpInstruction(*cmpInstruction, assemblyFileStream);
     }
     else if (auto idivInstruction =
-                 std::dynamic_pointer_cast<Assembly::IdivInstruction>(
-                     instruction)) {
-        emitAssyIdivInstruction(idivInstruction, assemblyFileStream);
+                 dynamic_cast<const Assembly::IdivInstruction *>(
+                     &instruction)) {
+        emitAssyIdivInstruction(*idivInstruction, assemblyFileStream);
     }
     else if (auto movsxInstruction =
-                 std::dynamic_pointer_cast<Assembly::MovsxInstruction>(
-                     instruction)) {
-        emitAssyMovsxInstruction(movsxInstruction, assemblyFileStream);
+                 dynamic_cast<const Assembly::MovsxInstruction *>(
+                     &instruction)) {
+        emitAssyMovsxInstruction(*movsxInstruction, assemblyFileStream);
     }
     else if (auto cdqInstruction =
-                 std::dynamic_pointer_cast<Assembly::CdqInstruction>(
-                     instruction)) {
-        emitAssyCdqInstruction(cdqInstruction, assemblyFileStream);
+                 dynamic_cast<const Assembly::CdqInstruction *>(&instruction)) {
+        emitAssyCdqInstruction(*cdqInstruction, assemblyFileStream);
     }
     else if (auto jmpInstruction =
-                 std::dynamic_pointer_cast<Assembly::JmpInstruction>(
-                     instruction)) {
-        emitAssyJmpInstruction(jmpInstruction, assemblyFileStream);
+                 dynamic_cast<const Assembly::JmpInstruction *>(&instruction)) {
+        emitAssyJmpInstruction(*jmpInstruction, assemblyFileStream);
     }
     else if (auto jmpCCInstruction =
-                 std::dynamic_pointer_cast<Assembly::JmpCCInstruction>(
-                     instruction)) {
-        emitAssyJmpCCInstruction(jmpCCInstruction, assemblyFileStream);
+                 dynamic_cast<const Assembly::JmpCCInstruction *>(
+                     &instruction)) {
+        emitAssyJmpCCInstruction(*jmpCCInstruction, assemblyFileStream);
     }
     else if (auto setCCInstruction =
-                 std::dynamic_pointer_cast<Assembly::SetCCInstruction>(
-                     instruction)) {
-        emitAssySetCCInstruction(setCCInstruction, assemblyFileStream);
+                 dynamic_cast<const Assembly::SetCCInstruction *>(
+                     &instruction)) {
+        emitAssySetCCInstruction(*setCCInstruction, assemblyFileStream);
     }
     else if (auto labelInstruction =
-                 std::dynamic_pointer_cast<Assembly::LabelInstruction>(
-                     instruction)) {
-        emitAssyLabelInstruction(labelInstruction, assemblyFileStream);
+                 dynamic_cast<const Assembly::LabelInstruction *>(
+                     &instruction)) {
+        emitAssyLabelInstruction(*labelInstruction, assemblyFileStream);
     }
     else {
         throw std::logic_error(
@@ -403,18 +386,17 @@ void PipelineStagesExecutors::emitAssyInstruction(
 }
 
 void PipelineStagesExecutors::emitAssyMovInstruction(
-    const std::shared_ptr<Assembly::MovInstruction> &movInstruction,
+    const Assembly::MovInstruction &movInstruction,
     std::ofstream &assemblyFileStream) {
-    auto type = movInstruction->getType();
+    auto type = movInstruction.getType();
 
     std::string instructionName;
     int registerSize;
-    if (auto longword = std::dynamic_pointer_cast<Assembly::Longword>(type)) {
+    if (dynamic_cast<const Assembly::Longword *>(type)) {
         instructionName = "movl";
         registerSize = 4;
     }
-    else if (auto quadword =
-                 std::dynamic_pointer_cast<Assembly::Quadword>(type)) {
+    else if (dynamic_cast<const Assembly::Quadword *>(type)) {
         instructionName = "movq";
         registerSize = 8;
     }
@@ -423,18 +405,16 @@ void PipelineStagesExecutors::emitAssyMovInstruction(
             "Invalid type while printing assembly mov instruction");
     }
 
-    auto src = movInstruction->getSrc();
+    auto src = movInstruction.getSrc();
     std::string srcStr;
-    if (auto srcReg =
-            std::dynamic_pointer_cast<Assembly::RegisterOperand>(src)) {
+    if (auto srcReg = dynamic_cast<const Assembly::RegisterOperand *>(src)) {
         srcStr = srcReg->getRegisterInBytesInStr(registerSize);
     }
     else if (auto srcImm =
-                 std::dynamic_pointer_cast<Assembly::ImmediateOperand>(src)) {
+                 dynamic_cast<const Assembly::ImmediateOperand *>(src)) {
         // Use long values for quadword instructions and int values for longword
         // instructions in order to avoid (potential) overflow issues.
-        if (auto quadword =
-                std::dynamic_pointer_cast<Assembly::Quadword>(type)) {
+        if (dynamic_cast<const Assembly::Quadword *>(type)) {
             srcStr = "$" + std::to_string(srcImm->getImmediateLong());
         }
         else {
@@ -442,12 +422,11 @@ void PipelineStagesExecutors::emitAssyMovInstruction(
         }
     }
     else if (auto srcStack =
-                 std::dynamic_pointer_cast<Assembly::StackOperand>(src)) {
+                 dynamic_cast<const Assembly::StackOperand *>(src)) {
         srcStr = std::to_string(srcStack->getOffset()) + "(" +
                  srcStack->getReservedRegisterInStr() + ")";
     }
-    else if (auto srcData =
-                 std::dynamic_pointer_cast<Assembly::DataOperand>(src)) {
+    else if (auto srcData = dynamic_cast<const Assembly::DataOperand *>(src)) {
         auto identifier = srcData->getIdentifier();
         prependUnderscoreToIdentifierIfMacOS(identifier);
         srcStr = identifier + "(%rip)";
@@ -457,19 +436,17 @@ void PipelineStagesExecutors::emitAssyMovInstruction(
             "Invalid source type while printing assembly mov instruction");
     }
 
-    auto dst = movInstruction->getDst();
+    auto dst = movInstruction.getDst();
     std::string dstStr;
-    if (auto dstReg =
-            std::dynamic_pointer_cast<Assembly::RegisterOperand>(dst)) {
+    if (auto dstReg = dynamic_cast<const Assembly::RegisterOperand *>(dst)) {
         dstStr = dstReg->getRegisterInBytesInStr(registerSize);
     }
     else if (auto dstStack =
-                 std::dynamic_pointer_cast<Assembly::StackOperand>(dst)) {
+                 dynamic_cast<const Assembly::StackOperand *>(dst)) {
         dstStr = std::to_string(dstStack->getOffset()) + "(" +
                  dstStack->getReservedRegisterInStr() + ")";
     }
-    else if (auto dstData =
-                 std::dynamic_pointer_cast<Assembly::DataOperand>(dst)) {
+    else if (auto dstData = dynamic_cast<const Assembly::DataOperand *>(dst)) {
         auto identifier = dstData->getIdentifier();
         prependUnderscoreToIdentifierIfMacOS(identifier);
         dstStr = identifier + "(%rip)";
@@ -484,25 +461,23 @@ void PipelineStagesExecutors::emitAssyMovInstruction(
 }
 
 void PipelineStagesExecutors::emitAssyMovsxInstruction(
-    const std::shared_ptr<Assembly::MovsxInstruction> &movsxInstruction,
+    const Assembly::MovsxInstruction &movsxInstruction,
     std::ofstream &assemblyFileStream) {
-    auto src = movsxInstruction->getSrc();
+    auto src = movsxInstruction.getSrc();
     std::string srcStr;
-    if (auto srcReg =
-            std::dynamic_pointer_cast<Assembly::RegisterOperand>(src)) {
+    if (auto srcReg = dynamic_cast<const Assembly::RegisterOperand *>(src)) {
         srcStr = srcReg->getRegisterInBytesInStr(4);
     }
     else if (auto srcImm =
-                 std::dynamic_pointer_cast<Assembly::ImmediateOperand>(src)) {
+                 dynamic_cast<const Assembly::ImmediateOperand *>(src)) {
         srcStr = "$" + std::to_string(srcImm->getImmediateLong());
     }
     else if (auto srcStack =
-                 std::dynamic_pointer_cast<Assembly::StackOperand>(src)) {
+                 dynamic_cast<const Assembly::StackOperand *>(src)) {
         srcStr = std::to_string(srcStack->getOffset()) + "(" +
                  srcStack->getReservedRegisterInStr() + ")";
     }
-    else if (auto srcData =
-                 std::dynamic_pointer_cast<Assembly::DataOperand>(src)) {
+    else if (auto srcData = dynamic_cast<const Assembly::DataOperand *>(src)) {
         auto identifier = srcData->getIdentifier();
         prependUnderscoreToIdentifierIfMacOS(identifier);
         srcStr = identifier + "(%rip)";
@@ -519,19 +494,17 @@ void PipelineStagesExecutors::emitAssyMovsxInstruction(
         throw std::logic_error(msg.str());
     }
 
-    auto dst = movsxInstruction->getDst();
+    auto dst = movsxInstruction.getDst();
     std::string dstStr;
-    if (auto dstReg =
-            std::dynamic_pointer_cast<Assembly::RegisterOperand>(dst)) {
+    if (auto dstReg = dynamic_cast<const Assembly::RegisterOperand *>(dst)) {
         dstStr = dstReg->getRegisterInBytesInStr(8);
     }
     else if (auto dstStack =
-                 std::dynamic_pointer_cast<Assembly::StackOperand>(dst)) {
+                 dynamic_cast<const Assembly::StackOperand *>(dst)) {
         dstStr = std::to_string(dstStack->getOffset()) + "(" +
                  dstStack->getReservedRegisterInStr() + ")";
     }
-    else if (auto dstData =
-                 std::dynamic_pointer_cast<Assembly::DataOperand>(dst)) {
+    else if (auto dstData = dynamic_cast<const Assembly::DataOperand *>(dst)) {
         auto identifier = dstData->getIdentifier();
         prependUnderscoreToIdentifierIfMacOS(identifier);
         dstStr = identifier + "(%rip)";
@@ -554,29 +527,27 @@ void PipelineStagesExecutors::emitAssyRetInstruction(
 }
 
 void PipelineStagesExecutors::emitAssyPushInstruction(
-    const std::shared_ptr<Assembly::PushInstruction> &pushInstruction,
+    const Assembly::PushInstruction &pushInstruction,
     std::ofstream &assemblyFileStream) {
-    auto operand = pushInstruction->getOperand();
+    auto operand = pushInstruction.getOperand();
 
     if (auto stackOperand =
-            std::dynamic_pointer_cast<Assembly::StackOperand>(operand)) {
+            dynamic_cast<const Assembly::StackOperand *>(operand)) {
         assemblyFileStream << "    pushq " << stackOperand->getOffset() << "("
                            << stackOperand->getReservedRegisterInStr() << ")\n";
     }
     else if (auto regOperand =
-                 std::dynamic_pointer_cast<Assembly::RegisterOperand>(
-                     operand)) {
+                 dynamic_cast<const Assembly::RegisterOperand *>(operand)) {
         assemblyFileStream << "    pushq "
                            << regOperand->getRegisterInBytesInStr(8) << "\n";
     }
     else if (auto immOperand =
-                 std::dynamic_pointer_cast<Assembly::ImmediateOperand>(
-                     operand)) {
+                 dynamic_cast<const Assembly::ImmediateOperand *>(operand)) {
         assemblyFileStream << "    pushq $" << immOperand->getImmediateLong()
                            << "\n";
     }
     else if (auto dataOperand =
-                 std::dynamic_pointer_cast<Assembly::DataOperand>(operand)) {
+                 dynamic_cast<const Assembly::DataOperand *>(operand)) {
         auto identifier = dataOperand->getIdentifier();
         prependUnderscoreToIdentifierIfMacOS(identifier);
         assemblyFileStream << "    pushq " << identifier << "(%rip)\n";
@@ -588,9 +559,9 @@ void PipelineStagesExecutors::emitAssyPushInstruction(
 }
 
 void PipelineStagesExecutors::emitAssyCallInstruction(
-    const std::shared_ptr<Assembly::CallInstruction> &callInstruction,
+    const Assembly::CallInstruction &callInstruction,
     std::ofstream &assemblyFileStream) {
-    auto functionName = callInstruction->getFunctionIdentifier();
+    auto functionName = callInstruction.getFunctionIdentifier();
     prependUnderscoreToIdentifierIfMacOS(functionName);
     assemblyFileStream << "    call " << functionName;
 // If the underlying OS is Linux, add the `@PLT` suffix (PLT modifier) to the
@@ -602,25 +573,20 @@ void PipelineStagesExecutors::emitAssyCallInstruction(
 }
 
 void PipelineStagesExecutors::emitAssyUnaryInstruction(
-    const std::shared_ptr<Assembly::UnaryInstruction> &unaryInstruction,
+    const Assembly::UnaryInstruction &unaryInstruction,
     std::ofstream &assemblyFileStream) {
-    auto unaryOperator = unaryInstruction->getUnaryOperator();
-    auto type = unaryInstruction->getType();
+    auto unaryOperator = unaryInstruction.getUnaryOperator();
+    auto type = unaryInstruction.getType();
 
     std::string instructionName;
-    if (auto negateOperator =
-            std::dynamic_pointer_cast<Assembly::NegateOperator>(
-                unaryOperator)) {
+    if (dynamic_cast<const Assembly::NegateOperator *>(unaryOperator)) {
         instructionName = "neg";
     }
-    else if (auto complementOperator =
-                 std::dynamic_pointer_cast<Assembly::ComplementOperator>(
-                     unaryOperator)) {
+    else if (dynamic_cast<const Assembly::ComplementOperator *>(
+                 unaryOperator)) {
         instructionName = "not";
     }
-    else if (auto notOperator =
-                 std::dynamic_pointer_cast<Assembly::NotOperator>(
-                     unaryOperator)) {
+    else if (dynamic_cast<const Assembly::NotOperator *>(unaryOperator)) {
         instructionName = "not";
     }
     else {
@@ -630,12 +596,11 @@ void PipelineStagesExecutors::emitAssyUnaryInstruction(
 
     std::string typeSuffix;
     int registerSize;
-    if (auto longword = std::dynamic_pointer_cast<Assembly::Longword>(type)) {
+    if (dynamic_cast<const Assembly::Longword *>(type)) {
         typeSuffix = "l";
         registerSize = 4;
     }
-    else if (auto quadword =
-                 std::dynamic_pointer_cast<Assembly::Quadword>(type)) {
+    else if (dynamic_cast<const Assembly::Quadword *>(type)) {
         typeSuffix = "q";
         registerSize = 8;
     }
@@ -646,20 +611,20 @@ void PipelineStagesExecutors::emitAssyUnaryInstruction(
 
     assemblyFileStream << "    " << instructionName << typeSuffix;
 
-    auto operand = unaryInstruction->getOperand();
+    auto operand = unaryInstruction.getOperand();
     if (auto regOperand =
-            std::dynamic_pointer_cast<Assembly::RegisterOperand>(operand)) {
+            dynamic_cast<const Assembly::RegisterOperand *>(operand)) {
         assemblyFileStream << " "
                            << regOperand->getRegisterInBytesInStr(registerSize)
                            << "\n";
     }
     else if (auto stackOperand =
-                 std::dynamic_pointer_cast<Assembly::StackOperand>(operand)) {
+                 dynamic_cast<const Assembly::StackOperand *>(operand)) {
         assemblyFileStream << " " << stackOperand->getOffset() << "("
                            << stackOperand->getReservedRegisterInStr() << ")\n";
     }
     else if (auto dataOperand =
-                 std::dynamic_pointer_cast<Assembly::DataOperand>(operand)) {
+                 dynamic_cast<const Assembly::DataOperand *>(operand)) {
         auto identifier = dataOperand->getIdentifier();
         prependUnderscoreToIdentifierIfMacOS(identifier);
         assemblyFileStream << " " << identifier << "(%rip)\n";
@@ -671,24 +636,19 @@ void PipelineStagesExecutors::emitAssyUnaryInstruction(
 }
 
 void PipelineStagesExecutors::emitAssyBinaryInstruction(
-    const std::shared_ptr<Assembly::BinaryInstruction> &binaryInstruction,
+    const Assembly::BinaryInstruction &binaryInstruction,
     std::ofstream &assemblyFileStream) {
-    auto binaryOperator = binaryInstruction->getBinaryOperator();
-    auto type = binaryInstruction->getType();
+    auto binaryOperator = binaryInstruction.getBinaryOperator();
+    auto type = binaryInstruction.getType();
 
     std::string instructionName;
-    if (auto addOperator =
-            std::dynamic_pointer_cast<Assembly::AddOperator>(binaryOperator)) {
+    if (dynamic_cast<const Assembly::AddOperator *>(binaryOperator)) {
         instructionName = "add";
     }
-    else if (auto subtractOperator =
-                 std::dynamic_pointer_cast<Assembly::SubtractOperator>(
-                     binaryOperator)) {
+    else if (dynamic_cast<const Assembly::SubtractOperator *>(binaryOperator)) {
         instructionName = "sub";
     }
-    else if (auto multiplyOperator =
-                 std::dynamic_pointer_cast<Assembly::MultiplyOperator>(
-                     binaryOperator)) {
+    else if (dynamic_cast<const Assembly::MultiplyOperator *>(binaryOperator)) {
         instructionName = "imul";
     }
     else {
@@ -698,12 +658,11 @@ void PipelineStagesExecutors::emitAssyBinaryInstruction(
 
     std::string typeSuffix;
     int registerSize;
-    if (auto longword = std::dynamic_pointer_cast<Assembly::Longword>(type)) {
+    if (dynamic_cast<const Assembly::Longword *>(type)) {
         typeSuffix = "l";
         registerSize = 4;
     }
-    else if (auto quadword =
-                 std::dynamic_pointer_cast<Assembly::Quadword>(type)) {
+    else if (dynamic_cast<const Assembly::Quadword *>(type)) {
         typeSuffix = "q";
         registerSize = 8;
     }
@@ -714,11 +673,10 @@ void PipelineStagesExecutors::emitAssyBinaryInstruction(
 
     assemblyFileStream << "    " << instructionName << typeSuffix;
 
-    auto operand1 = binaryInstruction->getOperand1();
+    auto operand1 = binaryInstruction.getOperand1();
     if (auto operand1Imm =
-            std::dynamic_pointer_cast<Assembly::ImmediateOperand>(operand1)) {
-        if (auto quadword =
-                std::dynamic_pointer_cast<Assembly::Quadword>(type)) {
+            dynamic_cast<const Assembly::ImmediateOperand *>(operand1)) {
+        if (dynamic_cast<const Assembly::Quadword *>(type)) {
             assemblyFileStream << " $" << operand1Imm->getImmediateLong()
                                << ",";
         }
@@ -727,39 +685,38 @@ void PipelineStagesExecutors::emitAssyBinaryInstruction(
         }
     }
     else if (auto operand1Reg =
-                 std::dynamic_pointer_cast<Assembly::RegisterOperand>(
-                     operand1)) {
+                 dynamic_cast<const Assembly::RegisterOperand *>(operand1)) {
         assemblyFileStream << " "
                            << operand1Reg->getRegisterInBytesInStr(registerSize)
                            << ",";
     }
     else if (auto operand1Stack =
-                 std::dynamic_pointer_cast<Assembly::StackOperand>(operand1)) {
+                 dynamic_cast<const Assembly::StackOperand *>(operand1)) {
         assemblyFileStream << " " << operand1Stack->getOffset() << "("
                            << operand1Stack->getReservedRegisterInStr() << "),";
     }
     else if (auto operand1Data =
-                 std::dynamic_pointer_cast<Assembly::DataOperand>(operand1)) {
+                 dynamic_cast<const Assembly::DataOperand *>(operand1)) {
         auto identifier = operand1Data->getIdentifier();
         prependUnderscoreToIdentifierIfMacOS(identifier);
         assemblyFileStream << " " << identifier << "(%rip),";
     }
 
-    auto operand2 = binaryInstruction->getOperand2();
+    auto operand2 = binaryInstruction.getOperand2();
     if (auto operand2Reg =
-            std::dynamic_pointer_cast<Assembly::RegisterOperand>(operand2)) {
+            dynamic_cast<const Assembly::RegisterOperand *>(operand2)) {
         assemblyFileStream << " "
                            << operand2Reg->getRegisterInBytesInStr(registerSize)
                            << "\n";
     }
     else if (auto operand2Stack =
-                 std::dynamic_pointer_cast<Assembly::StackOperand>(operand2)) {
+                 dynamic_cast<const Assembly::StackOperand *>(operand2)) {
         assemblyFileStream << " " << operand2Stack->getOffset() << "("
                            << operand2Stack->getReservedRegisterInStr()
                            << ")\n";
     }
     else if (auto operand2Data =
-                 std::dynamic_pointer_cast<Assembly::DataOperand>(operand2)) {
+                 dynamic_cast<const Assembly::DataOperand *>(operand2)) {
         auto identifier = operand2Data->getIdentifier();
         prependUnderscoreToIdentifierIfMacOS(identifier);
         assemblyFileStream << " " << identifier << "(%rip)\n";
@@ -771,18 +728,17 @@ void PipelineStagesExecutors::emitAssyBinaryInstruction(
 }
 
 void PipelineStagesExecutors::emitAssyCmpInstruction(
-    const std::shared_ptr<Assembly::CmpInstruction> &cmpInstruction,
+    const Assembly::CmpInstruction &cmpInstruction,
     std::ofstream &assemblyFileStream) {
-    auto type = cmpInstruction->getType();
+    auto type = cmpInstruction.getType();
 
     std::string typeSuffix;
     int registerSize;
-    if (auto longword = std::dynamic_pointer_cast<Assembly::Longword>(type)) {
+    if (dynamic_cast<const Assembly::Longword *>(type)) {
         typeSuffix = "l";
         registerSize = 4;
     }
-    else if (auto quadword =
-                 std::dynamic_pointer_cast<Assembly::Quadword>(type)) {
+    else if (dynamic_cast<const Assembly::Quadword *>(type)) {
         typeSuffix = "q";
         registerSize = 8;
     }
@@ -793,11 +749,10 @@ void PipelineStagesExecutors::emitAssyCmpInstruction(
 
     assemblyFileStream << "    cmp" << typeSuffix;
 
-    auto operand1 = cmpInstruction->getOperand1();
+    auto operand1 = cmpInstruction.getOperand1();
     if (auto operand1Imm =
-            std::dynamic_pointer_cast<Assembly::ImmediateOperand>(operand1)) {
-        if (auto quadword =
-                std::dynamic_pointer_cast<Assembly::Quadword>(type)) {
+            dynamic_cast<const Assembly::ImmediateOperand *>(operand1)) {
+        if (dynamic_cast<const Assembly::Quadword *>(type)) {
             assemblyFileStream << " $" << operand1Imm->getImmediateLong();
         }
         else {
@@ -805,19 +760,18 @@ void PipelineStagesExecutors::emitAssyCmpInstruction(
         }
     }
     else if (auto operand1Reg =
-                 std::dynamic_pointer_cast<Assembly::RegisterOperand>(
-                     operand1)) {
+                 dynamic_cast<const Assembly::RegisterOperand *>(operand1)) {
         assemblyFileStream << " "
                            << operand1Reg->getRegisterInBytesInStr(
                                   registerSize);
     }
     else if (auto operand1Stack =
-                 std::dynamic_pointer_cast<Assembly::StackOperand>(operand1)) {
+                 dynamic_cast<const Assembly::StackOperand *>(operand1)) {
         assemblyFileStream << " " << operand1Stack->getOffset() << "("
                            << operand1Stack->getReservedRegisterInStr() << ")";
     }
     else if (auto operand1Data =
-                 std::dynamic_pointer_cast<Assembly::DataOperand>(operand1)) {
+                 dynamic_cast<const Assembly::DataOperand *>(operand1)) {
         auto identifier = operand1Data->getIdentifier();
         prependUnderscoreToIdentifierIfMacOS(identifier);
         assemblyFileStream << " " << identifier << "(%rip)";
@@ -825,21 +779,21 @@ void PipelineStagesExecutors::emitAssyCmpInstruction(
 
     assemblyFileStream << ",";
 
-    auto operand2 = cmpInstruction->getOperand2();
+    auto operand2 = cmpInstruction.getOperand2();
     if (auto operand2Reg =
-            std::dynamic_pointer_cast<Assembly::RegisterOperand>(operand2)) {
+            dynamic_cast<const Assembly::RegisterOperand *>(operand2)) {
         assemblyFileStream << " "
                            << operand2Reg->getRegisterInBytesInStr(registerSize)
                            << "\n";
     }
     else if (auto operand2Stack =
-                 std::dynamic_pointer_cast<Assembly::StackOperand>(operand2)) {
+                 dynamic_cast<const Assembly::StackOperand *>(operand2)) {
         assemblyFileStream << " " << operand2Stack->getOffset() << "("
                            << operand2Stack->getReservedRegisterInStr()
                            << ")\n";
     }
     else if (auto operand2Data =
-                 std::dynamic_pointer_cast<Assembly::DataOperand>(operand2)) {
+                 dynamic_cast<const Assembly::DataOperand *>(operand2)) {
         auto identifier = operand2Data->getIdentifier();
         prependUnderscoreToIdentifierIfMacOS(identifier);
         assemblyFileStream << " " << identifier << "(%rip)\n";
@@ -851,18 +805,17 @@ void PipelineStagesExecutors::emitAssyCmpInstruction(
 }
 
 void PipelineStagesExecutors::emitAssyIdivInstruction(
-    const std::shared_ptr<Assembly::IdivInstruction> &idivInstruction,
+    const Assembly::IdivInstruction &idivInstruction,
     std::ofstream &assemblyFileStream) {
-    auto type = idivInstruction->getType();
+    auto type = idivInstruction.getType();
 
     std::string typeSuffix;
     int registerSize;
-    if (auto longword = std::dynamic_pointer_cast<Assembly::Longword>(type)) {
+    if (dynamic_cast<const Assembly::Longword *>(type)) {
         typeSuffix = "l";
         registerSize = 4;
     }
-    else if (auto quadword =
-                 std::dynamic_pointer_cast<Assembly::Quadword>(type)) {
+    else if (dynamic_cast<const Assembly::Quadword *>(type)) {
         typeSuffix = "q";
         registerSize = 8;
     }
@@ -873,20 +826,20 @@ void PipelineStagesExecutors::emitAssyIdivInstruction(
 
     assemblyFileStream << "    idiv" << typeSuffix;
 
-    auto operand = idivInstruction->getOperand();
+    auto operand = idivInstruction.getOperand();
     if (auto regOperand =
-            std::dynamic_pointer_cast<Assembly::RegisterOperand>(operand)) {
+            dynamic_cast<const Assembly::RegisterOperand *>(operand)) {
         assemblyFileStream << " "
                            << regOperand->getRegisterInBytesInStr(registerSize)
                            << "\n";
     }
     else if (auto stackOperand =
-                 std::dynamic_pointer_cast<Assembly::StackOperand>(operand)) {
+                 dynamic_cast<const Assembly::StackOperand *>(operand)) {
         assemblyFileStream << " " << stackOperand->getOffset() << "("
                            << stackOperand->getReservedRegisterInStr() << ")\n";
     }
     else if (auto dataOperand =
-                 std::dynamic_pointer_cast<Assembly::DataOperand>(operand)) {
+                 dynamic_cast<const Assembly::DataOperand *>(operand)) {
         auto identifier = dataOperand->getIdentifier();
         prependUnderscoreToIdentifierIfMacOS(identifier);
         assemblyFileStream << " " << identifier << "(%rip)\n";
@@ -898,15 +851,14 @@ void PipelineStagesExecutors::emitAssyIdivInstruction(
 }
 
 void PipelineStagesExecutors::emitAssyCdqInstruction(
-    const std::shared_ptr<Assembly::CdqInstruction> &cdqInstruction,
+    const Assembly::CdqInstruction &cdqInstruction,
     std::ofstream &assemblyFileStream) {
-    auto type = cdqInstruction->getType();
+    auto type = cdqInstruction.getType();
 
-    if (auto longword = std::dynamic_pointer_cast<Assembly::Longword>(type)) {
+    if (dynamic_cast<const Assembly::Longword *>(type)) {
         assemblyFileStream << "    cdq\n";
     }
-    else if (auto quadword =
-                 std::dynamic_pointer_cast<Assembly::Quadword>(type)) {
+    else if (dynamic_cast<const Assembly::Quadword *>(type)) {
         assemblyFileStream << "    cqo\n";
     }
     else {
@@ -916,32 +868,32 @@ void PipelineStagesExecutors::emitAssyCdqInstruction(
 }
 
 void PipelineStagesExecutors::emitAssyJmpInstruction(
-    const std::shared_ptr<Assembly::JmpInstruction> &jmpInstruction,
+    const Assembly::JmpInstruction &jmpInstruction,
     std::ofstream &assemblyFileStream) {
-    auto label = jmpInstruction->getLabel();
+    auto label = jmpInstruction.getLabel();
     assemblyFileStream << "    jmp .L" << label << "\n";
 }
 
 void PipelineStagesExecutors::emitAssyJmpCCInstruction(
-    const std::shared_ptr<Assembly::JmpCCInstruction> &jmpCCInstruction,
+    const Assembly::JmpCCInstruction &jmpCCInstruction,
     std::ofstream &assemblyFileStream) {
-    auto condCode = jmpCCInstruction->getCondCode();
-    if (auto e = std::dynamic_pointer_cast<Assembly::E>(condCode)) {
+    auto condCode = jmpCCInstruction.getCondCode();
+    if (dynamic_cast<const Assembly::E *>(condCode)) {
         assemblyFileStream << "    je";
     }
-    else if (auto ne = std::dynamic_pointer_cast<Assembly::NE>(condCode)) {
+    else if (dynamic_cast<const Assembly::NE *>(condCode)) {
         assemblyFileStream << "    jne";
     }
-    else if (auto g = std::dynamic_pointer_cast<Assembly::G>(condCode)) {
+    else if (dynamic_cast<const Assembly::G *>(condCode)) {
         assemblyFileStream << "    jg";
     }
-    else if (auto ge = std::dynamic_pointer_cast<Assembly::GE>(condCode)) {
+    else if (dynamic_cast<const Assembly::GE *>(condCode)) {
         assemblyFileStream << "    jge";
     }
-    else if (auto l = std::dynamic_pointer_cast<Assembly::L>(condCode)) {
+    else if (dynamic_cast<const Assembly::L *>(condCode)) {
         assemblyFileStream << "    jl";
     }
-    else if (auto le = std::dynamic_pointer_cast<Assembly::LE>(condCode)) {
+    else if (dynamic_cast<const Assembly::LE *>(condCode)) {
         assemblyFileStream << "    jle";
     }
     else {
@@ -949,30 +901,30 @@ void PipelineStagesExecutors::emitAssyJmpCCInstruction(
                                "assembly jmpcc instruction");
     }
 
-    auto label = jmpCCInstruction->getLabel();
+    auto label = jmpCCInstruction.getLabel();
     assemblyFileStream << " .L" << label << "\n";
 }
 
 void PipelineStagesExecutors::emitAssySetCCInstruction(
-    const std::shared_ptr<Assembly::SetCCInstruction> &setCCInstruction,
+    const Assembly::SetCCInstruction &setCCInstruction,
     std::ofstream &assemblyFileStream) {
-    auto condCode = setCCInstruction->getCondCode();
-    if (auto e = std::dynamic_pointer_cast<Assembly::E>(condCode)) {
+    auto condCode = setCCInstruction.getCondCode();
+    if (dynamic_cast<const Assembly::E *>(condCode)) {
         assemblyFileStream << "    sete";
     }
-    else if (auto ne = std::dynamic_pointer_cast<Assembly::NE>(condCode)) {
+    else if (dynamic_cast<const Assembly::NE *>(condCode)) {
         assemblyFileStream << "    setne";
     }
-    else if (auto g = std::dynamic_pointer_cast<Assembly::G>(condCode)) {
+    else if (dynamic_cast<const Assembly::G *>(condCode)) {
         assemblyFileStream << "    setg";
     }
-    else if (auto ge = std::dynamic_pointer_cast<Assembly::GE>(condCode)) {
+    else if (dynamic_cast<const Assembly::GE *>(condCode)) {
         assemblyFileStream << "    setge";
     }
-    else if (auto l = std::dynamic_pointer_cast<Assembly::L>(condCode)) {
+    else if (dynamic_cast<const Assembly::L *>(condCode)) {
         assemblyFileStream << "    setl";
     }
-    else if (auto le = std::dynamic_pointer_cast<Assembly::LE>(condCode)) {
+    else if (dynamic_cast<const Assembly::LE *>(condCode)) {
         assemblyFileStream << "    setle";
     }
     else {
@@ -980,19 +932,19 @@ void PipelineStagesExecutors::emitAssySetCCInstruction(
                                "assembly setcc instruction");
     }
 
-    auto operand = setCCInstruction->getOperand();
+    auto operand = setCCInstruction.getOperand();
     if (auto regOperand =
-            std::dynamic_pointer_cast<Assembly::RegisterOperand>(operand)) {
+            dynamic_cast<const Assembly::RegisterOperand *>(operand)) {
         assemblyFileStream << " " << regOperand->getRegisterInBytesInStr(1)
                            << "\n";
     }
     else if (auto stackOperand =
-                 std::dynamic_pointer_cast<Assembly::StackOperand>(operand)) {
+                 dynamic_cast<const Assembly::StackOperand *>(operand)) {
         assemblyFileStream << " " << stackOperand->getOffset() << "("
                            << stackOperand->getReservedRegisterInStr() << ")\n";
     }
     else if (auto dataOperand =
-                 std::dynamic_pointer_cast<Assembly::DataOperand>(operand)) {
+                 dynamic_cast<const Assembly::DataOperand *>(operand)) {
         auto identifier = dataOperand->getIdentifier();
         prependUnderscoreToIdentifierIfMacOS(identifier);
         assemblyFileStream << " " << identifier << "(%rip)\n";
@@ -1004,9 +956,9 @@ void PipelineStagesExecutors::emitAssySetCCInstruction(
 }
 
 void PipelineStagesExecutors::emitAssyLabelInstruction(
-    const std::shared_ptr<Assembly::LabelInstruction> &labelInstruction,
+    const Assembly::LabelInstruction &labelInstruction,
     std::ofstream &assemblyFileStream) {
-    auto label = labelInstruction->getLabel();
+    auto label = labelInstruction.getLabel();
     assemblyFileStream << ".L" << label << ":\n";
 }
 

--- a/src/utils/pipelineStagesExecutors.h
+++ b/src/utils/pipelineStagesExecutors.h
@@ -63,12 +63,12 @@ class PipelineStagesExecutors {
      * @param variableResolutionCounter An integer counter for variable
      * resolution.
      * @param frontendSymbolTable The frontend symbol table.
-     * @return A pair consisting of (a shared pointer to) the IR program and (a
-     * shared pointer to) the vector of static variables in IR.
+     * @return A pair consisting of the IR program and the vector of static
+     * variables in IR.
      */
     [[nodiscard]] static std::pair<
-        std::shared_ptr<IR::Program>,
-        std::shared_ptr<std::vector<std::shared_ptr<IR::StaticVariable>>>>
+        std::unique_ptr<IR::Program>,
+        std::unique_ptr<std::vector<std::unique_ptr<IR::StaticVariable>>>>
     irGeneratorExecutor(const std::shared_ptr<AST::Program> &astProgram,
                         int variableResolutionCounter,
                         AST::FrontendSymbolTable &frontendSymbolTable);
@@ -84,11 +84,11 @@ class PipelineStagesExecutors {
      * @param eliminateDeadStoresPass Whether to perform the dead-store
      * elimination pass.
      */
-    static void
-    irOptimizationExecutor(const std::shared_ptr<IR::Program> &irProgram,
-                           bool foldConstantsPass, bool propagateCopiesPass,
-                           bool eliminateUnreachableCodePass,
-                           bool eliminateDeadStoresPass);
+    static void irOptimizationExecutor(IR::Program &irProgram,
+                                       bool foldConstantsPass,
+                                       bool propagateCopiesPass,
+                                       bool eliminateUnreachableCodePass,
+                                       bool eliminateDeadStoresPass);
 
     /**
      * Generate (but not yet emit) the assembly program from the IR program.
@@ -98,11 +98,11 @@ class PipelineStagesExecutors {
      * @param frontendSymbolTable The frontend symbol table.
      * @return The assembly program generated from the IR.
      */
-    [[nodiscard]] static std::shared_ptr<Assembly::Program> codegenExecutor(
-        const std::shared_ptr<IR::Program> &irProgram,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::StaticVariable>>>
-            &irStaticVariables,
-        const AST::FrontendSymbolTable &frontendSymbolTable);
+    [[nodiscard]] static std::shared_ptr<Assembly::Program>
+    codegenExecutor(const IR::Program &irProgram,
+                    const std::vector<std::unique_ptr<IR::StaticVariable>>
+                        &irStaticVariables,
+                    const AST::FrontendSymbolTable &frontendSymbolTable);
 
     /**
      * Emit the generated assembly code to the assembly file.

--- a/src/utils/pipelineStagesExecutors.h
+++ b/src/utils/pipelineStagesExecutors.h
@@ -16,6 +16,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <string.h>
 #include <string_view>
@@ -42,7 +43,7 @@ class PipelineStagesExecutors {
      * @param tokens The list of tokens to parse.
      * @return The AST program generated from parsing.
      */
-    [[nodiscard]] static std::shared_ptr<AST::Program>
+    [[nodiscard]] static std::unique_ptr<AST::Program>
     parserExecutor(const std::vector<Token> &tokens);
 
     /**
@@ -53,7 +54,7 @@ class PipelineStagesExecutors {
      * @return An integer counter for variable resolution.
      */
     [[nodiscard]] static int
-    semanticAnalysisExecutor(const std::shared_ptr<AST::Program> &astProgram,
+    semanticAnalysisExecutor(AST::Program &astProgram,
                              AST::FrontendSymbolTable &frontendSymbolTable);
 
     /**
@@ -69,7 +70,7 @@ class PipelineStagesExecutors {
     [[nodiscard]] static std::pair<
         std::unique_ptr<IR::Program>,
         std::unique_ptr<std::vector<std::unique_ptr<IR::StaticVariable>>>>
-    irGeneratorExecutor(const std::shared_ptr<AST::Program> &astProgram,
+    irGeneratorExecutor(const AST::Program &astProgram,
                         int variableResolutionCounter,
                         AST::FrontendSymbolTable &frontendSymbolTable);
 
@@ -98,7 +99,7 @@ class PipelineStagesExecutors {
      * @param frontendSymbolTable The frontend symbol table.
      * @return The assembly program generated from the IR.
      */
-    [[nodiscard]] static std::shared_ptr<Assembly::Program>
+    [[nodiscard]] static std::unique_ptr<Assembly::Program>
     codegenExecutor(const IR::Program &irProgram,
                     const std::vector<std::unique_ptr<IR::StaticVariable>>
                         &irStaticVariables,
@@ -110,9 +111,8 @@ class PipelineStagesExecutors {
      * @param assemblyProgram The assembly program to emit.
      * @param assemblyFile The output assembly file.
      */
-    static void codeEmissionExecutor(
-        const std::shared_ptr<Assembly::Program> &assemblyProgram,
-        std::string_view assemblyFile);
+    static void codeEmissionExecutor(const Assembly::Program &assemblyProgram,
+                                     std::string_view assemblyFile);
 
   private:
     /**
@@ -122,7 +122,7 @@ class PipelineStagesExecutors {
      * @param assemblyFileStream The output assembly file stream.
      */
     static void emitAssyFunctionDefinition(
-        const std::shared_ptr<Assembly::FunctionDefinition> &functionDefinition,
+        const Assembly::FunctionDefinition &functionDefinition,
         std::ofstream &assemblyFileStream);
 
     /**
@@ -131,9 +131,9 @@ class PipelineStagesExecutors {
      * @param staticVariable The static variable to emit.
      * @param assemblyFileStream The output assembly file stream.
      */
-    static void emitAssyStaticVariable(
-        const std::shared_ptr<Assembly::StaticVariable> &staticVariable,
-        std::ofstream &assemblyFileStream);
+    static void
+    emitAssyStaticVariable(const Assembly::StaticVariable &staticVariable,
+                           std::ofstream &assemblyFileStream);
 
     /**
      * Emit the assembly code for an instruction.
@@ -141,9 +141,8 @@ class PipelineStagesExecutors {
      * @param instruction The instruction to emit.
      * @param assemblyFileStream The output assembly file stream.
      */
-    static void emitAssyInstruction(
-        const std::shared_ptr<Assembly::Instruction> &instruction,
-        std::ofstream &assemblyFileStream);
+    static void emitAssyInstruction(const Assembly::Instruction &instruction,
+                                    std::ofstream &assemblyFileStream);
 
     /**
      * Emit the assembly code for a move instruction.
@@ -151,9 +150,9 @@ class PipelineStagesExecutors {
      * @param movInstruction The move instruction to emit.
      * @param assemblyFileStream The output assembly file stream.
      */
-    static void emitAssyMovInstruction(
-        const std::shared_ptr<Assembly::MovInstruction> &movInstruction,
-        std::ofstream &assemblyFileStream);
+    static void
+    emitAssyMovInstruction(const Assembly::MovInstruction &movInstruction,
+                           std::ofstream &assemblyFileStream);
 
     /**
      * Emit the assembly code for a move-with-sign-extend instruction.
@@ -161,9 +160,9 @@ class PipelineStagesExecutors {
      * @param movsxInstruction The move-with-sign-extend instruction to emit.
      * @param assemblyFileStream The output assembly file stream.
      */
-    static void emitAssyMovsxInstruction(
-        const std::shared_ptr<Assembly::MovsxInstruction> &movsxInstruction,
-        std::ofstream &assemblyFileStream);
+    static void
+    emitAssyMovsxInstruction(const Assembly::MovsxInstruction &movsxInstruction,
+                             std::ofstream &assemblyFileStream);
 
     /**
      * Emit the assembly code for a return instruction.
@@ -178,9 +177,9 @@ class PipelineStagesExecutors {
      * @param pushInstruction The push instruction to emit.
      * @param assemblyFileStream The output assembly file stream.
      */
-    static void emitAssyPushInstruction(
-        const std::shared_ptr<Assembly::PushInstruction> &pushInstruction,
-        std::ofstream &assemblyFileStream);
+    static void
+    emitAssyPushInstruction(const Assembly::PushInstruction &pushInstruction,
+                            std::ofstream &assemblyFileStream);
 
     /**
      * Emit the assembly code for a call instruction.
@@ -188,9 +187,9 @@ class PipelineStagesExecutors {
      * @param callInstruction The call instruction to emit.
      * @param assemblyFileStream The output assembly file stream.
      */
-    static void emitAssyCallInstruction(
-        const std::shared_ptr<Assembly::CallInstruction> &callInstruction,
-        std::ofstream &assemblyFileStream);
+    static void
+    emitAssyCallInstruction(const Assembly::CallInstruction &callInstruction,
+                            std::ofstream &assemblyFileStream);
 
     /**
      * Emit the assembly code for a unary instruction.
@@ -198,9 +197,9 @@ class PipelineStagesExecutors {
      * @param unaryInstruction The unary instruction to emit.
      * @param assemblyFileStream The output assembly file stream.
      */
-    static void emitAssyUnaryInstruction(
-        const std::shared_ptr<Assembly::UnaryInstruction> &unaryInstruction,
-        std::ofstream &assemblyFileStream);
+    static void
+    emitAssyUnaryInstruction(const Assembly::UnaryInstruction &unaryInstruction,
+                             std::ofstream &assemblyFileStream);
 
     /**
      * Emit the assembly code for a binary instruction.
@@ -209,7 +208,7 @@ class PipelineStagesExecutors {
      * @param assemblyFileStream The output assembly file stream.
      */
     static void emitAssyBinaryInstruction(
-        const std::shared_ptr<Assembly::BinaryInstruction> &binaryInstruction,
+        const Assembly::BinaryInstruction &binaryInstruction,
         std::ofstream &assemblyFileStream);
 
     /**
@@ -218,9 +217,9 @@ class PipelineStagesExecutors {
      * @param cmpInstruction The compare instruction to emit.
      * @param assemblyFileStream The output assembly file stream.
      */
-    static void emitAssyCmpInstruction(
-        const std::shared_ptr<Assembly::CmpInstruction> &cmpInstruction,
-        std::ofstream &assemblyFileStream);
+    static void
+    emitAssyCmpInstruction(const Assembly::CmpInstruction &cmpInstruction,
+                           std::ofstream &assemblyFileStream);
 
     /**
      * Emit the assembly code for a signed-integer-division instruction.
@@ -228,9 +227,9 @@ class PipelineStagesExecutors {
      * @param idivInstruction The signed-integer-division instruction to emit.
      * @param assemblyFileStream The output assembly file stream.
      */
-    static void emitAssyIdivInstruction(
-        const std::shared_ptr<Assembly::IdivInstruction> &idivInstruction,
-        std::ofstream &assemblyFileStream);
+    static void
+    emitAssyIdivInstruction(const Assembly::IdivInstruction &idivInstruction,
+                            std::ofstream &assemblyFileStream);
 
     /**
      * Emit the assembly code for a covert-doubleword-to-quadword instruction.
@@ -239,9 +238,9 @@ class PipelineStagesExecutors {
      * emit.
      * @param assemblyFileStream The output assembly file stream.
      */
-    static void emitAssyCdqInstruction(
-        const std::shared_ptr<Assembly::CdqInstruction> &cdqInstruction,
-        std::ofstream &assemblyFileStream);
+    static void
+    emitAssyCdqInstruction(const Assembly::CdqInstruction &cdqInstruction,
+                           std::ofstream &assemblyFileStream);
 
     /**
      * Emit the assembly code for a jump instruction.
@@ -249,9 +248,9 @@ class PipelineStagesExecutors {
      * @param jmpInstruction The jump instruction to emit.
      * @param assemblyFileStream The output assembly file stream.
      */
-    static void emitAssyJmpInstruction(
-        const std::shared_ptr<Assembly::JmpInstruction> &jmpInstruction,
-        std::ofstream &assemblyFileStream);
+    static void
+    emitAssyJmpInstruction(const Assembly::JmpInstruction &jmpInstruction,
+                           std::ofstream &assemblyFileStream);
 
     /**
      * Emit the assembly code for a conditional jump instruction.
@@ -259,9 +258,9 @@ class PipelineStagesExecutors {
      * @param jmpCCInstruction The conditional jump instruction to emit.
      * @param assemblyFileStream The output assembly file stream.
      */
-    static void emitAssyJmpCCInstruction(
-        const std::shared_ptr<Assembly::JmpCCInstruction> &jmpCCInstruction,
-        std::ofstream &assemblyFileStream);
+    static void
+    emitAssyJmpCCInstruction(const Assembly::JmpCCInstruction &jmpCCInstruction,
+                             std::ofstream &assemblyFileStream);
 
     /**
      * Emit the assembly code for a set-byte-on-condition instruction.
@@ -269,9 +268,9 @@ class PipelineStagesExecutors {
      * @param setCCInstruction The set-byte-on-condition instruction to emit.
      * @param assemblyFileStream The output assembly file stream.
      */
-    static void emitAssySetCCInstruction(
-        const std::shared_ptr<Assembly::SetCCInstruction> &setCCInstruction,
-        std::ofstream &assemblyFileStream);
+    static void
+    emitAssySetCCInstruction(const Assembly::SetCCInstruction &setCCInstruction,
+                             std::ofstream &assemblyFileStream);
 
     /**
      * Emit the assembly code for a label instruction.
@@ -279,9 +278,9 @@ class PipelineStagesExecutors {
      * @param labelInstruction The label instruction to emit.
      * @param assemblyFileStream The output assembly file stream.
      */
-    static void emitAssyLabelInstruction(
-        const std::shared_ptr<Assembly::LabelInstruction> &labelInstruction,
-        std::ofstream &assemblyFileStream);
+    static void
+    emitAssyLabelInstruction(const Assembly::LabelInstruction &labelInstruction,
+                             std::ofstream &assemblyFileStream);
 
     /**
      * Prepend an underscore to the identifier if the underlying OS is macOS.

--- a/src/utils/prettyPrinters.cpp
+++ b/src/utils/prettyPrinters.cpp
@@ -7,15 +7,12 @@
  * Start: Functions to print the IR program to stdout.
  */
 void PrettyPrinters::printIRProgram(
-    const std::shared_ptr<IR::Program> &irProgram,
-    const std::shared_ptr<std::vector<std::shared_ptr<IR::StaticVariable>>>
-        &irStaticVariables) {
-    auto topLevels = irProgram->getTopLevels();
-
-    for (auto topLevel : *topLevels) {
-        if (auto functionDefinition =
-                std::dynamic_pointer_cast<IR::FunctionDefinition>(topLevel)) {
-            printIRFunctionDefinition(functionDefinition);
+    const IR::Program &irProgram,
+    const std::vector<std::unique_ptr<IR::StaticVariable>> &irStaticVariables) {
+    for (const auto &topLevel : irProgram.getTopLevels()) {
+        if (auto *functionDefinition =
+                dynamic_cast<IR::FunctionDefinition *>(topLevel.get())) {
+            printIRFunctionDefinition(*functionDefinition);
         }
         else {
             throw std::logic_error(
@@ -23,19 +20,19 @@ void PrettyPrinters::printIRProgram(
         }
     }
 
-    for (auto irStaticVariable : *irStaticVariables) {
-        printIRStaticVariable(irStaticVariable);
+    for (const auto &irStaticVariable : irStaticVariables) {
+        printIRStaticVariable(*irStaticVariable);
     }
 }
 
 void PrettyPrinters::printIRFunctionDefinition(
-    const std::shared_ptr<IR::FunctionDefinition> &functionDefinition) {
-    std::cout << functionDefinition->getFunctionIdentifier();
+    const IR::FunctionDefinition &functionDefinition) {
+    std::cout << functionDefinition.getFunctionIdentifier();
     std::cout << std::boolalpha;
-    std::cout << "[isGlobal: " << functionDefinition->isGlobal() << "]";
+    std::cout << "[isGlobal: " << functionDefinition.isGlobal() << "]";
     std::cout << "(";
 
-    auto &parameters = *functionDefinition->getParameterIdentifiers();
+    auto &parameters = functionDefinition.getParameterIdentifiers();
     for (auto it = parameters.begin(); it != parameters.end(); it++) {
         auto &parameter = *it;
         std::cout << parameter;
@@ -46,21 +43,20 @@ void PrettyPrinters::printIRFunctionDefinition(
     }
 
     std::cout << "):\n";
-    for (auto instruction : *functionDefinition->getFunctionBody()) {
-        printIRInstruction(instruction);
+    for (const auto &instruction : functionDefinition.getFunctionBody()) {
+        printIRInstruction(*instruction);
     }
 }
 
 void PrettyPrinters::printIRStaticVariable(
-    const std::shared_ptr<IR::StaticVariable> &staticVariable) {
-    auto staticInit = staticVariable->getStaticInit();
-    std::cout << "[static] " << staticVariable->getIdentifier() << " = ";
+    const IR::StaticVariable &staticVariable) {
+    auto staticInit = staticVariable.getStaticInit();
+    std::cout << "[static] " << staticVariable.getIdentifier() << " = ";
 
-    if (auto intInit = std::dynamic_pointer_cast<AST::IntInit>(staticInit)) {
+    if (auto intInit = dynamic_cast<const AST::IntInit *>(staticInit)) {
         std::cout << std::get<int>(intInit->getValue());
     }
-    else if (auto longInit =
-                 std::dynamic_pointer_cast<AST::LongInit>(staticInit)) {
+    else if (auto longInit = dynamic_cast<const AST::LongInit *>(staticInit)) {
         std::cout << std::get<long>(longInit->getValue());
     }
     else {
@@ -71,57 +67,54 @@ void PrettyPrinters::printIRStaticVariable(
     std::cout << "\n";
 }
 
-void PrettyPrinters::printIRInstruction(
-    const std::shared_ptr<IR::Instruction> &instruction) {
+void PrettyPrinters::printIRInstruction(const IR::Instruction &instruction) {
     if (auto returnInstruction =
-            std::dynamic_pointer_cast<IR::ReturnInstruction>(instruction)) {
-        printIRReturnInstruction(returnInstruction);
+            dynamic_cast<const IR::ReturnInstruction *>(&instruction)) {
+        printIRReturnInstruction(*returnInstruction);
     }
     else if (auto unaryInstruction =
-                 std::dynamic_pointer_cast<IR::UnaryInstruction>(instruction)) {
-        printIRUnaryInstruction(unaryInstruction);
+                 dynamic_cast<const IR::UnaryInstruction *>(&instruction)) {
+        printIRUnaryInstruction(*unaryInstruction);
     }
     else if (auto binaryInstruction =
-                 std::dynamic_pointer_cast<IR::BinaryInstruction>(
-                     instruction)) {
-        printIRBinaryInstruction(binaryInstruction);
+                 dynamic_cast<const IR::BinaryInstruction *>(&instruction)) {
+        printIRBinaryInstruction(*binaryInstruction);
     }
     else if (auto copyInstruction =
-                 std::dynamic_pointer_cast<IR::CopyInstruction>(instruction)) {
-        printIRCopyInstruction(copyInstruction);
+                 dynamic_cast<const IR::CopyInstruction *>(&instruction)) {
+        printIRCopyInstruction(*copyInstruction);
     }
     else if (auto jumpInstruction =
-                 std::dynamic_pointer_cast<IR::JumpInstruction>(instruction)) {
-        printIRJumpInstruction(jumpInstruction);
+                 dynamic_cast<const IR::JumpInstruction *>(&instruction)) {
+        printIRJumpInstruction(*jumpInstruction);
     }
     else if (auto jumpIfZeroInstruction =
-                 std::dynamic_pointer_cast<IR::JumpIfZeroInstruction>(
-                     instruction)) {
-        printIRJumpIfZeroInstruction(jumpIfZeroInstruction);
+                 dynamic_cast<const IR::JumpIfZeroInstruction *>(
+                     &instruction)) {
+        printIRJumpIfZeroInstruction(*jumpIfZeroInstruction);
     }
     else if (auto jumpIfNotZeroInstruction =
-                 std::dynamic_pointer_cast<IR::JumpIfNotZeroInstruction>(
-                     instruction)) {
-        printIRJumpIfNotZeroInstruction(jumpIfNotZeroInstruction);
+                 dynamic_cast<const IR::JumpIfNotZeroInstruction *>(
+                     &instruction)) {
+        printIRJumpIfNotZeroInstruction(*jumpIfNotZeroInstruction);
     }
     else if (auto labelInstruction =
-                 std::dynamic_pointer_cast<IR::LabelInstruction>(instruction)) {
-        printIRLabelInstruction(labelInstruction);
+                 dynamic_cast<const IR::LabelInstruction *>(&instruction)) {
+        printIRLabelInstruction(*labelInstruction);
     }
     else if (auto functionCallInstruction =
-                 std::dynamic_pointer_cast<IR::FunctionCallInstruction>(
-                     instruction)) {
-        printIRFunctionCallInstruction(functionCallInstruction);
+                 dynamic_cast<const IR::FunctionCallInstruction *>(
+                     &instruction)) {
+        printIRFunctionCallInstruction(*functionCallInstruction);
     }
     else if (auto signExtendInstruction =
-                 std::dynamic_pointer_cast<IR::SignExtendInstruction>(
-                     instruction)) {
-        printIRSignExtendInstruction(signExtendInstruction);
+                 dynamic_cast<const IR::SignExtendInstruction *>(
+                     &instruction)) {
+        printIRSignExtendInstruction(*signExtendInstruction);
     }
     else if (auto truncateInstruction =
-                 std::dynamic_pointer_cast<IR::TruncateInstruction>(
-                     instruction)) {
-        printIRTruncateInstruction(truncateInstruction);
+                 dynamic_cast<const IR::TruncateInstruction *>(&instruction)) {
+        printIRTruncateInstruction(*truncateInstruction);
     }
     else {
         throw std::logic_error(
@@ -130,18 +123,17 @@ void PrettyPrinters::printIRInstruction(
 }
 
 void PrettyPrinters::printIRReturnInstruction(
-    const std::shared_ptr<IR::ReturnInstruction> &returnInstruction) {
+    const IR::ReturnInstruction &returnInstruction) {
     std::cout << "    return ";
 
-    if (auto constantValue = std::dynamic_pointer_cast<IR::ConstantValue>(
-            returnInstruction->getReturnValue())) {
-        if (auto constantInt = std::dynamic_pointer_cast<AST::ConstantInt>(
+    if (auto constantValue = dynamic_cast<const IR::ConstantValue *>(
+            returnInstruction.getReturnValue())) {
+        if (auto constantInt = dynamic_cast<const AST::ConstantInt *>(
                 constantValue->getASTConstant())) {
             std::cout << constantInt->getValue();
         }
-        else if (auto constantLong =
-                     std::dynamic_pointer_cast<AST::ConstantLong>(
-                         constantValue->getASTConstant())) {
+        else if (auto constantLong = dynamic_cast<const AST::ConstantLong *>(
+                     constantValue->getASTConstant())) {
             std::cout << constantLong->getValue();
         }
         else {
@@ -149,8 +141,8 @@ void PrettyPrinters::printIRReturnInstruction(
                 "Unknown constant type while printing IR return instruction");
         }
     }
-    else if (auto variableValue = std::dynamic_pointer_cast<IR::VariableValue>(
-                 returnInstruction->getReturnValue())) {
+    else if (auto variableValue = dynamic_cast<const IR::VariableValue *>(
+                 returnInstruction.getReturnValue())) {
         std::cout << variableValue->getIdentifier();
     }
     else {
@@ -162,10 +154,10 @@ void PrettyPrinters::printIRReturnInstruction(
 }
 
 void PrettyPrinters::printIRSignExtendInstruction(
-    const std::shared_ptr<IR::SignExtendInstruction> &signExtendInstruction) {
+    const IR::SignExtendInstruction &signExtendInstruction) {
     std::cout << "    ";
-    if (auto variableValue = std::dynamic_pointer_cast<IR::VariableValue>(
-            signExtendInstruction->getDst())) {
+    if (auto variableValue = dynamic_cast<const IR::VariableValue *>(
+            signExtendInstruction.getDst())) {
         std::cout << variableValue->getIdentifier();
     }
     else {
@@ -175,15 +167,14 @@ void PrettyPrinters::printIRSignExtendInstruction(
 
     std::cout << " = sign_extend(";
 
-    if (auto constantValue = std::dynamic_pointer_cast<IR::ConstantValue>(
-            signExtendInstruction->getSrc())) {
-        if (auto constantInt = std::dynamic_pointer_cast<AST::ConstantInt>(
+    if (auto constantValue = dynamic_cast<const IR::ConstantValue *>(
+            signExtendInstruction.getSrc())) {
+        if (auto constantInt = dynamic_cast<const AST::ConstantInt *>(
                 constantValue->getASTConstant())) {
             std::cout << constantInt->getValue();
         }
-        else if (auto constantLong =
-                     std::dynamic_pointer_cast<AST::ConstantLong>(
-                         constantValue->getASTConstant())) {
+        else if (auto constantLong = dynamic_cast<const AST::ConstantLong *>(
+                     constantValue->getASTConstant())) {
             std::cout << constantLong->getValue();
         }
         else {
@@ -191,8 +182,8 @@ void PrettyPrinters::printIRSignExtendInstruction(
                                    "sign extend instruction");
         }
     }
-    else if (auto variableValue = std::dynamic_pointer_cast<IR::VariableValue>(
-                 signExtendInstruction->getSrc())) {
+    else if (auto variableValue = dynamic_cast<const IR::VariableValue *>(
+                 signExtendInstruction.getSrc())) {
         std::cout << variableValue->getIdentifier();
     }
     else {
@@ -204,10 +195,10 @@ void PrettyPrinters::printIRSignExtendInstruction(
 }
 
 void PrettyPrinters::printIRTruncateInstruction(
-    const std::shared_ptr<IR::TruncateInstruction> &truncateInstruction) {
+    const IR::TruncateInstruction &truncateInstruction) {
     std::cout << "    ";
-    if (auto variableValue = std::dynamic_pointer_cast<IR::VariableValue>(
-            truncateInstruction->getDst())) {
+    if (auto variableValue = dynamic_cast<const IR::VariableValue *>(
+            truncateInstruction.getDst())) {
         std::cout << variableValue->getIdentifier();
     }
     else {
@@ -217,15 +208,14 @@ void PrettyPrinters::printIRTruncateInstruction(
 
     std::cout << " = truncate(";
 
-    if (auto constantValue = std::dynamic_pointer_cast<IR::ConstantValue>(
-            truncateInstruction->getSrc())) {
-        if (auto constantInt = std::dynamic_pointer_cast<AST::ConstantInt>(
+    if (auto constantValue = dynamic_cast<const IR::ConstantValue *>(
+            truncateInstruction.getSrc())) {
+        if (auto constantInt = dynamic_cast<const AST::ConstantInt *>(
                 constantValue->getASTConstant())) {
             std::cout << constantInt->getValue();
         }
-        else if (auto constantLong =
-                     std::dynamic_pointer_cast<AST::ConstantLong>(
-                         constantValue->getASTConstant())) {
+        else if (auto constantLong = dynamic_cast<const AST::ConstantLong *>(
+                     constantValue->getASTConstant())) {
             std::cout << constantLong->getValue();
         }
         else {
@@ -233,8 +223,8 @@ void PrettyPrinters::printIRTruncateInstruction(
                 "Unknown constant type while printing IR truncate instruction");
         }
     }
-    else if (auto variableValue = std::dynamic_pointer_cast<IR::VariableValue>(
-                 truncateInstruction->getSrc())) {
+    else if (auto variableValue = dynamic_cast<const IR::VariableValue *>(
+                 truncateInstruction.getSrc())) {
         std::cout << variableValue->getIdentifier();
     }
     else {
@@ -246,11 +236,11 @@ void PrettyPrinters::printIRTruncateInstruction(
 }
 
 void PrettyPrinters::printIRUnaryInstruction(
-    const std::shared_ptr<IR::UnaryInstruction> &unaryInstruction) {
+    const IR::UnaryInstruction &unaryInstruction) {
     std::cout << "    ";
 
-    if (auto variableValue = std::dynamic_pointer_cast<IR::VariableValue>(
-            unaryInstruction->getDst())) {
+    if (auto variableValue = dynamic_cast<const IR::VariableValue *>(
+            unaryInstruction.getDst())) {
         std::cout << variableValue->getIdentifier();
     }
     else {
@@ -258,18 +248,16 @@ void PrettyPrinters::printIRUnaryInstruction(
                                "IR unary instruction");
     }
 
-    if (auto complementOperator =
-            std::dynamic_pointer_cast<IR::ComplementOperator>(
-                unaryInstruction->getUnaryOperator())) {
+    if (dynamic_cast<const IR::ComplementOperator *>(
+            unaryInstruction.getUnaryOperator())) {
         std::cout << " = ~";
     }
-    else if (auto negateOperator =
-                 std::dynamic_pointer_cast<IR::NegateOperator>(
-                     unaryInstruction->getUnaryOperator())) {
+    else if (dynamic_cast<const IR::NegateOperator *>(
+                 unaryInstruction.getUnaryOperator())) {
         std::cout << " = -";
     }
-    else if (auto notOperator = std::dynamic_pointer_cast<IR::NotOperator>(
-                 unaryInstruction->getUnaryOperator())) {
+    else if (dynamic_cast<const IR::NotOperator *>(
+                 unaryInstruction.getUnaryOperator())) {
         std::cout << " = !";
     }
     else {
@@ -277,20 +265,19 @@ void PrettyPrinters::printIRUnaryInstruction(
             "Unknown unary operator while printing IR unary instruction");
     }
 
-    if (auto variableValue = std::dynamic_pointer_cast<IR::VariableValue>(
-            unaryInstruction->getSrc())) {
+    if (auto variableValue = dynamic_cast<const IR::VariableValue *>(
+            unaryInstruction.getSrc())) {
         std::cout << variableValue->getIdentifier();
     }
-    else if (auto constantValue = std::dynamic_pointer_cast<IR::ConstantValue>(
-                 unaryInstruction->getSrc())) {
-        if (auto constantInt = std::dynamic_pointer_cast<AST::ConstantInt>(
+    else if (auto constantValue = dynamic_cast<const IR::ConstantValue *>(
+                 unaryInstruction.getSrc())) {
+        if (auto constantInt = dynamic_cast<const AST::ConstantInt *>(
                 constantValue->getASTConstant())) {
             std::cout << constantInt->getValue();
             std::cout << "\n";
         }
-        else if (auto constantLong =
-                     std::dynamic_pointer_cast<AST::ConstantLong>(
-                         constantValue->getASTConstant())) {
+        else if (auto constantLong = dynamic_cast<const AST::ConstantLong *>(
+                     constantValue->getASTConstant())) {
             std::cout << constantLong->getValue();
             std::cout << "\n";
         }
@@ -308,27 +295,26 @@ void PrettyPrinters::printIRUnaryInstruction(
 }
 
 void PrettyPrinters::printIRBinaryInstruction(
-    const std::shared_ptr<IR::BinaryInstruction> &binaryInstruction) {
-    if (auto variableValue = std::dynamic_pointer_cast<IR::VariableValue>(
-            binaryInstruction->getDst())) {
+    const IR::BinaryInstruction &binaryInstruction) {
+    if (auto variableValue = dynamic_cast<const IR::VariableValue *>(
+            binaryInstruction.getDst())) {
         std::cout << "    " << variableValue->getIdentifier();
     }
 
     std::cout << " = ";
 
-    if (auto variableValue = std::dynamic_pointer_cast<IR::VariableValue>(
-            binaryInstruction->getSrc1())) {
+    if (auto variableValue = dynamic_cast<const IR::VariableValue *>(
+            binaryInstruction.getSrc1())) {
         std::cout << variableValue->getIdentifier();
     }
-    else if (auto constantValue = std::dynamic_pointer_cast<IR::ConstantValue>(
-                 binaryInstruction->getSrc1())) {
-        if (auto constantInt = std::dynamic_pointer_cast<AST::ConstantInt>(
+    else if (auto constantValue = dynamic_cast<const IR::ConstantValue *>(
+                 binaryInstruction.getSrc1())) {
+        if (auto constantInt = dynamic_cast<const AST::ConstantInt *>(
                 constantValue->getASTConstant())) {
             std::cout << constantInt->getValue();
         }
-        else if (auto constantLong =
-                     std::dynamic_pointer_cast<AST::ConstantLong>(
-                         constantValue->getASTConstant())) {
+        else if (auto constantLong = dynamic_cast<const AST::ConstantLong *>(
+                     constantValue->getASTConstant())) {
             std::cout << constantLong->getValue();
         }
         else {
@@ -341,58 +327,48 @@ void PrettyPrinters::printIRBinaryInstruction(
             "Unknown source value type while printing IR binary instruction");
     }
 
-    if (auto binaryOperator = std::dynamic_pointer_cast<IR::AddOperator>(
-            binaryInstruction->getBinaryOperator())) {
+    if (dynamic_cast<const IR::AddOperator *>(
+            binaryInstruction.getBinaryOperator())) {
         std::cout << " + ";
     }
-    else if (auto binaryOperator1 =
-                 std::dynamic_pointer_cast<IR::SubtractOperator>(
-                     binaryInstruction->getBinaryOperator())) {
+    else if (dynamic_cast<const IR::SubtractOperator *>(
+                 binaryInstruction.getBinaryOperator())) {
         std::cout << " - ";
     }
-    else if (auto binaryOperator2 =
-                 std::dynamic_pointer_cast<IR::MultiplyOperator>(
-                     binaryInstruction->getBinaryOperator())) {
+    else if (dynamic_cast<const IR::MultiplyOperator *>(
+                 binaryInstruction.getBinaryOperator())) {
         std::cout << " * ";
     }
-    else if (auto binaryOperator3 =
-                 std::dynamic_pointer_cast<IR::DivideOperator>(
-                     binaryInstruction->getBinaryOperator())) {
+    else if (dynamic_cast<const IR::DivideOperator *>(
+                 binaryInstruction.getBinaryOperator())) {
         std::cout << " / ";
     }
-    else if (auto binaryOperator4 =
-                 std::dynamic_pointer_cast<IR::RemainderOperator>(
-                     binaryInstruction->getBinaryOperator())) {
+    else if (dynamic_cast<const IR::RemainderOperator *>(
+                 binaryInstruction.getBinaryOperator())) {
         std::cout << " % ";
     }
-    else if (auto binaryOperator5 =
-                 std::dynamic_pointer_cast<IR::EqualOperator>(
-                     binaryInstruction->getBinaryOperator())) {
+    else if (dynamic_cast<const IR::EqualOperator *>(
+                 binaryInstruction.getBinaryOperator())) {
         std::cout << " == ";
     }
-    else if (auto binaryOperator6 =
-                 std::dynamic_pointer_cast<IR::NotEqualOperator>(
-                     binaryInstruction->getBinaryOperator())) {
+    else if (dynamic_cast<const IR::NotEqualOperator *>(
+                 binaryInstruction.getBinaryOperator())) {
         std::cout << " != ";
     }
-    else if (auto binaryOperator7 =
-                 std::dynamic_pointer_cast<IR::LessThanOperator>(
-                     binaryInstruction->getBinaryOperator())) {
+    else if (dynamic_cast<const IR::LessThanOperator *>(
+                 binaryInstruction.getBinaryOperator())) {
         std::cout << " < ";
     }
-    else if (auto binaryOperator8 =
-                 std::dynamic_pointer_cast<IR::LessThanOrEqualOperator>(
-                     binaryInstruction->getBinaryOperator())) {
+    else if (dynamic_cast<const IR::LessThanOrEqualOperator *>(
+                 binaryInstruction.getBinaryOperator())) {
         std::cout << " <= ";
     }
-    else if (auto binaryOperator9 =
-                 std::dynamic_pointer_cast<IR::GreaterThanOperator>(
-                     binaryInstruction->getBinaryOperator())) {
+    else if (dynamic_cast<const IR::GreaterThanOperator *>(
+                 binaryInstruction.getBinaryOperator())) {
         std::cout << " > ";
     }
-    else if (auto binaryOperator10 =
-                 std::dynamic_pointer_cast<IR::GreaterThanOrEqualOperator>(
-                     binaryInstruction->getBinaryOperator())) {
+    else if (dynamic_cast<const IR::GreaterThanOrEqualOperator *>(
+                 binaryInstruction.getBinaryOperator())) {
         std::cout << " >= ";
     }
     else {
@@ -400,19 +376,18 @@ void PrettyPrinters::printIRBinaryInstruction(
             "Unknown binary operator while printing IR binary instruction");
     }
 
-    if (auto variableValue = std::dynamic_pointer_cast<IR::VariableValue>(
-            binaryInstruction->getSrc2())) {
+    if (auto variableValue = dynamic_cast<const IR::VariableValue *>(
+            binaryInstruction.getSrc2())) {
         std::cout << variableValue->getIdentifier();
     }
-    else if (auto constantValue = std::dynamic_pointer_cast<IR::ConstantValue>(
-                 binaryInstruction->getSrc2())) {
-        if (auto constantInt = std::dynamic_pointer_cast<AST::ConstantInt>(
+    else if (auto constantValue = dynamic_cast<const IR::ConstantValue *>(
+                 binaryInstruction.getSrc2())) {
+        if (auto constantInt = dynamic_cast<const AST::ConstantInt *>(
                 constantValue->getASTConstant())) {
             std::cout << constantInt->getValue();
         }
-        else if (auto constantLong =
-                     std::dynamic_pointer_cast<AST::ConstantLong>(
-                         constantValue->getASTConstant())) {
+        else if (auto constantLong = dynamic_cast<const AST::ConstantLong *>(
+                     constantValue->getASTConstant())) {
             std::cout << constantLong->getValue();
         }
         else {
@@ -429,10 +404,10 @@ void PrettyPrinters::printIRBinaryInstruction(
 }
 
 void PrettyPrinters::printIRCopyInstruction(
-    const std::shared_ptr<IR::CopyInstruction> &copyInstruction) {
+    const IR::CopyInstruction &copyInstruction) {
     std::cout << "    ";
-    if (auto variableValue = std::dynamic_pointer_cast<IR::VariableValue>(
-            copyInstruction->getDst())) {
+    if (auto variableValue =
+            dynamic_cast<const IR::VariableValue *>(copyInstruction.getDst())) {
         std::cout << variableValue->getIdentifier();
     }
     else {
@@ -442,21 +417,19 @@ void PrettyPrinters::printIRCopyInstruction(
 
     std::cout << " = ";
 
-    auto src = copyInstruction->getSrc();
+    auto src = copyInstruction.getSrc();
     if (!src) {
         throw std::logic_error(
             "Source value is null while printing IR copy instruction");
     }
 
-    if (auto constantValue =
-            std::dynamic_pointer_cast<IR::ConstantValue>(src)) {
-        if (auto constantInt = std::dynamic_pointer_cast<AST::ConstantInt>(
+    if (auto constantValue = dynamic_cast<const IR::ConstantValue *>(src)) {
+        if (auto constantInt = dynamic_cast<const AST::ConstantInt *>(
                 constantValue->getASTConstant())) {
             std::cout << constantInt->getValue();
         }
-        else if (auto constantLong =
-                     std::dynamic_pointer_cast<AST::ConstantLong>(
-                         constantValue->getASTConstant())) {
+        else if (auto constantLong = dynamic_cast<const AST::ConstantLong *>(
+                     constantValue->getASTConstant())) {
             std::cout << constantLong->getValue();
         }
         else {
@@ -465,7 +438,7 @@ void PrettyPrinters::printIRCopyInstruction(
         }
     }
     else if (auto variableValue =
-                 std::dynamic_pointer_cast<IR::VariableValue>(src)) {
+                 dynamic_cast<const IR::VariableValue *>(src)) {
         std::cout << variableValue->getIdentifier();
     }
     else {
@@ -477,27 +450,26 @@ void PrettyPrinters::printIRCopyInstruction(
 }
 
 void PrettyPrinters::printIRJumpInstruction(
-    const std::shared_ptr<IR::JumpInstruction> &jumpInstruction) {
-    std::cout << "    Jump(" << jumpInstruction->getTarget() << ")\n";
+    const IR::JumpInstruction &jumpInstruction) {
+    std::cout << "    Jump(" << jumpInstruction.getTarget() << ")\n";
 }
 
 void PrettyPrinters::printIRJumpIfZeroInstruction(
-    const std::shared_ptr<IR::JumpIfZeroInstruction> &jumpIfZeroInstruction) {
+    const IR::JumpIfZeroInstruction &jumpIfZeroInstruction) {
     std::cout << "    JumpIfZero(";
 
-    if (auto variableValue = std::dynamic_pointer_cast<IR::VariableValue>(
-            jumpIfZeroInstruction->getCondition())) {
+    if (auto variableValue = dynamic_cast<const IR::VariableValue *>(
+            jumpIfZeroInstruction.getCondition())) {
         std::cout << variableValue->getIdentifier();
     }
-    else if (auto constantValue = std::dynamic_pointer_cast<IR::ConstantValue>(
-                 jumpIfZeroInstruction->getCondition())) {
-        if (auto constantInt = std::dynamic_pointer_cast<AST::ConstantInt>(
+    else if (auto constantValue = dynamic_cast<const IR::ConstantValue *>(
+                 jumpIfZeroInstruction.getCondition())) {
+        if (auto constantInt = dynamic_cast<const AST::ConstantInt *>(
                 constantValue->getASTConstant())) {
             std::cout << constantInt->getValue();
         }
-        else if (auto constantLong =
-                     std::dynamic_pointer_cast<AST::ConstantLong>(
-                         constantValue->getASTConstant())) {
+        else if (auto constantLong = dynamic_cast<const AST::ConstantLong *>(
+                     constantValue->getASTConstant())) {
             std::cout << constantLong->getValue();
         }
         else {
@@ -506,27 +478,25 @@ void PrettyPrinters::printIRJumpIfZeroInstruction(
         }
     }
 
-    std::cout << ", " << jumpIfZeroInstruction->getTarget() << ")\n";
+    std::cout << ", " << jumpIfZeroInstruction.getTarget() << ")\n";
 }
 
 void PrettyPrinters::printIRJumpIfNotZeroInstruction(
-    const std::shared_ptr<IR::JumpIfNotZeroInstruction>
-        &jumpIfNotZeroInstruction) {
+    const IR::JumpIfNotZeroInstruction &jumpIfNotZeroInstruction) {
     std::cout << "    JumpIfNotZero(";
 
-    if (auto variableValue = std::dynamic_pointer_cast<IR::VariableValue>(
-            jumpIfNotZeroInstruction->getCondition())) {
+    if (auto variableValue = dynamic_cast<const IR::VariableValue *>(
+            jumpIfNotZeroInstruction.getCondition())) {
         std::cout << variableValue->getIdentifier();
     }
-    else if (auto constantValue = std::dynamic_pointer_cast<IR::ConstantValue>(
-                 jumpIfNotZeroInstruction->getCondition())) {
-        if (auto constantInt = std::dynamic_pointer_cast<AST::ConstantInt>(
+    else if (auto constantValue = dynamic_cast<const IR::ConstantValue *>(
+                 jumpIfNotZeroInstruction.getCondition())) {
+        if (auto constantInt = dynamic_cast<const AST::ConstantInt *>(
                 constantValue->getASTConstant())) {
             std::cout << constantInt->getValue();
         }
-        else if (auto constantLong =
-                     std::dynamic_pointer_cast<AST::ConstantLong>(
-                         constantValue->getASTConstant())) {
+        else if (auto constantLong = dynamic_cast<const AST::ConstantLong *>(
+                     constantValue->getASTConstant())) {
             std::cout << constantLong->getValue();
         }
         else {
@@ -539,21 +509,19 @@ void PrettyPrinters::printIRJumpIfNotZeroInstruction(
                                "jump if not zero instruction");
     }
 
-    std::cout << ", " << jumpIfNotZeroInstruction->getTarget() << ")\n";
+    std::cout << ", " << jumpIfNotZeroInstruction.getTarget() << ")\n";
 }
 
 void PrettyPrinters::printIRLabelInstruction(
-    const std::shared_ptr<IR::LabelInstruction> &labelInstruction) {
-    std::cout << "    Label(" << labelInstruction->getLabel() << ")\n";
+    const IR::LabelInstruction &labelInstruction) {
+    std::cout << "    Label(" << labelInstruction.getLabel() << ")\n";
 }
 
 void PrettyPrinters::printIRFunctionCallInstruction(
-    const std::shared_ptr<IR::FunctionCallInstruction>
-        &functionCallInstruction) {
-    auto dst = functionCallInstruction->getDst();
+    const IR::FunctionCallInstruction &functionCallInstruction) {
+    auto dst = functionCallInstruction.getDst();
 
-    if (auto variableValue =
-            std::dynamic_pointer_cast<IR::VariableValue>(dst)) {
+    if (auto variableValue = dynamic_cast<const IR::VariableValue *>(dst)) {
         std::cout << "    " << variableValue->getIdentifier() << " = ";
     }
     else {
@@ -561,24 +529,24 @@ void PrettyPrinters::printIRFunctionCallInstruction(
                                "IR function call instruction");
     }
 
-    auto functionIdentifier = functionCallInstruction->getFunctionIdentifier();
+    auto functionIdentifier = functionCallInstruction.getFunctionIdentifier();
     std::cout << functionIdentifier << "(";
 
-    auto &args = *functionCallInstruction->getArgs();
+    auto &args = functionCallInstruction.getArgs();
     for (auto it = args.begin(); it != args.end(); it++) {
         auto &arg = *it;
         if (auto variableValue =
-                std::dynamic_pointer_cast<IR::VariableValue>(arg)) {
+                dynamic_cast<const IR::VariableValue *>(arg.get())) {
             std::cout << variableValue->getIdentifier();
         }
         else if (auto constantValue =
-                     std::dynamic_pointer_cast<IR::ConstantValue>(arg)) {
-            if (auto constantInt = std::dynamic_pointer_cast<AST::ConstantInt>(
+                     dynamic_cast<const IR::ConstantValue *>(arg.get())) {
+            if (auto constantInt = dynamic_cast<const AST::ConstantInt *>(
                     constantValue->getASTConstant())) {
                 std::cout << constantInt->getValue();
             }
             else if (auto constantLong =
-                         std::dynamic_pointer_cast<AST::ConstantLong>(
+                         dynamic_cast<const AST::ConstantLong *>(
                              constantValue->getASTConstant())) {
                 std::cout << constantLong->getValue();
             }

--- a/src/utils/prettyPrinters.h
+++ b/src/utils/prettyPrinters.h
@@ -26,8 +26,7 @@ class PrettyPrinters {
      *
      * @param assemblyProgram The assembly program to print.
      */
-    static void printAssemblyProgram(
-        const std::shared_ptr<Assembly::Program> &assemblyProgram);
+    static void printAssemblyProgram(const Assembly::Program &assemblyProgram);
 
   private:
     /**
@@ -147,32 +146,30 @@ class PrettyPrinters {
      * @param functionDefinition The assembly function definition to print.
      */
     static void printAssyFunctionDefinition(
-        const std::shared_ptr<Assembly::FunctionDefinition>
-            &functionDefinition);
+        const Assembly::FunctionDefinition &functionDefinition);
 
     /**
      * Print an assembly static variable to stdout.
      *
      * @param staticVariable The assembly static variable to print.
      */
-    static void printAssyStaticVariable(
-        const std::shared_ptr<Assembly::StaticVariable> &staticVariable);
+    static void
+    printAssyStaticVariable(const Assembly::StaticVariable &staticVariable);
 
     /**
      * Print an assembly instruction to stdout.
      *
      * @param instruction The assembly instruction to print.
      */
-    static void printAssyInstruction(
-        const std::shared_ptr<Assembly::Instruction> &instruction);
+    static void printAssyInstruction(const Assembly::Instruction &instruction);
 
     /**
      * Print an assembly move instruction to stdout.
      *
      * @param movInstruction The assembly move instruction to print.
      */
-    static void printAssyMovInstruction(
-        const std::shared_ptr<Assembly::MovInstruction> &movInstruction);
+    static void
+    printAssyMovInstruction(const Assembly::MovInstruction &movInstruction);
 
     /**
      * Print an assembly move-with-sign-extend instruction to stdout.
@@ -181,31 +178,31 @@ class PrettyPrinters {
      * print.
      */
     static void printAssyMovsxInstruction(
-        const std::shared_ptr<Assembly::MovsxInstruction> &movsxInstruction);
+        const Assembly::MovsxInstruction &movsxInstruction);
 
     /**
      * Print an assembly return instruction to stdout.
      *
      * @param retInstruction The assembly return instruction to print.
      */
-    static void printAssyRetInstruction(
-        const std::shared_ptr<Assembly::RetInstruction> &retInstruction);
+    static void
+    printAssyRetInstruction(const Assembly::RetInstruction &retInstruction);
 
     /**
      * Print an assembly push instruction to stdout.
      *
      * @param pushInstruction The assembly push instruction to print.
      */
-    static void printAssyPushInstruction(
-        const std::shared_ptr<Assembly::PushInstruction> &pushInstruction);
+    static void
+    printAssyPushInstruction(const Assembly::PushInstruction &pushInstruction);
 
     /**
      * Print an assembly call instruction to stdout.
      *
      * @param callInstruction The assembly call instruction to print.
      */
-    static void printAssyCallInstruction(
-        const std::shared_ptr<Assembly::CallInstruction> &callInstruction);
+    static void
+    printAssyCallInstruction(const Assembly::CallInstruction &callInstruction);
 
     /**
      * Print an assembly unary instruction to stdout.
@@ -213,7 +210,7 @@ class PrettyPrinters {
      * @param unaryInstruction The assembly unary instruction to print.
      */
     static void printAssyUnaryInstruction(
-        const std::shared_ptr<Assembly::UnaryInstruction> &unaryInstruction);
+        const Assembly::UnaryInstruction &unaryInstruction);
 
     /**
      * Print an assembly binary instruction to stdout.
@@ -221,15 +218,15 @@ class PrettyPrinters {
      * @param binaryInstruction The assembly binary instruction to print.
      */
     static void printAssyBinaryInstruction(
-        const std::shared_ptr<Assembly::BinaryInstruction> &binaryInstruction);
+        const Assembly::BinaryInstruction &binaryInstruction);
 
     /**
      * Print an assembly compare instruction to stdout.
      *
      * @param cmpInstruction The assembly compare instruction to print.
      */
-    static void printAssyCmpInstruction(
-        const std::shared_ptr<Assembly::CmpInstruction> &cmpInstruction);
+    static void
+    printAssyCmpInstruction(const Assembly::CmpInstruction &cmpInstruction);
 
     /**
      * Print an assembly signed-integer-division instruction to stdout.
@@ -237,8 +234,8 @@ class PrettyPrinters {
      * @param idivInstruction The assembly signed-integer-division instruction
      * to print.
      */
-    static void printAssyIdivInstruction(
-        const std::shared_ptr<Assembly::IdivInstruction> &idivInstruction);
+    static void
+    printAssyIdivInstruction(const Assembly::IdivInstruction &idivInstruction);
 
     /**
      * Print an assembly covert-doubleword-to-quadword instruction to stdout.
@@ -246,16 +243,16 @@ class PrettyPrinters {
      * @param cdqInstruction The assembly covert-doubleword-to-quadword
      * instruction to print.
      */
-    static void printAssyCdqInstruction(
-        const std::shared_ptr<Assembly::CdqInstruction> &cdqInstruction);
+    static void
+    printAssyCdqInstruction(const Assembly::CdqInstruction &cdqInstruction);
 
     /**
      * Print an assembly jump instruction to stdout.
      *
      * @param jmpInstruction The assembly jump instruction to print.
      */
-    static void printAssyJmpInstruction(
-        const std::shared_ptr<Assembly::JmpInstruction> &jmpInstruction);
+    static void
+    printAssyJmpInstruction(const Assembly::JmpInstruction &jmpInstruction);
 
     /**
      * Print an assembly conditional-jump instruction to stdout.
@@ -264,7 +261,7 @@ class PrettyPrinters {
      * print.
      */
     static void printAssyJmpCCInstruction(
-        const std::shared_ptr<Assembly::JmpCCInstruction> &jmpCCInstruction);
+        const Assembly::JmpCCInstruction &jmpCCInstruction);
 
     /**
      * Print an assembly set-on-condition instruction to stdout.
@@ -273,7 +270,7 @@ class PrettyPrinters {
      * print.
      */
     static void printAssySetCCInstruction(
-        const std::shared_ptr<Assembly::SetCCInstruction> &setCCInstruction);
+        const Assembly::SetCCInstruction &setCCInstruction);
 
     /**
      * Print an assembly label instruction to stdout.
@@ -281,7 +278,7 @@ class PrettyPrinters {
      * @param labelInstruction The assembly label instruction to print.
      */
     static void printAssyLabelInstruction(
-        const std::shared_ptr<Assembly::LabelInstruction> &labelInstruction);
+        const Assembly::LabelInstruction &labelInstruction);
 
     /**
      * Prepend an underscore to the identifier if the underlying OS is macOS.

--- a/src/utils/prettyPrinters.h
+++ b/src/utils/prettyPrinters.h
@@ -16,10 +16,10 @@ class PrettyPrinters {
      * @param irProgram The IR program to print.
      * @param irStaticVariables The list of IR static variables.
      */
-    static void printIRProgram(
-        const std::shared_ptr<IR::Program> &irProgram,
-        const std::shared_ptr<std::vector<std::shared_ptr<IR::StaticVariable>>>
-            &irStaticVariables);
+    static void
+    printIRProgram(const IR::Program &irProgram,
+                   const std::vector<std::unique_ptr<IR::StaticVariable>>
+                       &irStaticVariables);
 
     /**
      * Print the assembly program to stdout.
@@ -35,32 +35,30 @@ class PrettyPrinters {
      *
      * @param functionDefinition The IR function definition to print.
      */
-    static void printIRFunctionDefinition(
-        const std::shared_ptr<IR::FunctionDefinition> &functionDefinition);
+    static void
+    printIRFunctionDefinition(const IR::FunctionDefinition &functionDefinition);
 
     /**
      * Print an IR static variable to stdout.
      *
      * @param staticVariable The IR static variable to print.
      */
-    static void printIRStaticVariable(
-        const std::shared_ptr<IR::StaticVariable> &staticVariable);
+    static void printIRStaticVariable(const IR::StaticVariable &staticVariable);
 
     /**
      * Print an IR instruction to stdout.
      *
      * @param instruction The IR instruction to print.
      */
-    static void
-    printIRInstruction(const std::shared_ptr<IR::Instruction> &instruction);
+    static void printIRInstruction(const IR::Instruction &instruction);
 
     /**
      * Print an IR return instruction to stdout.
      *
      * @param returnInstruction The IR return instruction to print.
      */
-    static void printIRReturnInstruction(
-        const std::shared_ptr<IR::ReturnInstruction> &returnInstruction);
+    static void
+    printIRReturnInstruction(const IR::ReturnInstruction &returnInstruction);
 
     /**
      * Print an IR sign-extend instruction to stdout.
@@ -68,8 +66,7 @@ class PrettyPrinters {
      * @param signExtendInstruction The IR sign-extend instruction to print.
      */
     static void printIRSignExtendInstruction(
-        const std::shared_ptr<IR::SignExtendInstruction>
-            &signExtendInstruction);
+        const IR::SignExtendInstruction &signExtendInstruction);
 
     /**
      * Print an IR truncate instruction to stdout.
@@ -77,39 +74,39 @@ class PrettyPrinters {
      * @param truncateInstruction The IR truncate instruction to print.
      */
     static void printIRTruncateInstruction(
-        const std::shared_ptr<IR::TruncateInstruction> &truncateInstruction);
+        const IR::TruncateInstruction &truncateInstruction);
 
     /**
      * Print an IR unary instruction to stdout.
      *
      * @param unaryInstruction The IR unary instruction to print.
      */
-    static void printIRUnaryInstruction(
-        const std::shared_ptr<IR::UnaryInstruction> &unaryInstruction);
+    static void
+    printIRUnaryInstruction(const IR::UnaryInstruction &unaryInstruction);
 
     /**
      * Print an IR binary instruction to stdout.
      *
      * @param binaryInstruction The IR binary instruction to print.
      */
-    static void printIRBinaryInstruction(
-        const std::shared_ptr<IR::BinaryInstruction> &binaryInstruction);
+    static void
+    printIRBinaryInstruction(const IR::BinaryInstruction &binaryInstruction);
 
     /**
      * Print an IR copy instruction to stdout.
      *
      * @param copyInstruction The IR copy instruction to print.
      */
-    static void printIRCopyInstruction(
-        const std::shared_ptr<IR::CopyInstruction> &copyInstruction);
+    static void
+    printIRCopyInstruction(const IR::CopyInstruction &copyInstruction);
 
     /**
      * Print an IR jump instruction to stdout.
      *
      * @param jumpInstruction The IR jump instruction to print.
      */
-    static void printIRJumpInstruction(
-        const std::shared_ptr<IR::JumpInstruction> &jumpInstruction);
+    static void
+    printIRJumpInstruction(const IR::JumpInstruction &jumpInstruction);
 
     /**
      * Print an IR jump-if-zero instruction to stdout.
@@ -117,8 +114,7 @@ class PrettyPrinters {
      * @param jumpIfZeroInstruction The IR jump-if-zero instruction to print.
      */
     static void printIRJumpIfZeroInstruction(
-        const std::shared_ptr<IR::JumpIfZeroInstruction>
-            &jumpIfZeroInstruction);
+        const IR::JumpIfZeroInstruction &jumpIfZeroInstruction);
 
     /**
      * Print an IR jump-if-not-zero instruction to stdout.
@@ -127,16 +123,15 @@ class PrettyPrinters {
      * print.
      */
     static void printIRJumpIfNotZeroInstruction(
-        const std::shared_ptr<IR::JumpIfNotZeroInstruction>
-            &jumpIfNotZeroInstruction);
+        const IR::JumpIfNotZeroInstruction &jumpIfNotZeroInstruction);
 
     /**
      * Print an IR label instruction to stdout.
      *
      * @param labelInstruction The IR label instruction to print.
      */
-    static void printIRLabelInstruction(
-        const std::shared_ptr<IR::LabelInstruction> &labelInstruction);
+    static void
+    printIRLabelInstruction(const IR::LabelInstruction &labelInstruction);
 
     /**
      * Print an IR function call instruction to stdout.
@@ -144,8 +139,7 @@ class PrettyPrinters {
      * @param functionCallInstruction The IR function call instruction to print.
      */
     static void printIRFunctionCallInstruction(
-        const std::shared_ptr<IR::FunctionCallInstruction>
-            &functionCallInstruction);
+        const IR::FunctionCallInstruction &functionCallInstruction);
 
     /**
      * Print an assembly function definition to stdout.


### PR DESCRIPTION
This PR consists of commits that refactor the entire codebase to replace the usage of shared pointers with unique pointers and references for clearer (more explicit) memory and ownership management.